### PR TITLE
islandora_delete_object() now follows function description.

### DIFF
--- a/islandora.module
+++ b/islandora.module
@@ -836,10 +836,18 @@ function islandora_add_object(NewFedoraObject &$object) {
  *   An object to delete.
  *
  * @return bool
- *   The ingested FedoraObject, after running the pre/post ingest hooks.
+ *   TRUE if successful, FALSE otherwise.
  */
 function islandora_delete_object(FedoraObject &$object) {
-  return $object->repository->purgeObject($object->id);
+  try {
+    $object->repository->purgeObject($object->id);
+    $object = NULL;
+    return TRUE;
+  }
+  catch(Exception $e) {
+    // Exception message gets logged in Tuque Wrapper.
+    return FALSE;
+  }
 }
 
 /**


### PR DESCRIPTION
islandora_delete_object() no longer throws. Now it will only return TRUE if
successful, FALSE otherwise as expected.

This fixes the issue where solution packs were not reinstalling existing objects.
