### PR TITLE
replaced digital repository breadcrumb with the name of the repository

### DIFF
--- a/ObjectHelper.inc
+++ b/ObjectHelper.inc
@@ -924,7 +924,8 @@ class ObjectHelper {
     // Before executing the query, we hve a base case of accessing the top-level collection
     global $base_url;
     if ($pid == variable_get('fedora_repository_pid', 'islandora:root')) {
-      $breadcrumbs[] = l(t('Digital repository'), 'fedora/repository');
+      //$breadcrumbs[] = l(t('Digital repository'), 'fedora/repository');
+      $breadcrumbs[] = l(variable_get('fedora_repository_title', 'Digital repository'), 'fedora/repository');
       $breadcrumbs[] = l(t('Home'), $base_url);
     }
     else {
@@ -954,7 +955,8 @@ class ObjectHelper {
         
         $breadcrumbs[] = l($matches[1], 'fedora/repository/' . $pid);
         if ($parent == variable_get('fedora_repository_pid', 'islandora:root')) {
-          $breadcrumbs[] = l(t('Digital repository'), 'fedora/repository');
+          //$breadcrumbs[] = l(t('Digital repository'), 'fedora/repository');
+          $breadcrumbs[] = l(variable_get('fedora_repository_title', 'Digital repository'), 'fedora/repository');
           $breadcrumbs[] = l(t('Home'), $base_url);
         }
         elseif ($level > 0) {


### PR DESCRIPTION
The breadcrumb inside the Digital repository always said "Digital repository" regardless of what the user specified as the name of the repository.  These two lines pull the name from the database and display that instead.
