### PR TITLE
Warning no longer displayed when attempting to call islandora_load_objec...

### DIFF
--- a/islandora.module
+++ b/islandora.module
@@ -167,7 +167,6 @@ function islandora_menu() {
     'load arguments' => array('%map'),
     'type' => MENU_DEFAULT_LOCAL_TASK,
   );
-   
   $items['islandora/object/%islandora_object/datastream/%islandora_datastream/download'] = array(
     'title' => 'Download datastream',
     'page callback' => 'islandora_download_datastream',
@@ -530,7 +529,7 @@ function islandora_object_load($object_id) {
  *   '%islandora_tokened_object'.
  * @param array $map
  *   Used to extract the Fedora object's DSID at $map[4].
- * 
+ *
  * @return FedoraObject
  *   A token authenticated object. @see islandora_object_load
  */
@@ -547,21 +546,21 @@ function islandora_tokened_object_load($object_id, $map) {
 }
 
 /**
- * This datastream load must take in arguments in a different 
- * order than the usual islandora_datastream_load.  This is because 
+ * This datastream load must take in arguments in a different
+ * order than the usual islandora_datastream_load.  This is because
  * the function islandora_tokened_object_load needs DSID. It uses
  * the path %map to avoid duplicate parameters. The menu system
  * passes 'load arguments' to both islandora_tokened_object_load
  * and this function and the first parameter is positional with the token.
- * An alternative: 
+ * An alternative:
  * islandora_tokened_object_load(PID, DSID, PID)
  * islandora_tokened_datastream_load(DSID, DSID, PID)
- * 
+ *
  * @param mixed $datastream_id
  *   %islandora_tokened_datastream @see islandora_datastream_load
  * @param array $map
  *   Used to extract the Fedora object's PID at $map[2].
- * 
+ *
  * @return FedoraDatastream
  *   A datastream from Fedora.
  *   @see islandora_datastream_load
@@ -582,8 +581,8 @@ function islandora_tokened_datastream_load($datastream_id, $map) {
  *   from the given object in the menu path identified by '%islandora_object'.
  *
  * @param mixed $object_id
- *   The object to load the datastream from.  This can be a Fedora PID or 
- *   an instantiated IslandoraFedoraObject as it implements __toString() 
+ *   The object to load the datastream from.  This can be a Fedora PID or
+ *   an instantiated IslandoraFedoraObject as it implements __toString()
  *   returning the PID.
  *
  * @return FedoraDatastream
@@ -591,12 +590,10 @@ function islandora_tokened_datastream_load($datastream_id, $map) {
  *   object, otherwise it returns NULL which triggers drupal_page_not_found().
  */
 function islandora_datastream_load($datastream_id, $object_id) {
-  $object = islandora_object_load($object_id);
-
+  $object = is_object($object_id) ? $object_id : islandora_object_load($object_id);
   if (!$object) {
     return NULL;
   }
-
   return $object[$datastream_id];
 }
 
@@ -875,7 +872,7 @@ function islandora_post_delete_datastream(FedoraObject $object, $datastream_id) 
 
 /**
  * Implements hook_cron()
- * 
+ *
  * Removes expired authentication tokens.
  */
 function islandora_cron() {


### PR DESCRIPTION
...t with an existing object in the datastream_load function.

The warning was trigged inside of SimpleCache when attempting to use the object passed in as a key.
