### PR TITLE
Add check for PHP XSLT Processor extension. v2

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -20,11 +20,6 @@ function islandora_repository_admin(array $form, array &$form_state) {
   module_load_include('inc', 'islandora', 'includes/utilities');
   drupal_add_css(drupal_get_path('module', 'islandora') . '/css/islandora.admin.css');
   
-  if (!class_exists('XSLTProcessor', FALSE)) {
-    $link = l(t('PHP XSL extension'), 'http://us2.php.net/manual/en/book.xsl.php', array('attributes' => array('target'=>'_blank')));
-    drupal_set_message(t('The !xsllink is required. Check your installed PHP extensions and php.ini file.', array('!xsllink' => $link)),'error');
-  }
-
   $form = array();
   if (isset($form_state['values']['islandora_base_url'])) {
     $url = $form_state['values']['islandora_base_url'];

--- a/islandora.install
+++ b/islandora.install
@@ -4,6 +4,25 @@
  * @file
  * This file contains all install related hooks.
  */
+ 
+/**
+ * Implements hook_requirements().
+ */
+function islandora_requirements($phase) {
+  $requirements = array();
+  // Ensure translations don't break at install time
+  $t = get_t();
+
+  if (!class_exists('XSLTProcessor', FALSE)) {
+    $requirements['islandora_xsltprocessor']['title'] = $t('Islandora XSLTProcessor Prerequisite');
+    $requirements['islandora_xsltprocessor']['value'] = $t('Not installed');
+    $link = l($t('PHP XSL extension'), 'http://us2.php.net/manual/en/book.xsl.php', array('attributes' => array('target'=>'_blank')));
+    $requirements['islandora_xsltprocessor']['description'] = $t('The !xsllink is required. Check your installed PHP extensions and php.ini file.', array('!xsllink' => $link)),'error');
+    $requirements['islandora_xsltprocessor']['severity'] = REQUIREMENT_ERROR;
+  }
+  
+  return $requirements;
+}
 
 /**
  * Implements hook_install().


### PR DESCRIPTION
[Version 2 of this pull request]

When the PHP XSLT Processor extension is not loaded, Islandora will silently fail when attempting to add new objects.  This changeset adds a check to the Islandora configuration screen for the XSLTProcessor class.  If it isn't found, a message is thrown.

The "silently fails" happens when trying to move from the metadata entry screen of adding an object to the object upload screen.  The returned page is empty, and this error is sent to the apache error log:

```
PHP Fatal error:  Class 'XSLTProcessor' not found in .../islandora_xml_forms/builder/includes/associations.inc on line 198
```
