### PR TITLE
fixed typo in get_mimetype

### DIFF
--- a/api/fedora_item.inc
+++ b/api/fedora_item.inc
@@ -860,7 +860,7 @@ RDF;
     $this->get_datastreams_list_as_SimpleXML();
 
     $mimetype = '';
-    foreach ($datastream_list as $datastream) {
+    foreach ($this->datastreams_list as $datastream) {
       foreach ($datastream as $datastreamValue) {
         if ($datastreamValue->ID == $dsid) {
           return $datastreamValue->MIMEType;


### PR DESCRIPTION
A typo in the get_mimetype_of_datastream function was causing an error and returning nothing any time someone asked for a mimetype, its feeling much better now
