### PR TITLE
Hook was inconsistently named

### DIFF
--- a/islandora.api.php
+++ b/islandora.api.php
@@ -65,7 +65,7 @@ function hook_islandora_edit_object($islandora_object) {}
  * @param type $islandora_object
  *   a tugue FedoraObject
  */
-function islandora_islandora_edit_object_alter($islandora_object) {}
+function hook_islandora_edit_object_alter($islandora_object) {}
 
 
 /**
@@ -123,4 +123,3 @@ function hook_islandora_display_alter($arr) {}
  * @param string $collection_pid
  */
 function hook_islandora_ingest_pre_ingest($islandora_object, $content_models, $collection_pid) {}
-


### PR DESCRIPTION
It looked like a hook implementation rather than a hook declaration, I've changed it to look as a hook declaration, doing a "grep -r islandora_edit_object_alter *" I was unable to find any other implementations or calls to this hook. 

Requires review.
