### PR TITLE
Added the quiet=true flag to fedora_item.inc

### DIFF
--- a/api/fedora_item.inc
+++ b/api/fedora_item.inc
@@ -59,7 +59,7 @@ class Fedora_Item {
         self::$connection_helper = new ConnectionHelper();
       }
 
-      $raw_objprofile = $this->soap_call('getObjectProfile', array('pid' => $this->pid, 'asOfDateTime' => ""));
+      $raw_objprofile = $this->soap_call('getObjectProfile', array('pid' => $this->pid, 'asOfDateTime' => ""), TRUE);
 
       if (!empty($raw_objprofile)) {
         $this->objectProfile = $raw_objprofile->objectProfile;


### PR DESCRIPTION
In Fedora item when you call the constructor it automatically does
a getObjectProfile soap call. This was reporting soap errors
when called on an item that dosen't exist, we don't want to
show the user this.
