### PR TITLE
updated configurations to save display mode as well and config options, ...

### DIFF
--- a/ObjectDetails.inc
+++ b/ObjectDetails.inc
@@ -207,8 +207,10 @@ function fedora_repository_object_details_XSLT_config() {
  *   The user supplied values for the form.
  */
 function fedora_repository_object_details_XSLT_config_submit($form, &$form_state) {
+  variable_set('islandora_object_details_display_table', 'xslt');
   variable_set('islandora_object_details_xslt_sheet', $form_state['values']['xslt']);
   variable_set('islandora_object_details_xslt_datastream', $form_state['values']['dsid']);
+  drupal_set_message('Object Details view has been set to XSLT and your configuration has been saved');
 }
 
 /**
@@ -268,5 +270,7 @@ function fedora_repository_object_details_table_config() {
  *   The user supplied values for the form.
  */
 function fedora_repository_object_details_table_config_submit($form, &$form_state) {
+  variable_set('islandora_object_details_display_table', 'table');
   variable_set('islandora_object_details_table_datastream', $form_state['values']['dsid']);
+  drupal_set_message('Object Details view has been set to Table and your configuration has been saved');
 }


### PR DESCRIPTION
When you edit the internal object details configuration options it now sets the display mode (so if you edit the xslt options, it automatically sets the view mode to xslt).  It also drupal_set_message's the user to let them know settings were updated.

addresses https://jira.duraspace.org/browse/ISLANDORA-662
and https://jira.duraspace.org/browse/ISLANDORA-661
