### PR TITLE
coder cleanup

### DIFF
--- a/admin/islandora.admin.inc
+++ b/admin/islandora.admin.inc
@@ -1,11 +1,14 @@
 <?php
 
 /**
- * @file islandora.admin.inc
- * Create admin form
- * @return array 
+ * @file
+ * islandora.admin.inc: This file contains the general islandora admin form and callback functions.
  */
 
+/**
+ * Create admin form
+ * @return array
+ */
 function islandora_repository_admin($form, &$form_state) {
   module_load_include('inc', 'islandora', 'includes/tuque');
   module_load_include('inc', 'islandora', 'includes/utilities');
@@ -17,7 +20,7 @@ function islandora_repository_admin($form, &$form_state) {
 
   $form = array();
 
-  if(isset($form_state['values']['islandora_base_url'])) {
+  if (isset($form_state['values']['islandora_base_url'])) {
     $url = $form_state['values']['islandora_base_url'];
   }
   else {
@@ -33,7 +36,7 @@ function islandora_repository_admin($form, &$form_state) {
     $info = FALSE;
   }
 
-  if($info) {
+  if ($info) {
     try {
       $dc = $connection->api->m->getDatastream('fedora-system:ContentModel-3.0', 'DC');
     }
@@ -41,9 +44,9 @@ function islandora_repository_admin($form, &$form_state) {
       $dc = FALSE;
     }
   }
-  
-  if($info) {
-    if($dc) {
+
+  if ($info) {
+    if ($dc) {
       $confirmation_message = '<img src="' . url('misc/watchdog-ok.png') . '"/>'
         . t('Successfully connected to Fedora Server (Version !version).', array('!version' => $info['repositoryVersion']));
     }
@@ -77,7 +80,7 @@ function islandora_repository_admin($form, &$form_state) {
     '#type' => 'textfield',
     '#title' => t('Fedora base URL'),
     '#default_value' => variable_get('islandora_base_url', 'http://localhost:8080/fedora'),
-    '#description' => t('The URL to use for REST connections <br>' . $confirmation_message),
+    '#description' => t('The URL to use for REST connections <br />' . $confirmation_message),
     '#required' => TRUE,
     '#ajax' => array(
       'callback' => 'islandora_update_url_div',
@@ -121,20 +124,20 @@ function islandora_repository_admin($form, &$form_state) {
       'progress' => array('type' => 'throbber'),
     ),
   );
-  
-  if(isset($form_state['values']['islandora_namespace_restriction_enforced'])) {
+
+  if (isset($form_state['values']['islandora_namespace_restriction_enforced'])) {
     $namespaces = $form_state['values']['islandora_namespace_restriction_enforced'];
   }
   else {
     $namespaces = variable_get('islandora_namespace_restriction_enforced', FALSE);
   }
 
-  if($namespaces) {
+  if ($namespaces) {
     $form['islandora_tabs']['islandora_namespace']['wrapper']['islandora_pids_allowed'] = array(
       '#type' => 'textfield',
       '#title' => t('PID namespaces allowed in this Drupal install'),
       '#default_value' => variable_get('islandora_pids_allowed', 'default: demo: changeme: ilives: islandora-book: books: newspapers: '),
-      '#description' => t('A space separated list of PID namespaces that users are permitted to access from this Drupal installation. <br /> This could be more than a simple namespace ie demo:mydemos. <br> islandora: is reserved and is always allowed.'),
+      '#description' => t('A space separated list of PID namespaces that users are permitted to access from this Drupal installation. <br /> This could be more than a simple namespace ie demo:mydemos. <br /> islandora: is reserved and is always allowed.'),
       '#weight' => 0,
     );
   }
@@ -158,6 +161,6 @@ function islandora_update_url_div($form, $form_state) {
 function islandora_update_namespace_div($form, $form_state) {
   unset($form_state['submit_handlers']);
   $form_state['rebuild'] = TRUE;
-  
+
   return $form['islandora_tabs']['islandora_namespace']['wrapper'];
 }

--- a/includes/breadcrumb.inc
+++ b/includes/breadcrumb.inc
@@ -1,11 +1,16 @@
 <?php
 
+/**
+ * @file
+ * This file contains functions to create breadcrumbs on Islandora object pages.
+ */
+
 function islandora_get_breadcrumbs($object) {
   $breadcrumbs = array();
 
   islandora_get_breadcrumbs_recursive($object->id, $breadcrumbs, $object->repository);
-  
-  if(isset($breadcrumbs[0])) {
+
+  if (isset($breadcrumbs[0])) {
     unset($breadcrumbs[0]);
   }
 
@@ -69,8 +74,8 @@ function islandora_get_breadcrumbs_recursive($pid, &$breadcrumbs, $repository) {
       islandora_get_breadcrumbs_recursive($parent, $breadcrumbs, $repository);
     }
     else {
-      $breadcrumbs[] = '...'; //Add an non-link, as we don't know how to get back to the root.
-      islandora_get_breadcrumbs_recursive($root, $breadcrumbs, $repository); //And render the last two links and break (on the next pass).
+      $breadcrumbs[] = '...'; // Add an non-link, as we don't know how to get back to the root.
+      islandora_get_breadcrumbs_recursive($root, $breadcrumbs, $repository); // And render the last two links and break (on the next pass).
     }
   }
 }

--- a/includes/datastream.inc
+++ b/includes/datastream.inc
@@ -1,26 +1,28 @@
 <?php
 
 /**
- * @file datastream.inc 
+ * @file
+ * This file contains the admin form and callback functions for datastream manipulations.
  */
 
 define('DS_COMP_STREAM', 'DS-COMPOSITE-MODEL');
 /**
+ * Callback function to view or download a datastream.
  *
  * @global object $user
  * @param string $object_id
  * @param string $dsid
- * @return stream 
+ * @return stream
  *  prints datastream to browser
  */
 function islandora_view_datastream($object, $dsid, $method = 'view') {
   // if the object exists but the datastream doesn't
-  if(!isset($object[$dsid])) {
+  if (!isset($object[$dsid])) {
     return drupal_not_found();
   }
 
   header('Content-type: ' . $object[$dsid]->mimetype);
-  if($object[$dsid]->controlGroup == 'M' || $object[$dsid]->controlGroup == 'X') {
+  if ($object[$dsid]->controlGroup == 'M' || $object[$dsid]->controlGroup == 'X') {
     header('Content-length: ' . $object[$dsid]->size);
   }
 
@@ -45,7 +47,7 @@ function islandora_datastream_get_parents($islandora_object) {
   }
   $collections = array_merge($collections1, $collections2);
 
-  foreach($collections as $collection) {
+  foreach ($collections as $collection) {
     try {
       $pid = $collection['object']['value'];
       $object = $repository->getObject($collection['object']['value']);
@@ -55,7 +57,9 @@ function islandora_datastream_get_parents($islandora_object) {
       $parent_collections[$pid]['label'] = $object->label;
       $parent_collections[$pid]['label_link'] = l($parent_collections[$pid]['label'], $parent_collections[$pid]['url']);
     }
-    catch (RepositoryException $e) {}
+    catch (RepositoryException $e) {
+
+    }
   }
 
   return $parent_collections;
@@ -65,13 +69,13 @@ function islandora_datastream_get_parents($islandora_object) {
  *
  * @param array $arr
  *   an array of dsids that are defined by this objects cmodels
- * @param string $ds_comp_stream 
+ * @param string $ds_comp_stream
  *   the dscomposite stream as xml
  */
 function islandora_get_defined_dsids_array(&$arr, $ds_comp_stream) {
   $sxml = new SimpleXMLElement($ds_comp_stream);
   foreach ($sxml->dsTypeModel as $ds) {
-    //$arr[$ds['ID']] 
+    //$arr[$ds['ID']]
     $mimes = array();
     foreach ($ds->form as $form) {
       $mimetype = (string) $form['MIME'];
@@ -88,13 +92,13 @@ function islandora_get_defined_dsids_array(&$arr, $ds_comp_stream) {
  *
  * @global type $user
  * @param string $object_id
- * @return string|array 
+ * @return string|array
  */
 function islandora_get_unused_dsids($object) {
 
   $defined_dsids = array();
 
-  if(!$object) {
+  if (!$object) {
     return $defined_dsids;
   }
 
@@ -124,11 +128,11 @@ function islandora_get_unused_dsids($object) {
  * buids the default add datastream form
  * @param string $object_id
  * @param array $form_state
- * @return array 
+ * @return array
  *  a form ready to be rendered with a call to Drupal render
  */
 function islandora_get_add_datastream_form($object, &$form_state) {
-  $unused_dsids = islandora_get_unused_dsids($object); 
+  $unused_dsids = islandora_get_unused_dsids($object);
   $form = array();
   $form['add_fieldset'] = array(
     '#type' => 'fieldset',
@@ -168,9 +172,9 @@ function islandora_get_add_datastream_form($object, &$form_state) {
   );
 
   if (!empty($unused_dsids)) {
-    $dsidsForForm = array();
+    $dsids_for_form = array();
     foreach ($unused_dsids as $key => $value) {
-      $dsidsForForm[$key] = $key;
+      $dsids_for_form[$key] = $key;
     }
     $form['add_fieldset']['stream_id'] = array(
       '#type' => 'select',
@@ -179,7 +183,7 @@ function islandora_get_add_datastream_form($object, &$form_state) {
       '#weight' => '-1',
       '#description' => t('Datastream IDs defined by the content model.'),
     );
-    $form['add_fieldset']['stream_id']['#options'] = $dsidsForForm;
+    $form['add_fieldset']['stream_id']['#options'] = $dsids_for_form;
   }
   else {
     $form['add_fieldset']['stream_id'] = array(
@@ -201,7 +205,7 @@ function islandora_get_add_datastream_form($object, &$form_state) {
  *   Drupal user
  * @param array $form
  * @param array $form_state
- * @return type 
+ * @return type
  */
 function islandora_add_datastream_form_submit($form, &$form_state) {
   global $base_url;
@@ -212,7 +216,7 @@ function islandora_add_datastream_form_submit($form, &$form_state) {
 
   module_load_include('inc', 'islandora', 'includes/mime.detect');
   $mimetype = new MimeDetect();
-  
+
   $file = $form_state['values']['add-stream-file-location'];
   $file = drupal_realpath($file);
 
@@ -220,11 +224,11 @@ function islandora_add_datastream_form_submit($form, &$form_state) {
   $dsid = $form_state['values']['stream_id'];
   $ds_label = $form_state['values']['stream_label'];
   $dformat = $mimetype->getMimeType($file);
-  $controlGroup = "M";
+  $control_group = "M";
 
   try {
     $fedora_object = islandora_object_load($object_id);
-    $ds = $fedora_object->constructDatastream($dsid, $controlGroup);
+    $ds = $fedora_object->constructDatastream($dsid, $control_group);
     $ds->label = $ds_label;
     $ds->mimetype = $dformat;
     $ds->setContentFromFile($file);
@@ -235,16 +239,16 @@ function islandora_add_datastream_form_submit($form, &$form_state) {
     drupal_set_message(t('@message', array('@message' => check_plain($e->getMessage()))), 'error');
     return;
   }
-  drupal_set_message("Successfully Added Datastream!");
+  drupal_set_message(t("Successfully Added Datastream!"));
   drupal_goto("islandora/object/$object_id");
 }
 
 /**
- * validates this datastream id against its allowed mimetypes in the dscomposite 
+ * validates this datastream id against its allowed mimetypes in the dscomposite
  * of its content models.
  * @param array $form
  * @param array $form_state
- * @return boolean 
+ * @return boolean
  */
 function islandora_add_datastream_form_validate($form, &$form_state) {
   module_load_include('inc', 'islandora', 'includes/mime.detect');
@@ -254,8 +258,8 @@ function islandora_add_datastream_form_validate($form, &$form_state) {
     return;
   }
   $dsid = $form_state['values']['stream_id'];
-  $dsLabel = $form_state['values']['stream_label'];
-  if (strlen($dsid) > 64) {
+  $ds_label = $form_state['values']['stream_label'];
+  if (drupal_strlen($dsid) > 64) {
     form_set_error('', t('Data stream ID cannot be more than 64 characters.'));
     return FALSE;
   }
@@ -263,11 +267,11 @@ function islandora_add_datastream_form_validate($form, &$form_state) {
     form_set_error('', t("Data stream ID (@dsid) has to start with a letter.", array('@dsid' => check_plain($dsid))));
     return FALSE;
   }
-  if (strlen($dsLabel) > 64) {
+  if (drupal_strlen($ds_label) > 64) {
     form_set_error('', t('Data stream Label cannot be more than 64 characters.'));
     return FALSE;
   }
-  if (strpos($dsLabel, '/')) {
+  if (strpos($ds_label, '/')) {
     form_set_error('', t('Data stream Label cannot contain a "/".'));
     return FALSE;
   }
@@ -275,7 +279,7 @@ function islandora_add_datastream_form_validate($form, &$form_state) {
   $object_id = $form_state['values']['pid'];
   $fedora_object = islandora_object_load($object_id);
 
-  if(isset($fedora_object[$dsid])) {
+  if (isset($fedora_object[$dsid])) {
     form_set_error('', t('Data stream ID already exists in object.'));
     return FALSE;
   }
@@ -283,7 +287,7 @@ function islandora_add_datastream_form_validate($form, &$form_state) {
   $mimetype = new MimeDetect();
   $object = islandora_object_load($form_state['values']['pid']);
   $unused_dsids = islandora_get_unused_dsids($object);
-  if(isset($unused_dsids[$dsid])) {
+  if (isset($unused_dsids[$dsid])) {
     $types_allowed = $unused_dsids[$dsid];
     $arr = array();
     foreach ($types_allowed as $type) {
@@ -295,7 +299,7 @@ function islandora_add_datastream_form_validate($form, &$form_state) {
     // http://api.drupal.org/api/drupal/includes!file.inc/function/file_save_upload/7
     $arr = array();
   }
-  
+
 
   $file = file_save_upload('add-stream-file-location', array('file_validate_extensions' => $arr));
   if ($file) {
@@ -312,7 +316,7 @@ function islandora_add_datastream_form_validate($form, &$form_state) {
  * buids the default add datastream form
  * @param string $object_id
  * @param array $form_state
- * @return array 
+ * @return array
  *  a form ready to be rendered with a call to Drupal render
  */
 function islandora_add_datastream_form($form, &$form_state, $object) {
@@ -356,19 +360,19 @@ function islandora_add_datastream_form($form, &$form_state, $object) {
   );
 
   $unused_dsids = islandora_get_unused_dsids($object);
-  $dsidsForForm = '';
+  $dsids_for_form = '';
   $i = 0;
   foreach ($unused_dsids as $key => $value) {
-    if($i++) {
-      $dsidsForForm .= ", ";
+    if ($i++) {
+      $dsids_for_form .= ", ";
     }
-    $dsidsForForm .= "'$key'";
+    $dsids_for_form .= "'$key'";
   }
 
   $form['add_fieldset']['stream_id'] = array(
     '#title' => 'Datastream ID',
     '#required' => 'TRUE',
-    '#description' => t('An ID for this stream that is unique to this object. Must start with a letter and contain only alphanumeric characters and dashes and underscores. Datastreams that are defined by the content model dont currently exist: <b>' . $dsidsForForm . '</b>.'),
+    '#description' => t('An ID for this stream that is unique to this object. Must start with a letter and contain only alphanumeric characters and dashes and underscores. Datastreams that are defined by the content model dont currently exist: <b>' . $dsids_for_form . '</b>.'),
     '#type' => 'textfield',
     '#weight' => -1,
     '#autocomplete_path' => "islandora/object/$object->id/manage/datastreams/add/autocomplete",
@@ -379,13 +383,13 @@ function islandora_add_datastream_form($form, &$form_state, $object) {
 function islandora_datastream_autocomplete_callback($object, $string = '') {
   $dsids = islandora_get_unused_dsids($object);
   $output = array();
-  foreach($dsids as $id => $ds) {
-    if(trim($string) == '') {
+  foreach ($dsids as $id => $ds) {
+    if (trim($string) == '') {
       $output[$id] = $id;
     }
     else {
       $ret = stripos($id, $string);
-      if($ret !== FALSE) {
+      if ($ret !== FALSE) {
         $output[$id] = $id;
       }
     }
@@ -397,7 +401,7 @@ function islandora_datastream_get_human_readable_size($ds) {
   module_load_include('inc', 'islandora', 'includes/utilities');
 
   // we return - if we don't have a size
-  if($ds->controlGroup == 'M' || $ds->controlGroup == 'X') {
+  if ($ds->controlGroup == 'M' || $ds->controlGroup == 'X') {
     return islandora_convert_bytes_to_human_readable($ds->size);
   }
   else {
@@ -406,7 +410,7 @@ function islandora_datastream_get_human_readable_size($ds) {
 }
 
 function islandora_datastream_get_url($ds, $type = 'download') {
-  if($ds->controlGroup == 'R') {
+  if ($ds->controlGroup == 'R') {
     return $ds->url;
   }
   else {
@@ -417,7 +421,7 @@ function islandora_datastream_get_url($ds, $type = 'download') {
 function islandora_datastream_get_delete_link($ds) {
   $datastreams = module_invoke_all('islandora_undeletable_datastreams', $ds->parent->models);
 
-  if(in_array($ds->id, $datastreams)) {
+  if (in_array($ds->id, $datastreams)) {
     return '';
   }
   else {

--- a/includes/ingest-menu.inc
+++ b/includes/ingest-menu.inc
@@ -11,13 +11,13 @@
  * @param string $pid
  */
 function islandora_ingest_callback($collection_object) {
-  if(!$collection_object) {
+  if (!$collection_object) {
     return drupal_not_found();
   }
 
   $ingest_registry = module_invoke_all('islandora_ingest_registry', $collection_object);
   $registry_count = count($ingest_registry);
-  
+
   if ($registry_count == 0) {
     // No ingest implementations.
     drupal_set_message(t('There are no ingest methods specified for @name.', array('@name', $collection_object->label)));
@@ -33,7 +33,7 @@ function islandora_ingest_callback($collection_object) {
   }
 }
 
-//@TODO: theme
+// @TODO: theme
 function islandora_ingest_registry_render($ingest_registry) {
   $output = array(
     '#type' => 'markup',

--- a/includes/islandora.ingest.inc
+++ b/includes/islandora.ingest.inc
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * @file
+ * This file contains ingest callback functions
+ */
+
 function islandora_ingest_get_information(AbstractFedoraObject $collection_object) {
   $models = $collection_object->models;
   $collection_info = module_invoke_all('islandora_ingest_get_information', $models, $collection_object);
@@ -12,7 +17,7 @@ function islandora_ingest_get_object($content_models, $collection_pid, $relation
   global $user;
   $connection = new IslandoraTuque($user);
   $object = $connection->repository->constructObject($namespace);
-  foreach($content_models as $content_model) {
+  foreach ($content_models as $content_model) {
     $object->relationships->add(FEDORA_MODEL_URI, 'hasModel', $content_model['pid']);
   }
   $object->relationships->add(FEDORA_RELS_EXT_URI, $relationship, $collection_pid);

--- a/includes/islandora_dublin_core.inc
+++ b/includes/islandora_dublin_core.inc
@@ -70,7 +70,7 @@ class Dublin_Core {
   /**
    * Serialize this object to XML and return it.
    * @param type $with_preamble
-   * @return type 
+   * @return type
    */
   function as_xml($with_preamble = FALSE) {
     $dc_xml = new DomDocument();
@@ -96,7 +96,7 @@ class Dublin_Core {
    * Create dc from dict ( does nothing )
    */
   static function create_dc_from_dict() {
-    
+
   }
 
   function as_formatted_array() {
@@ -108,9 +108,9 @@ class Dublin_Core {
           if (is_array($values)) {
             $value = '';
             $i = 0;
-            foreach($values as $piece) {
-              if(!empty($piece)) {
-                if($i++) {
+            foreach ($values as $piece) {
+              if (!empty($piece)) {
+                if ($i++) {
                   $value .= ", ";
                 }
                 $value .= $piece;
@@ -121,16 +121,16 @@ class Dublin_Core {
             $value = $values;
           }
           $dc_label = explode(':', $field);
-          $element_label = ucfirst($dc_label[1]);
+          $element_label = drupal_ucfirst($dc_label[1]);
           $dc_array[$field]['label'] = $element_label;
           $dc_array[$field]['value'] = $value;
-          $dc_array[$field]['class'] = strtolower(preg_replace('/[^A-Za-z0-9]/', '-', $field));
+          $dc_array[$field]['class'] = drupal_strtolower(preg_replace('/[^A-Za-z0-9]/', '-', $field));
         }
       }
     }
     return $dc_array;
   }
-  
+
 
   /**
    * Creates a new instance of the class by parsing dc_xml

--- a/includes/mime.detect.inc
+++ b/includes/mime.detect.inc
@@ -227,7 +227,7 @@ class MimeDetect {
   public function getMimetype($filename, $debug = FALSE) {
 
     $file_name_and_extension = explode('.', $filename);
-    $ext = strtolower(array_pop($file_name_and_extension));
+    $ext = drupal_strtolower(array_pop($file_name_and_extension));
 
     if (!empty($this->protectedMimeTypes[$ext])) {
       if (TRUE === $debug) {

--- a/includes/object_properties.inc
+++ b/includes/object_properties.inc
@@ -1,13 +1,20 @@
 <?php
 
 /**
- * may want more validation here the only restrictions i see on
+ * @file
+ * Contains admin form functions for object properties
+ */
+
+/**
+ * Validate function for object properties admin form.
+ *
+ * @TODO: may want more validation here the only restrictions i see on
  * the object label and owner is the foxml schema says they should be
  * an xsd:string there maybe further restrictions such as length but they aren't
  * defined in the schema.
  * @param array $form
  * @param array $form_state
- * @return boolean 
+ * @return boolean
  */
 function islandora_edit_properties_form_validate($form, &$form_state) {
   $islandora_object = islandora_object_load($form_state['values']['pid']);
@@ -18,9 +25,10 @@ function islandora_edit_properties_form_validate($form, &$form_state) {
 }
 
 /**
+ * Submit function for object properties admin form.
  *
  * @param array $form
- * @param array $form_state 
+ * @param array $form_state
  */
 function islandora_edit_properties_form_submit($form, &$form_state) {
   $islandora_object = islandora_object_load($form_state['values']['pid']);
@@ -32,7 +40,7 @@ function islandora_edit_properties_form_submit($form, &$form_state) {
       $islandora_object->owner = $owner;
       drupal_set_message(t('Successfully updated owner %s', array('%s' => $owner)));
     } catch (Exception $e) {
-      form_set_error('object_owner',t('Error updating owner %s', array('%s'=> $e->getMessage())));
+      form_set_error('object_owner', t('Error updating owner %s', array('%s' => $e->getMessage())));
     }
   }
   if (isset($state) && $state != $islandora_object->state) {
@@ -40,7 +48,7 @@ function islandora_edit_properties_form_submit($form, &$form_state) {
       $islandora_object->state = $state;
       drupal_set_message(t('Successfully updated state %s', array('%s' => $state)));
     } catch (Exception $e) {
-      form_set_error('object_state',t('Error updating state %s', array('%s'=> $e->getMessage())));
+      form_set_error('object_state', t('Error updating state %s', array('%s' => $e->getMessage())));
     }
   }
   if (isset($label) && $label != $islandora_object->label) {
@@ -53,18 +61,22 @@ function islandora_edit_properties_form_submit($form, &$form_state) {
   }
 }
 
+/**
+ * Callback function for object properties admin form delete button.
+ */
 function islandora_edit_properties_form_delete($form, &$form_state) {
   $islandora_object = $form_state['values']['pid'];
   drupal_goto("islandora/object/$islandora_object/delete");
 }
 
 /**
+ * Object properties admin form.
  *
  * @param array $form
  * @param array $form_state
  * @param string $object_id
  *   an object id
- * @return array 
+ * @return array
  */
 function islandora_edit_properties_form($form, &$form_state, $object) {
   $form = array();
@@ -111,5 +123,3 @@ function islandora_edit_properties_form($form, &$form_state, $object) {
   );
   return $form;
 }
-
-?>

--- a/includes/purge.form.inc
+++ b/includes/purge.form.inc
@@ -1,6 +1,11 @@
 <?php
 
 /**
+ * @file
+ * This file contains the admin (confirmation) form and callback functions to purge an object.
+ */
+
+/**
  * Gives the option of deleting or purging and object.
  *
  * The default behaviour is to purge the object to reduce maintenance.
@@ -154,7 +159,7 @@ function islandora_purge_datastream_submit($form, &$form_state) {
     }
   }
   //notify modules post deletion
-  module_invoke_all('islandora_post_purge_datastream', $object, $datastream_id); 
+  module_invoke_all('islandora_post_purge_datastream', $object, $datastream_id);
   drupal_set_message(t('%d datastream sucessfully purged from Islandora object %o', array('%d' => $datastream_id, '%o' => $object->label)));
   drupal_goto('islandora/object/' . $object->id);
 }

--- a/includes/tuque.inc
+++ b/includes/tuque.inc
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * @file
+ * This file contains a class to include the Tuque php library.
+ */
+
 $islandora_module_path = drupal_get_path('module', 'islandora');
 
 //do this until we expost these in a module or library
@@ -54,14 +59,15 @@ class IslandoraTuque {
   public $repository = NULL;
 
   function __construct($user = NULL, $url = NULL) {
-    if(!isset($user)) {
+    if (!isset($user)) {
       global $user;
     }
-    
-    if(!isset($user) || $user->uid == 0){
+
+    if (!isset($user) || $user->uid == 0) {
       $user_string = 'anonymous';
       $pass_string = 'anonymous';
-    } else {
+    }
+    else {
       $user_string = $user->name;
       $pass_string = $user->pass;
     }
@@ -70,7 +76,7 @@ class IslandoraTuque {
       $url = variable_get('islandora_base_url', 'http://localhost:8080/fedora');
     }
 
-    if(self::exists()) {
+    if (self::exists()) {
       $this->connection = new RepositoryConnection($url, $user_string, $pass_string);
       $this->connection->reuseConnection = TRUE;
       $this->api = new FedoraApi($this->connection);
@@ -87,7 +93,7 @@ class IslandoraTuque {
     $islandora_doc_link = l(t('Islandora documentation'), 'https://wiki.duraspace.org/display/ISLANDORA/Islandora');
     $tuque_link = l(t('Tuque Fedora API'), 'http://github.com/islandora/tuque');
     $message = t('Islandora requires the !tuque_url. Please install in /sites/all/libraries/tuque before continuing. See the !islandora_url.', array( '!tuque_url' => $tuque_link, '!islandora_url' => $islandora_doc_link));
-    drupal_set_message($message, 'error', FALSE);
+    drupal_set_message(filter_xss($message), 'error', FALSE);
   }
 }
 

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -1,39 +1,44 @@
 <?php
 
 /**
+ * @file
+ * Contains islandora utility functions
+ */
+
+/**
  * Convert bytes to human readable format
  *
  * @param integer bytes Size in bytes to convert
  * @return string
  */
-function islandora_convert_bytes_to_human_readable($bytes, $precision = 2)
-{
-    $kilobyte = 1024;
-    $megabyte = $kilobyte * 1024;
-    $gigabyte = $megabyte * 1024;
-    $terabyte = $gigabyte * 1024;
+function islandora_convert_bytes_to_human_readable($bytes, $precision = 2) {
+  $kilobyte = 1024;
+  $megabyte = $kilobyte * 1024;
+  $gigabyte = $megabyte * 1024;
+  $terabyte = $gigabyte * 1024;
 
-    if (($bytes >= 0) && ($bytes < $kilobyte)) {
-        return $bytes . ' B';
-
-    } elseif (($bytes >= $kilobyte) && ($bytes < $megabyte)) {
-        return round($bytes / $kilobyte, $precision) . ' KB';
-
-    } elseif (($bytes >= $megabyte) && ($bytes < $gigabyte)) {
-        return round($bytes / $megabyte, $precision) . ' MB';
-
-    } elseif (($bytes >= $gigabyte) && ($bytes < $terabyte)) {
-        return round($bytes / $gigabyte, $precision) . ' GB';
-
-    } elseif ($bytes >= $terabyte) {
-        return round($bytes / $terabyte, $precision) . ' TB';
-    } else {
-        return $bytes . ' B';
-    }
+  if (($bytes >= 0) && ($bytes < $kilobyte)) {
+    return $bytes . ' B';
+  }
+  elseif (($bytes >= $kilobyte) && ($bytes < $megabyte)) {
+    return round($bytes / $kilobyte, $precision) . ' KB';
+  }
+  elseif (($bytes >= $megabyte) && ($bytes < $gigabyte)) {
+    return round($bytes / $megabyte, $precision) . ' MB';
+  }
+  elseif (($bytes >= $gigabyte) && ($bytes < $terabyte)) {
+    return round($bytes / $gigabyte, $precision) . ' GB';
+  }
+  elseif ($bytes >= $terabyte) {
+    return round($bytes / $terabyte, $precision) . ' TB';
+  }
+  else {
+    return $bytes . ' B';
+  }
 }
 
 function islandora_control_group_to_human_readable($control_group) {
-  switch($control_group) {
+  switch ($control_group) {
     case 'M':
       return '<b>M</b>anaged';
     case 'X':
@@ -54,7 +59,7 @@ function islandora_control_group_to_human_readable($control_group) {
  */
 function islandora_validate_pid($pid) {
   $valid = FALSE;
-  if (strlen(trim($pid)) <= 64 && preg_match('/^([A-Za-z0-9]|-|\.)+:(([A-Za-z0-9])|-|\.|~|_|(%[0-9A-F]{2}))+$/', trim($pid))) {
+  if (drupal_strlen(trim($pid)) <= 64 && preg_match('/^([A-Za-z0-9]|-|\.)+:(([A-Za-z0-9])|-|\.|~|_|(%[0-9A-F]{2}))+$/', trim($pid))) {
     $valid = TRUE;
   }
 
@@ -68,7 +73,7 @@ function islandora_validate_pid($pid) {
  */
 function islandora_validate_dsid($dsid) {
   $valid = FALSE;
-  if (strlen(trim($dsid)) <= 64 && preg_match('/^[a-zA-Z0-9\_\-\.]+$/', trim($dsid))) {
+  if (drupal_strlen(trim($dsid)) <= 64 && preg_match('/^[a-zA-Z0-9\_\-\.]+$/', trim($dsid))) {
     $valid = TRUE;
   }
 
@@ -76,9 +81,9 @@ function islandora_validate_dsid($dsid) {
 }
 
 /* Helper function to describe a Fedora repository.
- * 
+ *
  * Can be used to check if Fedora is available.
- * 
+ *
  * @param $url
  *   A url to a Fedora repository.
  * @return
@@ -86,7 +91,7 @@ function islandora_validate_dsid($dsid) {
  *   or if the url is incorrect.
  */
 function islandora_describe_repository($url) {
-  
+
   $connection = new IslandoraTuque(NULL, $url);
   try {
     $info = $connection->api->a->describeRepository();

--- a/islandora.api.php
+++ b/islandora.api.php
@@ -1,83 +1,89 @@
 <?php
+
+/**
+ * @file
+ * This file lists and documents all available hook functions to manipulate data.
+ */
+
 /**
  * remove a datastream from a repository object
  * @param object $fedora_object
  *  tuque FedoraObject
- * @param string $datastream_id 
+ * @param string $datastream_id
  */
-function hook_islandora_purge_datastream ($fedora_object, $datastream_id){}
+function hook_islandora_purge_datastream($fedora_object, $datastream_id) {}
 
 /**
  *
- * @param type $object 
+ * @param type $object
  *   tuque FedoraObject
  */
-function hook_islandora_purge_object($islandora_object) {} 
+function hook_islandora_purge_object($islandora_object) {}
 
 /**
  * allows modules to add to a repository objects display.  If you implement this
- * hook you should also register your module for view with the get types hook.  
- * 
- * islandora gets all displays back in an array and iterates over them.  the order 
+ * hook you should also register your module for view with the get types hook.
+ *
+ * islandora gets all displays back in an array and iterates over them.  the order
  * they are displayed is based on the order of the key of the array that each
  * module returns.
- * 
- * your module may also want to register a varible that says whether or not it 
+ *
+ * your module may also want to register a varible that says whether or not it
  * should be part of the default display. Modules can also add secondary tabs as
- * a way to add there output to an islandora display.  the basic image module has 
+ * a way to add there output to an islandora display.  the basic image module has
  * samples of both (the secondary tabs examples are commented out)
- * 
+ *
  * @param type $islandora_object
- *   tuque FedoraObject 
+ *   tuque FedoraObject
  */
-function hook_islandora_view_object($islandora_object){}
+function hook_islandora_view_object($islandora_object) {}
 
 /**
  * returns an array listing object types provided by sub modules
  *  Ex.  array($types['islandora:collectionCModel'][ISLANDORA_VIEW_HOOK] = variable_get('islandora_basic_collection_use_for_default_tab', TRUE);
  * $types['islandora:collectionCModel'][ISLANDORA_EDIT_HOOK] = FALSE;
- * 
- * @return array 
+ *
+ * @return array
  */
-function hook_islandora_get_types(){}
+function hook_islandora_get_types() {}
 
 /**
  * allows modules to define an object edit page by cmodel
- * 
+ *
  * your module should return true for ISLANDORA_EDIT_HOOK in its get_types function
- * 
+ *
  * islandora provides a default implementation that should work for most use cases
  * @param string $islandora_object
- * @return string 
- * 
+ * @return string
+ *
  */
-function hook_islandora_edit_object($islandora_object){}
+function hook_islandora_edit_object($islandora_object) {}
 
 /**
  * allows modules to alter the fedora object before it is pass through the edit
  * hooks
- * @param type $islandora_object 
+ * @param type $islandora_object
  *   a tugue FedoraObject
  */
-function islandora_islandora_edit_object_alter ($islandora_object){}
+function islandora_islandora_edit_object_alter($islandora_object) {}
 
 
 /**
- * creates and populates a php Fedora object. 
+ * creates and populates a php Fedora object.
  */
-function hook_islandora_preingest_alter(){}
+function hook_islandora_preingest_alter() {}
 
 /**
  * modules can implement this hook to add or remove datastreams after an
- * object has been ingested.  
- * 
- * Each module should check for the newly ingested repository objects content 
- * model to make sure it is a type of object they want to act on.  
- * 
- * @param type $islandora_object 
+ * object has been ingested.
+ *
+ * Each module should check for the newly ingested repository objects content
+ * model to make sure it is a type of object they want to act on.
+ *
+ * @param type $islandora_object
  *   tugue FeodoraObject
  */
-function hook_islandora_postingest($islandora_object){}
+function hook_islandora_postingest($islandora_object) {}
 
 /**
  * Register potential ingest routes. Implementations should return an array containing possible routes.
@@ -96,25 +102,25 @@ function hook_islandora_edit_datastream_registry($islandora_object, $ds_id) {}
 
 /**
  * alter an object before it gets used further down the stack
- * @param type $object 
+ * @param type $object
  *   a tuque FedoraObject
  */
-function hook_islandora_object_alter ($fedora_object){}
+function hook_islandora_object_alter($fedora_object) {}
 
 /**
- * insert or remove rendered elements by implementing this function 
- * in your module 
- * @param type $arr 
+ * insert or remove rendered elements by implementing this function
+ * in your module
+ * @param type $arr
  *   an arr of rendered views
  */
-function hook_islandora_display_alter ($arr){}
+function hook_islandora_display_alter($arr) {}
 
 /**
  *
  * @param type $islandora_object
  *   a tuque FedoraObject
  * @param array $content_models
- * @param string $collection_pid 
+ * @param string $collection_pid
  */
-function hook_islandora_ingest_pre_ingest($islandora_object, $content_models, $collection_pid){}
+function hook_islandora_ingest_pre_ingest($islandora_object, $content_models, $collection_pid) {}
 

--- a/islandora.install
+++ b/islandora.install
@@ -1,0 +1,6 @@
+<?php
+
+/**
+ * @file
+ * This file contains all install functions.
+ */

--- a/islandora.module
+++ b/islandora.module
@@ -1,28 +1,28 @@
 <?php
 
 /*
- * @file islandora.module
- * defines paths (drupal menu items) as entry points and acts as a hub for dispatching tasks to other modules.
- * 
- * 
+ * @file
+ *
+ * islandora.module: defines paths (drupal menu items) as entry points and acts as a hub for dispatching tasks to other modules.
+ *
  * This file is part of Islandora.
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with the program.  If not, see <http ://www.gnu.org/licenses/>.
  */
 
 
-//Permissions
+// Permissions
 define('FEDORA_VIEW', 'view fedora repository');
 define('FEDORA_METADATA_EDIT', 'edit fedora metadata');
 define('FEDORA_ADD_DS', 'add fedora datastreams');
@@ -31,12 +31,12 @@ define('FEDORA_PURGE', 'delete fedora objects and datastreams');
 define('FEDORA_MODIFY_STATE', 'modify fedora state');
 define('FEDORA_MANAGE', 'manage fedora items');
 
-//hooks
+// hooks
 define('ISLANDORA_VIEW_HOOK', 'islandora_view_object');
 define('ISLANDORA_EDIT_HOOK', 'islandora_edit_object');
 
 /**
- * Implementation of hook_menu. 
+ * Implements hook_menu().
  * we need some standard entry points so we can have consistent urls for different Object actions
  */
 function islandora_menu() {
@@ -215,20 +215,20 @@ function islandora_admin_paths() {
  * @param string $op
  * @param string $pid
  *
- *  @return boolean 
+ *  @return boolean
  */
 function islandora_access_callback($object = NULL, $perm = NULL) {
-  if(!$object || !$perm) {
+  if (!$object || !$perm) {
     return FALSE;
   }
 
   $isRestricted = variable_get('islandora_namespace_restriction_enforced', FALSE);
-  
+
   if (!$isRestricted) {
     $namespace_access = TRUE;
   }
   else {
-    $pid_namespace = substr($object->id, 0, strpos($object->id, ':') + 1); //Get the namespace (with colon)
+    $pid_namespace = substr($object->id, 0, strpos($object->id, ':') + 1); // Get the namespace (with colon)
     $allowed_namespaces = explode(" ", variable_get('islandora_pids_allowed', 'default: demo: changeme: islandora: ilives: islandora-book: books: newspapers: '));
     $namespace_access = in_array($pid_namespace, $allowed_namespaces);
   }
@@ -238,7 +238,7 @@ function islandora_access_callback($object = NULL, $perm = NULL) {
 
 /**
  * returns an array listing object types provided by sub modules
- * @return array 
+ * @return array
  */
 function islandora_get_types() {
   return module_invoke_all('islandora_get_types');
@@ -255,10 +255,10 @@ function islandora_init() {
  * that handle this function this module will build a default page.
  * @global object $user
  * @param string $object_id
- * @return string 
+ * @return string
  */
 function islandora_edit_object($object) {
-  if(!$object) {
+  if (!$object) {
     return drupal_not_found();
   }
   drupal_alter('islandora_edit_object', $object);
@@ -274,7 +274,7 @@ function islandora_edit_object($object) {
 /**
  * edit properties form
  * @param type $object_id
- * @return string 
+ * @return string
  */
 function islandora_edit_properties($object_id) {
   $object = islandora_object_load($object_id);
@@ -290,7 +290,7 @@ function islandora_edit_properties($object_id) {
 /**
  * builds a default page for the edit tab
  *
- * @param object $fedora_object 
+ * @param object $fedora_object
  *   A tuque Fedora Object
  */
 function islandora_islandora_edit_object($fedora_object) {
@@ -315,14 +315,14 @@ function islandora_view_default_object() {
  * their modules want to provide a view for.
  * @global object $user
  * @param string $object_id
- * 
- * @return string 
+ *
+ * @return string
  */
 function islandora_view_object($fedora_object = NULL) {
   module_load_include('inc', 'islandora', 'includes/breadcrumb');
   global $user;
 
-  if(!$fedora_object) {
+  if (!$fedora_object) {
     return drupal_not_found();
   }
 
@@ -348,10 +348,10 @@ function islandora_view_object($fedora_object = NULL) {
 }
 
 /**
- * the default view hook.  If there are no modules registered to handle this objects cmodels or there are 
+ * the default view hook.  If there are no modules registered to handle this objects cmodels or there are
  * not any cmodels specified this will create a default display.
  * @param string $object_id
- * @return string 
+ * @return string
  */
 function islandora_islandora_view_object($object) {
   $supported_models = islandora_get_types();
@@ -425,17 +425,17 @@ function islandora_permission() {
  * a helper function to get a connection and return an object
  * @global object $user
  * @param string $object_id
- * @return FedoraObject 
+ * @return FedoraObject
  */
 function islandora_object_load($object_id) {
   module_load_include('inc', 'islandora', 'includes/tuque');
   static $islandora_tuque = NULL;
 
-  if(!$islandora_tuque) {
+  if (!$islandora_tuque) {
     $islandora_tuque = new IslandoraTuque();
   }
 
-  if(IslandoraTuque::exists()) {
+  if (IslandoraTuque::exists()) {
     try {
       $fedora_object = $islandora_tuque->repository->getObject($object_id);
     } catch (Exception $e) {
@@ -450,13 +450,13 @@ function islandora_object_load($object_id) {
 }
 
 function islandora_ingest_access_callback($object, $perm) {
-  if(islandora_access_callback($object, $perm) === FALSE) {
+  if (islandora_access_callback($object, $perm) === FALSE) {
     return FALSE;
   }
 
   $ingest_registry = module_invoke_all('islandora_ingest_registry', $object);
 
-  if(count($ingest_registry) > 0) {
+  if (count($ingest_registry) > 0) {
     return TRUE;
   }
   else {

--- a/theme/islandora-object-edit.tpl.php
+++ b/theme/islandora-object-edit.tpl.php
@@ -1,50 +1,24 @@
 <?php
 
-/*
- * islandora-object-edit.tpl.php
- * 
+/**
+ * @file
+ * islandora-object-edit.tpl.php: This is a template for objects that do not have
+ * a module to registered to build their display.
  *
- * 
- * This file is part of Islandora.
- * 
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- * 
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- * 
- * You should have received a copy of the GNU General Public License
- * along with the program.  If not, see <http ://www.gnu.org/licenses/>.
- */
-?>
-<?php
-
-/* 
- * this is a template for objects that do not have a module to registered to build their display.
- * 
  * islandora_object is a fedora tuque Object
  *    $object->label
  *    $object->id
  * to get the contents of a datastream
- *    $object['dsid']->content 
- * 
+ *    $object['dsid']->content
+ *
  * $dublin_core is a Dublin_Core object
  * which is an array of elements, such as dc.title
  * and each element has an array of values.  dc.title can have none, one or many titles
  * this is the case for all dc elements.
- * 
- * 
- * 
+ *
  */
-
-//dsm($object);
-
-drupal_set_title($islandora_object->label);
-//print($islandora_object->label . ' ' . $islandora_object->id); 
-print (theme_table($variables['datastream_table']));
 ?>
 
+<?php drupal_set_title($islandora_object->label); ?>
+
+<?php print (theme_table($variables['datastream_table'])); ?>

--- a/theme/islandora-object.tpl.php
+++ b/theme/islandora-object.tpl.php
@@ -1,30 +1,8 @@
 <?php
 
 /*
- * islandora-object.tpl.php
- * 
- *
- * 
- * This file is part of Islandora.
- * 
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- * 
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- * 
- * You should have received a copy of the GNU General Public License
- * along with the program.  If not, see <http ://www.gnu.org/licenses/>.
- */
-?>
-<?php
-
-/* 
- * this is a template for objects that do not have a module to registered to build their display.
+ * @file
+ * This is a template for objects that do not have a module to registered to build their display.
  * 
  * islandora_object is a fedora tuque Object
  *    $object->label             - The label for this object.

--- a/theme/islandora.theme.inc
+++ b/theme/islandora.theme.inc
@@ -1,6 +1,11 @@
 <?php
 
 /**
+ * @file
+ * This file contains all theme and preprocess functions.
+ */
+
+/**
  * preprocess the edit template
  * @global string $base_url
  * @param array $variables
@@ -72,9 +77,11 @@ function islandora_preprocess_islandora_default(&$variables) {
       $datastreams[$id]['mimetype'] = $ds->mimetype;
       $datastreams[$id]['size'] = islandora_datastream_get_human_readable_size($ds);
       $datastreams[$id]['created_date'] = $ds->createdDate->format("Y-m-d");
-      $datastreams[$id]['class'] = strtolower(preg_replace('/[^A-Za-z0-9]/', '-', $id));
+      $datastreams[$id]['class'] = drupal_strtolower(preg_replace('/[^A-Za-z0-9]/', '-', $id));
     }
-    catch (RepositoryException $e) {}
+    catch (RepositoryException $e) {
+
+    }
   }
   $variables['datastreams'] = $datastreams;
   try {


### PR DESCRIPTION
Did a coder cleanup based on the most strict warnings. The only line I kept for now is the following:

islandora.module
    severity: minorLine 231: in most cases, replace the string function with the drupal_ equivalent string functions
        $pid_namespace = substr($object->id, 0, strpos($object->id, ':') + 1); // Get the namespace (with colon)

Because the api documentation says that the php functions are much faster. I would still use the drupal functions if it wasn't for the critical location of the functions. They're in an access callback function that is used by almost half of the registered islandora paths.
http://api.drupal.org/api/drupal/includes%21unicode.inc/function/drupal_substr/7

The doxygen comments are overall pretty good, but some might need a little cleanup.
