### PR TITLE
Add check for PHP XSLT Processor extension.

### DIFF
--- a/islandora.install
+++ b/islandora.install
@@ -6,6 +6,25 @@
  */
 
 /**
+ * Implements hook_requirements().
+ */
+function islandora_requirements($phase) {
+  $requirements = array();
+  // Ensure translations don't break at install time
+  $t = get_t();
+
+  if (!class_exists('XSLTProcessor', FALSE)) {
+    $requirements['islandora_xsltprocessor']['title'] = $t('Islandora XSLTProcessor Prerequisite');
+    $requirements['islandora_xsltprocessor']['value'] = $t('Not installed');
+    $link = l($t('PHP XSL extension'), 'http://us2.php.net/manual/en/book.xsl.php', array('attributes' => array('target'=>'_blank')));
+    $requirements['islandora_xsltprocessor']['description'] = $t('The !xsllink is required. Check your installed PHP extensions and php.ini file.', array('!xsllink' => $link));
+    $requirements['islandora_xsltprocessor']['severity'] = REQUIREMENT_ERROR;
+  }
+
+  return $requirements;
+}
+
+/**
  * Implements hook_install().
  *
  * @see islandora_islandora_required_objects()


### PR DESCRIPTION
When the PHP XSLT Processor extension is not loaded, Islandora will
silently fail when attempting to add new objects.  This changeset
adds a check in the Islandora hook_requirements() hook for the
XSLTProcessor class.  If it isn't found, a message is thrown.

Conflicts:

```
islandora.install
```
