### PR TITLE
Added a function for forgetting a object when memory constraints apply.

### DIFF
--- a/api/fedora_item.inc
+++ b/api/fedora_item.inc
@@ -62,7 +62,7 @@ class Fedora_Item {
    * Removes this object from the static list of $instantiated_pids
    */
   function forget() {
-    unset(Fedora_Item::$instantiated_pids[$pid]);
+    unset(Fedora_Item::$instantiated_pids[$this->pid]);
   }
 
   /**


### PR DESCRIPTION
The Fedora_Item class has a built in cache, that stores all Fedora_Items's that have been instantiated. These objects are stored in a static array within the class. I've added a new function for removing the instantiated object from the static array. 

This is required when long running processes that instantiate 1000's of pids. When doing so users of the Fedora_Item class who are aware of memory constraints can remove the instantiated objects to prevent memory leaks that would otherwise bring down the http process.
