### PR TITLE
ISLANDORA-362 updated the do_curl method to be renamed do_curl_ext and re

### DIFF
--- a/api/fedora_utils.inc
+++ b/api/fedora_utils.inc
@@ -30,17 +30,76 @@ if (!function_exists('str_getcsv')) {
 }
 
 /**
- * do curl
- * @global type $user
- * @param type $url
- * @param type $return_to_variable
- * @param type $number_of_post_vars
- * @param type $post
- * @return type 
+ * 
+ * Utility method to get data from a url location using curl_exec and return
+ * 
+ * This method takes identical parameters to do_curl_ext and passes them
+ * directly to do_curl_ext.  The output from do_curl_ext is processed into
+ * either a TRUE, FALSE, or NULL value.
+ * 
+ * This method exists for historical reasons as existing code makes use of
+ * do_curl directly and expects a simple return value and not an array.
+ * 
+ * @param $url
+ *   URL to be accessed by the function
+ * @param $return_to_variable
+ *   Indicates whether the resource accessed by the curl call (HTML page,
+ *   XML page, etc.) is returned directly from the function to the calling
+ *   program or if it is sent directly to output.
+ * @param $number_of_post_vars
+ *   Number of variable sot be posted
+ * @param $post
+ *   Whether the curl_exec is done as a "get" or a "post"
+ *   
+ * @return
+ *   TRUE, FALSE, NULL, or the data returned from accessing the URL
  */
 function do_curl($url, $return_to_variable = 1, $number_of_post_vars = 0, $post = NULL) {
+  $return_array = do_curl_ext($url, $return_to_variable, $number_of_post_vars, $post);
+  return ($return_array != NULL) ? $return_array[0] : NULL;
+}
+
+/**
+ * 
+ * Utility method to get data from a url location using curl_exec
+ * 
+ * This method takes a URL and three associated parameters and initializes the
+ * structure required to make a call to curl_exec.  As a part of the
+ * initialization the permissions associated with the (global) user are added
+ * to the call.  This ensures access to any potentially user restricted URLs.
+ * 
+ * Various defaults are used for the parameters required by curl_exec including
+ * the user agent and timeout.  These are hard-coded.
+ * 
+ * @param $url
+ *   URL to be accessed by the function
+ * @param $return_to_variable
+ *   Indicates whether the resource accessed by the curl call (HTML page,
+ *   XML page, etc.) is returned directly from the function to the calling
+ *   program or if it is sent directly to output.
+ * @param $number_of_post_vars
+ *   Number of variable sot be posted
+ * @param $post
+ *   Whether the curl_exec is done as a "get" or a "post"
+ *   
+ * @return
+ *   an array that consists of three value or NULL if curl is not suported:
+ *   - element 0:
+ *     The value returned from the curl_exec function call.
+ *     This is either a TRUE or FALSE value or the actual data returned from
+ *     accessing the URL.
+ *   - element 1:
+ *     The error code reslting from attempting to access the URL with curl_exec
+ *   - element 2:
+ *     A string representing a textual representation of the error code that
+ *     resulted from attempting to access the URL with curl_exec
+ */
+function do_curl_ext($url, $return_to_variable = 1, $number_of_post_vars = 0, $post = NULL) {
   global $user;
+  
   // Check if we are inside Drupal and there is a valid user.
+  
+  // If the user is not valid for a Fedora call curl will throw an exception.
   if ((!isset($user)) || $user->uid == 0) {
     $fedora_user = 'anonymous';
     $fedora_pass = 'anonymous';
@@ -67,8 +126,14 @@ function do_curl($url, $return_to_variable = 1, $number_of_post_vars = 0, $post 
       curl_setopt($ch, CURLOPT_POST, $number_of_post_vars);
       curl_setopt($ch, CURLOPT_POSTFIELDS, "$post");
     }
-    return curl_exec($ch);
+    
+    $ret_val = curl_exec($ch);
+    
+    $error_code = curl_errno($ch);
+    $error_string = curl_error($ch);
+    return array ($ret_val, $error_code, $error_string);
   }
+  
   else {
     if (function_exists(drupal_set_message)) {
       drupal_set_message(t('No curl support.'), 'error');
@@ -83,9 +148,20 @@ function do_curl($url, $return_to_variable = 1, $number_of_post_vars = 0, $post 
  */
 function fedora_available() {
 
-  $response = do_curl(variable_get('fedora_base_url', 'http://localhost:8080/fedora') . '/describe');
-  return strstr($response, 'Repository Information HTML Presentation') !== FALSE;
+  $response = do_curl_ext(variable_get('fedora_base_url', 'http://localhost:8080/fedora') . '/describe');
+  return ($response != NULL) ? ($response[1] == 0) : FALSE;
 }
+
+/**
+ * Resource index search available
+ * @return type 
+ */
+function risearch_available() {
+
+  $response = do_curl_ext(variable_get('fedora_repository_url', 'http://localhost:8080/fedora/risearch'));
+  return ($response != NULL) ? ($response[1] == 0): FALSE;
+}
+
 
 /**
  * Returns a UTF-8-encoded transcripiton of the string given in $in_str.

--- a/fedora_repository.module
+++ b/fedora_repository.module
@@ -907,6 +907,11 @@ function fedora_repository_get_items($pid = NULL, $dsId = NULL, $collection = NU
     return '';
   }
   
+  if (!risearch_available()) {
+    drupal_set_message(t('The Fedora resource index search is currently unavailable. Please contact the site administrator.'), 'warning', FALSE);
+    return '';
+  }
+  
   if ($pid == NULL) {
     $pid = variable_get('fedora_repository_pid', 'islandora:root');
   }


### PR DESCRIPTION
ISLANDORA-362 updated the do_curl method to be renamed do_curl_ext and return additional information to determine the success of curl_exec.  do_curl was modified to call do_curl_ext and retain historical method call correctness. fedora_repository.module was updated to test for the existence of risearch and output a message when it is not available.
