### PR TITLE
Islandora 315

### DIFF
--- a/api/fedora_item.inc
+++ b/api/fedora_item.inc
@@ -800,7 +800,7 @@ class Fedora_Item {
 
   function set_datastream_state($dsid, $state, $log_message = 'Modified by Islandora API', $quiet = FALSE) {
     $valid_states = array('A', 'D', 'I');
-    if (key_exists($state, $valid_states)) {
+    if (array_search($state, $valid_states) !== FALSE) {
       $params = array(
         'pid' => $this->pid,
         'dsID' => $dsid,


### PR DESCRIPTION
I've added a API-M function to the Fedora_Item class. It has been tested and is ready to go into 6.x.

I've added the function:

https://wiki.duraspace.org/display/FEDORA34/API-M#API-M-setDatastreamState

This is required for the Content Model Viewer to function correctly as it allows users to change the state of data streams.
