### PR TITLE
Change so that modify_datastream_by_reference attempts to access a file ...

### DIFF
--- a/api/fedora_item.inc
+++ b/api/fedora_item.inc
@@ -1068,6 +1068,14 @@ RDF;
    * @return type
    */
   function modify_datastream_by_reference($external_url, $dsid, $label, $mime_type, $force = FALSE, $logMessage = 'Modified by Islandora API', $quiet=FALSE) {
+    global $base_url;
+
+    // Fedora has some problems getting files from HTTPS connections sometimes, so if we are getting a file
+    // from the local drupal, we try to pass a HTTP url instead of a HTTPS one.
+    if(stripos($external_url, 'https://') !== FALSE && stripos($external_url, $base_url) !== FALSE) {
+      $external_url = str_ireplace('https://', 'http://', $external_url);
+    }
+    
     $params = array(
       'pid' => $this->pid,
       'dsID' => $dsid,


### PR DESCRIPTION
...via HTTP and not HTTPS. Previously the file could not be accessed.

add_datastream_from_url also employs this.
