### PR TITLE
fix for ISLANDORA 604 and added some defines to FedoraItem.inc

### DIFF
--- a/CollectionClass.inc
+++ b/CollectionClass.inc
@@ -105,7 +105,7 @@ class CollectionClass {
    */
   function getRelatedItems($pid, $query_string = NULL, $limit = NULL, $offset = NULL) {
     module_load_include('inc', 'fedora_repository', 'api/fedora_utils');
-
+    module_load_include('inc', 'fedora_repository', 'ObjectHelper');
     if (!fedora_repository_access(OBJECTHELPER :: $OBJECT_HELPER_VIEW_FEDORA, $pid)) {
       drupal_set_message(t("You do not have access to Fedora objects within the attempted namespace or access to Fedora denied."), 'error');
       return ' ';

--- a/api/fedora_item.inc
+++ b/api/fedora_item.inc
@@ -7,6 +7,8 @@
 define('RELS_EXT_URI', 'info:fedora/fedora-system:def/relations-external#');
 define("FEDORA_MODEL_URI", 'info:fedora/fedora-system:def/model#');
 define("ISLANDORA_PAGE_URI", 'info:islandora/islandora-system:def/pageinfo#');
+define("ISLANDORA_RELS_EXT_URI", 'http://islandora.ca/ontology/relsext#');
+define("ISLANDORA_RELS_INT_URI", "http://islandora.ca/ontology/relsint#");
 
 /**
  * Fedora Item Class


### PR DESCRIPTION
could get to getRelatedItems without ObjectHelper being loaded so added a module_load_include
