### PR TITLE
ISLANDORA-350: When viewing non-existing objects the Drupal not found pag

### DIFF
--- a/fedora_repository.module
+++ b/fedora_repository.module
@@ -914,6 +914,7 @@ function fedora_repository_get_items($pid = NULL, $dsId = NULL, $collection = NU
   $item = new fedora_item($pid);
   if (!$item->exists()) {
     drupal_not_found();
+    exit();
   }
 
   if ($pid & !valid_pid($pid)) {


### PR DESCRIPTION
ISLANDORA-350: When viewing non-existing objects the Drupal not found page renders along with a failed attempt at rendering the missing object.
