### PR TITLE
Added a new function islandora_user_access() to simplify access callbacks

### DIFF
--- a/islandora.module
+++ b/islandora.module
@@ -401,7 +401,7 @@ function islandora_user_access($object, array $permissions, $content_models = ar
   }
   elseif (is_subclass_of($object, 'FedoraDatastream')) {
     $datastream = $object;
-    $object = $datstream->parent;
+    $object = $datastream->parent;
   }
   // Check for access.
   $accessible_namespace = islandora_namespace_accessible($object->id);

--- a/tests/islandora_manage_permissions.test
+++ b/tests/islandora_manage_permissions.test
@@ -81,4 +81,56 @@ class IslandoraPermissionsTestCase extends IslandoraWebTestCase {
     $this->assertNoLink('Properties', 'Properties tab is not on current page.');
     $this->assertNoLink('Collection', 'Collection tab is not on current page.');
   }
+
+  /**
+   * Test generic access functions.
+   *
+   * Note that we can't test with the Global user as SimpleTest doesn't support
+   * it. Therefore we can't test the authtoken support.
+   */
+  public function testAccessFunctions() {
+    $object = islandora_object_load(variable_get('islandora_repository_pid', 'islandora:root'));
+    // Test islandora_user_access();
+    // Test no object/permissions.
+    $ret = islandora_user_access(NULL, array());
+    $this->assertFalse($ret, 'User access denied when no object/permissions are provided.');
+    // Test with object no permissions.
+    $ret = islandora_user_access($object, array());
+    $this->assertFalse($ret, 'User access denied when no permissions are provided.');
+    // Test access with matching permission.
+    $user = $this->drupalCreateUser(array(FEDORA_VIEW_OBJECTS));
+    $ret = islandora_user_access($object, array(FEDORA_VIEW_OBJECTS), array(), TRUE, $user);
+    $this->assertTrue($ret, 'User access granted when permissions match.');
+    // Test access with matching permission but access any is FALSE.
+    $user = $this->drupalCreateUser(array(FEDORA_VIEW_OBJECTS));
+    $ret = islandora_user_access($object, array(FEDORA_VIEW_OBJECTS, FEDORA_PURGE), array(), FALSE, $user);
+    $this->assertFalse($ret, 'User access denied for matching permission but with access any set to FALSE.');
+    // Test access with non-matching permission.
+    $user = $this->drupalCreateUser(array(FEDORA_PURGE));
+    $ret = islandora_user_access($object, array(FEDORA_VIEW_OBJECTS), array(), TRUE, $user);
+    $this->assertFalse($ret, 'User access denied when permissions did not match.');
+    // Test access with both permissions and content model.
+    $user = $this->drupalCreateUser(array(FEDORA_VIEW_OBJECTS));
+    $model = $object->models;
+    $model = reset($model);
+    $ret = islandora_user_access($object, array(FEDORA_VIEW_OBJECTS), array($model), TRUE, $user);
+    $this->assertTrue($ret, 'User access granted for matching permission and model.');
+    // Test access with matching permissions and non-matching content model.
+    $user = $this->drupalCreateUser(array(FEDORA_VIEW_OBJECTS));
+    $ret = islandora_user_access($object, array(FEDORA_VIEW_OBJECTS), array('islandora:obviouslyNotACModel'), TRUE, $user);
+    $this->assertFalse($ret, 'User access denied for matching permission and non-matching model.');
+    // Test access with all matching permissions and one matching model but
+    // access any is FALSE.
+    $user = $this->drupalCreateUser(array(FEDORA_VIEW_OBJECTS, FEDORA_PURGE));
+    $model = $object->models;
+    $model = reset($model);
+    $ret = islandora_user_access($object, array(FEDORA_VIEW_OBJECTS, FEDORA_PURGE), array($model, 'islandora:obviouslyNotACModel'), FALSE, $user);
+    $this->assertFalse($ret, 'User access denied for all matching permissions and one matching model but with access any set to FALSE.');
+    $ret = islandora_user_access($object, array(FEDORA_VIEW_OBJECTS, FEDORA_PURGE), array($model), FALSE, $user);
+    $this->assertTrue($ret, 'User access granted for all matching permissions and matching models with access any set to FALSE.');
+    // Test passing in a Datastream.
+    $user = $this->drupalCreateUser(array(FEDORA_VIEW_OBJECTS, FEDORA_PURGE));
+    $ret = islandora_user_access($object['DC'], array(FEDORA_VIEW_OBJECTS), array(), TRUE, $user);
+    $this->assertTrue($ret, 'User access granted for matching permissions, with a datastream given instead of an object.');
+  }
 }


### PR DESCRIPTION
This function will check the given object/datastream against the given
permissions and required content models using the given user. If no user is
given the user identified by the GET token will be used, if no token is present
the global user will be used.
