### PR TITLE
Fixed paging issue in sparql_to_html.xsl

### DIFF
--- a/xsl/sparql_to_html.xsl
+++ b/xsl/sparql_to_html.xsl
@@ -8,7 +8,6 @@
   <xsl:value-of select="$path"/>
  </xsl:variable>
  <xsl:variable name="thisPid" select="$collectionPid"/>
- <xsl:variable name="thisTitle" select="Collection"/>
  <xsl:variable name="size"  select="20"/>
  <xsl:variable name="page" select="$hitPage"/>
  <xsl:variable name="start" select="((number($page) - 1) * number($size)) + 1"/>


### PR DESCRIPTION
The change from the thisTitle variable to 'Collection' wasn't working and so the urls being created had the form fedora/repository/islandora:basic_image/-//1. I removed the variable and just put 'Collection' in as a string and this seems to have fixed the issue. I also took out the declaration of the $thisTitle variable as it was no longer serving any purpose.
