### PR TITLE
Fix breadcrumb bug due to alternate menu titles.

### DIFF
--- a/includes/breadcrumb.inc
+++ b/includes/breadcrumb.inc
@@ -57,9 +57,10 @@ function islandora_get_breadcrumbs_recursive($pid, FedoraRepository $repository,
 
   $root = variable_get('islandora_repository_pid', 'islandora:root');
   if ($pid == $root) {
+    $item = menu_get_item('islandora');
     return array(
       l(t('Home'), '<front>'),
-      l(menu_get_active_title(), 'islandora'),
+      l($item['title'], 'islandora'),
     );
   }
   else {


### PR DESCRIPTION
If you created a menu entry to a certain object, then the second entry in the breadcrumbs would end up being given the title of the menu entry, instead of the title for the 'islandora' ("Islandora Repository") menu path it would otherwise be.
