### PR TITLE
ISLANDORA-318

### DIFF
--- a/fedora_repository.module
+++ b/fedora_repository.module
@@ -799,7 +799,7 @@ function fedora_repository_get_items($pid = NULL, $dsId = NULL, $collection = NU
   module_load_include('inc', 'fedora_repository', 'CollectionClass');
   $collectionClass = new CollectionClass();
   module_load_include('inc', 'fedora_repository', 'ContentModel');
-  module_load_include('inc', 'fedora_repository', 'plugins/fedoraObject');
+  module_load_include('inc', 'fedora_repository', 'plugins/FedoraObjectDetailedContent');
   $breadcrumbs = array();
   $objectHelper->getBreadcrumbs($pid, $breadcrumbs);
   drupal_set_breadcrumb(array_reverse($breadcrumbs));
@@ -824,7 +824,7 @@ function fedora_repository_get_items($pid = NULL, $dsId = NULL, $collection = NU
     }
   }
 // Add a 'manage object' tab for all objects, where detailed list of content is shown.
-  $obj = new FedoraObject($pid);
+  $obj = new FedoraObjectDetailedContent($pid);
   $object_details = $obj->showFieldSets();
   $cmodels_tabs = array_merge($cmodels_tabs, $object_details);
   return tabs_render($cmodels_tabs);

--- a/plugins/FedoraObjectDetailedContent.inc
+++ b/plugins/FedoraObjectDetailedContent.inc
@@ -4,13 +4,15 @@
 
 /**
  * @file
- * FedoraObject class
+ * FedoraObjectDetailedContent class
  */
 
 /**
- * Fedora Object class ??
+ * Fedora Object. This class is a plugin called from content models to display a detailed list of 
+ * content of the Fedora Item. This is hard coded into Islandora core, and it can also be called
+ * from the IslandoraCM stream.
  */
-class FedoraObject {
+class FedoraObjectDetailedContent {
 
   /**
    * Constructor


### PR DESCRIPTION
Updated the class in core which shows the detailed list of content. Renamed it from FedoraObject -> FedoraObjectDetailedContent. This will allow the new API to be used with the newest release of Islandora.
