### PR TITLE
ISLANDORA-548 Updated curl call in ObjectHelper

### DIFF
--- a/ObjectHelper.inc
+++ b/ObjectHelper.inc
@@ -122,8 +122,7 @@ class ObjectHelper {
         $dsID = variable_get('fedora_default_display_dsid', 'TN');
         $mimeType = 'image/jpeg';
       }
-
-      $url = variable_get('fedora_base_url', 'http://localhost:8080/fedora') . '/get/' . $pid . '/' . $dsID;
+      $url = variable_get('fedora_base_url', 'http://localhost:8080/fedora') . '/objects/' . $pid . '/datastreams/' . $dsID . '/content';
       if ($version) {
         $url .= '/' . $version; //drupal_urlencode($version);
       }


### PR DESCRIPTION
The ObjectHelper.inc file uses the deprecated API-A Lite API, i.e. localhost:8080/fedora/get/{pid}/{dsID}

This causes problems when XACML policies are in place that require access to certain datastreams based on fedoraRole. Basically, despite sending accurate credentials in the GET request, the fedoraRole is not recognized by fedora's AttributeFinderModule, and a user cannot access a particular datastream. The protected datastreams, however, are viewable in Fedora's admin console (while using the same credentials) since that uses the REST API.

Updated the curl call to use the new REST API.
