### PR TITLE
Decode the pid when retrieved from the url as it may be encoded, which c...

### DIFF
--- a/islandora.module
+++ b/islandora.module
@@ -507,7 +507,7 @@ function islandora_object_load($object_id) {
   $tuque = islandora_get_tuque_connection();
   if ($tuque) {
     try {
-      $object = $tuque->repository->getObject($object_id);
+      $object = $tuque->repository->getObject(urldecode($object_id));
       drupal_alter('islandora_object', $object);
       return $object;
     } catch (Exception $e) {


### PR DESCRIPTION
...auses problems with tuque.

Broke searching or processing the objects relationships as the encoded PID didn't exactly match the string used for the PID inside of the objects RELS-EXT.
