### PR TITLE
ISLANDORA-352: Fedora Repository now requires Islandora Content Model For

### DIFF
--- a/fedora_repository.info
+++ b/fedora_repository.info
@@ -2,6 +2,7 @@
 name = Digital Repository
 dependencies[] = imageapi
 dependencies[] = tabs
+dependencies[] = islandora_content_model_forms
 description = Shows a list of items in a fedora collection.
 package = Islandora
 version = 11.2.beta1


### PR DESCRIPTION
ISLANDORA-352: Fedora Repository now requires Islandora Content Model Forms
