### PR TITLE
Updated SecurityClass to properly search XACML

### DIFF
--- a/SecurityClass.inc
+++ b/SecurityClass.inc
@@ -34,7 +34,6 @@ class SecurityClass {
     $objectHelper = new ObjectHelper();
     // get the childsecurity policy from the collection.
     $policyStream = $objectHelper->getStream($collection_pid, SECURITYCLASS :: $SECURITY_CLASS_SECURITY_STREAM, FALSE);
-
     if ($policyStream == NULL) {
       // no child policy stream so collection is wide open to anyone to ingest, that has the permission ingest in Drupal.
       // maybe we should return FALSE here?? would be more secure.
@@ -79,34 +78,20 @@ class SecurityClass {
     }
     $xml->registerXPathNamespace('default', 'urn:oasis:names:tc:xacml:1.0:policy');
 
-    $conditions = $xml->xpath("//default:Condition");
+    $roles = $xml->xpath('//default:SubjectAttributeDesignator[@AttributeId="fedoraRole"]/../default:Apply/default:AttributeValue');
+    $users = $xml->xpath('//default:SubjectAttributeDesignator[@AttributeId="urn:fedora:names:fedora:2.1:subject:loginId"]/../default:Apply/default:AttributeValue');
 
-    foreach ($conditions as $condition) {
-      $designator = $condition->Apply->SubjectAttributeDesignator;
-      if (empty($designator)) {//$disignator may be wrapped by an or
-        $designator = $condition->Apply->Apply->SubjectAttributeDesignator;
-      }
-      $attributeId = strip_tags($designator['AttributeId']);
-
-      if ($attributeId == "fedoraRole") {
-        foreach ($condition->Apply->Apply->AttributeValue as $attributeValue) {
-          $allowedRoles[] = strip_tags($attributeValue->asXML());
-        }
-        foreach ($condition->Apply->Apply->Apply->AttributeValue as $attributeValue) {
-          $allowedRoles[] = strip_tags($attributeValue->asXML());
-        }
-      }
-      if ($attributeId == "urn:fedora:names:fedora:2.1:subject:loginId") {
-        foreach ($condition->Apply->Apply->AttributeValue as $attributeValue) {
-          $allowedUsers[] = strip_tags($attributeValue->asXML());
-        }
-        foreach ($condition->Apply->Apply->Apply->AttributeValue as $attributeValue) {
-          $allowedUsers[] = strip_tags($attributeValue->asXML());
-        }
-      }
+    foreach($roles as $role) {
+      $allowedRoles[] = (string)$role;
     }
+    foreach($users as $user) {
+      $allowedUsers[] = (string)$user;
+    }
+
     $usersAndRoles['users'] = $allowedUsers;
     $usersAndRoles['roles'] = $allowedRoles;
+
+    dd($usersAndRoles);
     return $usersAndRoles;
   }
 


### PR DESCRIPTION
The SecurityClass module does a naive search of an XACML policy to
pull out the users and roles listed. Assuming that they are who
can edit the object. With certain policies this was failing, and
only returning the users, not the roles. This became a problem
with the XACML editor in use because this class was used more often.

I updated the XPATH expressions that it uses to find the users and
roles, so it should find them in all cases now. We should update
the security class to call the more precise XACML class first and
only fall back on the security class if XACML fails to parse the
file, however this would mean moving the XACML stuff into core.
