### PR TITLE
Coding standards update

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -58,7 +58,7 @@ function islandora_repository_admin(array $form, array &$form_state) {
     else {
       $confirmation_message = theme_image(array('path' => 'misc/watchdog-warning.png', 'attributes' => array()));
       $confirmation_message .= t('Unable to authenticate when connecting to to Fedora Server (Version !version). Please configure the !filter.',
-                               array('!version' => $info['repositoryVersion'], '!filter' => 'Drupal Filter'));
+        array('!version' => $info['repositoryVersion'], '!filter' => 'Drupal Filter'));
     }
   }
   else {
@@ -146,7 +146,10 @@ function islandora_repository_admin(array $form, array &$form_state) {
       '#type' => 'textfield',
       '#title' => t('PID namespaces allowed in this Drupal install'),
       '#default_value' => variable_get('islandora_pids_allowed', 'default: demo: changeme: ilives: islandora-book: books: newspapers: '),
-      '#description' => t('A list of PID namespaces, separated by spaces, that users are permitted to access from this Drupal installation. <br /> This could be more than a simple namespace, e.g. <b>demo:mydemos</b>. <br /> The namespace <b>islandora:</b> is reserved, and is always allowed.'),
+      '#description' => t('A list of PID namespaces, separated by spaces, that users are
+                        permitted to access from this Drupal installation. <br /> This
+                        could be more than a simple namespace, e.g., <b>demo:mydemos</b>.
+                        <br /> The namespace <b>islandora:</b> is reserved, and is always allowed.'),
       '#weight' => 0,
     );
   }

--- a/includes/mime_detect.inc
+++ b/includes/mime_detect.inc
@@ -21,6 +21,10 @@
  * http://api.drupal.org/api/function/file_default_mimetype_mapping/7
  */
 
+/**
+ * MimeDetect class
+ * @author discoverygarden
+ */
 class MimeDetect {
 
   protected $protectedMimeTypes = array(
@@ -301,7 +305,7 @@ class MimeDetect {
    * Gets an associative array of MIME type and extension associations.
    *
    * Users the system mime.types file, or a local mime.types if one is found
-   * @see MIMEDetect::__constuctor()
+   * @see MIMEDetect.__construct()
    *
    * @return array
    *   An associative array where the keys are MIME types and the values
@@ -336,7 +340,7 @@ class MimeDetect {
    * Gets a associative array of extensions and MIME types.
    *
    * Users the system mime.types file, or a local mime.types if one is found
-   * @see MIMEDetect::__constuctor()
+   * @see MIMEDetect.__construct()
    *
    * @return array
    *   An associative array where the keys are extensions and the values

--- a/includes/object.entity_controller.inc
+++ b/includes/object.entity_controller.inc
@@ -5,6 +5,10 @@
  * Very basic entity controller.
  */
 
+/**
+ * IslandoraObjectEntityController Class
+ * @author discoverygarden
+ */
 class IslandoraObjectEntityController implements DrupalEntityControllerInterface {
 
   /**

--- a/includes/solution_packs.inc
+++ b/includes/solution_packs.inc
@@ -131,7 +131,7 @@ function islandora_solution_pack_form(array $form, array &$form_state, $solution
         '#markup' => t('<strong>Object status:</strong> !image !status', array(
                      '!image' => $solution_pack_status_info['image'],
                      '!status' => $solution_pack_status_info['solution_pack'],
-                   )),
+  )),
         '#prefix' => '<div class="islandora-solution-pack-install-status">',
         '#suffix' => '</div>',
       ),
@@ -594,7 +594,7 @@ function theme_islandora_viewers_table($variables) {
                'header' => $header,
                'rows' => $rows,
                'attributes' => array('id' => 'islandora-viewers-table'),
-             ));
+  ));
   $output .= drupal_render_children($form);
   return $output;
 }

--- a/includes/tuque.inc
+++ b/includes/tuque.inc
@@ -28,6 +28,10 @@ $islandora_module_path = drupal_get_path('module', 'islandora');
 @include_once "$islandora_module_path/libraries/tuque/Repository.php";
 @include_once "$islandora_module_path/libraries/tuque/FedoraRelationships.php";
 
+/**
+ * IslandoraTuque
+ * @author discoverygarden
+ */
 class IslandoraTuque {
 
   /**

--- a/includes/tuque_wrapper.inc
+++ b/includes/tuque_wrapper.inc
@@ -71,6 +71,10 @@ function islandora_invoke_datastream_hooks($hook, array $models, $dsid) {
   return islandora_invoke_hook_list($hook, $refinements, array_slice(func_get_args(), 3));
 }
 
+/**
+ * IslandoraFedoraRepository
+ * @author discoverygarden
+ */
 class IslandoraFedoraRepository extends FedoraRepository {
   protected $queryClass = 'IslandoraRepositoryQuery';
   protected $newObjectClass = 'IslandoraNewFedoraObject';
@@ -79,7 +83,7 @@ class IslandoraFedoraRepository extends FedoraRepository {
   /**
    * Ingest the given object.
    *
-   * @see FedoraRepository::ingestObject()
+   * @see FedoraRepository.ingestObject()
    */
   public function ingestObject(NewFedoraObject &$object) {
     $context = array(
@@ -112,12 +116,20 @@ class IslandoraFedoraRepository extends FedoraRepository {
 
 class IslandoraRepositoryQuery extends RepositoryQuery {}
 
+/**
+ * IslandoraNewFedoraObject
+ * @author discoverygarden
+ */
 class IslandoraNewFedoraObject extends NewFedoraObject {
   protected $newFedoraDatastreamClass = 'IslandoraNewFedoraDatastream';
   protected $fedoraDatastreamClass = 'IslandoraFedoraDatastream';
   protected $fedoraRelsExtClass = 'IslandoraFedoraRelsExt';
 }
 
+/**
+ * IslandoraFedoraObject
+ * @author discoverygarden
+ */
 class IslandoraFedoraObject extends FedoraObject {
   protected $newFedoraDatastreamClass = 'IslandoraNewFedoraDatastream';
   protected $fedoraDatastreamClass = 'IslandoraFedoraDatastream';
@@ -126,7 +138,7 @@ class IslandoraFedoraObject extends FedoraObject {
   /**
    * Ingest the given datastream.
    *
-   * @see FedoraObject::ingestDatastream()
+   * @see FedoraObject.ingestDatastream()
    */
   public function ingestDatastream(&$datastream) {
     $object = $datastream->parent;
@@ -156,12 +168,16 @@ class IslandoraFedoraObject extends FedoraObject {
 
 class IslandoraRepositoryConnection extends RepositoryConnection {}
 
+/**
+ * IslandoraFedoraApi
+ * @author discoverygarden
+ */
 class IslandoraFedoraApi extends FedoraApi {
 
   /**
    * Instantiate a IslandoraFedoraApi object.
    *
-   * @see FedoraApi::__construct()
+   * @see FedoraApi.__construct()
    */
   public function __construct(IslandoraRepositoryConnection $connection, FedoraApiSerializer $serializer = NULL) {
     if (!$serializer) {
@@ -173,6 +189,10 @@ class IslandoraFedoraApi extends FedoraApi {
   }
 }
 
+/**
+ * IslandoraFedoraApiM
+ * @author discoverygarden
+ */
 class IslandoraFedoraApiM extends FedoraApiM {
 
   /**
@@ -183,7 +203,7 @@ class IslandoraFedoraApiM extends FedoraApiM {
    * @throws Exception
    *   If the modify datastream request was block by some module.
    *
-   * @see FedoraApiM::modifyDatastream
+   * @see FedoraApiM.modifyDatastream()
    */
   public function modifyDatastream($pid, $dsid, $params = array()) {
     $object = islandora_object_load($pid);
@@ -218,7 +238,7 @@ class IslandoraFedoraApiM extends FedoraApiM {
   /**
    * Update Fedora Object parameters.
    *
-   * @see FedoraApiM::modifyObject
+   * @see FedoraApiM.modifyObject
    */
   public function modifyObject($pid, $params = NULL) {
     $object = islandora_object_load($pid);
@@ -251,7 +271,7 @@ class IslandoraFedoraApiM extends FedoraApiM {
   /**
    * Purge a datastream from from Fedora.
    *
-   * @see FedoraApiM::purgeDatastream
+   * @see FedoraApiM.purgeDatastream
    */
   public function purgeDatastream($pid, $dsid, $params = array()) {
     $object = islandora_object_load($pid);
@@ -294,7 +314,7 @@ class IslandoraFedoraApiM extends FedoraApiM {
   /**
    * Purge an object.
    *
-   * @see FedoraApiM::purgeObject
+   * @see FedoraApiM.purgeObject
    */
   public function purgeObject($pid, $log_message = NULL) {
     $object = islandora_object_load($pid);
@@ -338,16 +358,28 @@ class IslandoraFedoraApiM extends FedoraApiM {
 
 class IslandoraSimpleCache extends SimpleCache {}
 
+/**
+ * IslandoraNewFedoraDatastream
+ * @author discoverygarden
+ */
 class IslandoraNewFedoraDatastream extends NewFedoraDatastream {
   protected $fedoraRelsIntClass = 'IslandoraFedoraRelsInt';
   protected $fedoraDatastreamVersionClass = 'IslandoraFedoraDatastreamVersion';
 }
 
+/**
+ * IslandoraFedoraDatastream
+ * @author discoverygarden
+ */
 class IslandoraFedoraDatastream extends FedoraDatastream {
   protected $fedoraRelsIntClass = 'IslandoraFedoraRelsInt';
   protected $fedoraDatastreamVersionClass = 'IslandoraFedoraDatastreamVersion';
 }
 
+/**
+ * IslandoraFedoraDatastreamVersion
+ * @author discoverygarden
+ */
 class IslandoraFedoraDatastreamVersion extends FedoraDatastreamVersion {
   protected $fedoraRelsIntClass = 'IslandoraFedoraRelsInt';
   protected $fedoraDatastreamVersionClass = 'IslandoraFedoraDatastreamVersion';

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -764,4 +764,3 @@ function islandora_get_content_models($ignore_system_namespace = TRUE) {
   }
   return $content_models;
 }
-

--- a/islandora.api.php
+++ b/islandora.api.php
@@ -115,7 +115,7 @@ function hook_islandora_edit_object_alter(&$object, &$rendered) {
  *     The key value pairs repersent what values will be changed. The params
  *     will match the same params as passed to FedoraApiM::modifyObject().
  *
- * @see FedoraApiM::modifyObject()
+ * @see FedoraApiM.modifyObject()
  */
 function hook_islandora_object_alter(AbstractFedoraObject $object, array &$context) {
 }
@@ -164,7 +164,7 @@ function hook_CMODEL_PID_islandora_object_alter(AbstractFedoraObject $object, ar
  *     The key value pairs repersent what values will be changed. The params
  *     will match the same params as passed to FedoraApiM::modifyDatastream().
  *
- * @see FedoraApiM::modifyDatastream()
+ * @see FedoraApiM.modifyDatastream()
  */
 function hook_islandora_datastream_alter(AbstractFedoraObject $object, AbstractFedoraDatastream $datastream, array &$context) {
 }

--- a/islandora.module
+++ b/islandora.module
@@ -790,7 +790,8 @@ function islandora_object_load($object_id) {
  *   Used to extract the Fedora object's DSID at $map[4].
  *
  * @return FedoraObject
- *   A token authenticated object. @see islandora_object_load
+ *   A token authenticated object.
+ * @see islandora_object_load()
  */
 function islandora_tokened_object_load($object_id, $map) {
   if (array_key_exists('token', $_GET)) {
@@ -819,14 +820,15 @@ function islandora_tokened_object_load($object_id, $map) {
  * islandora_tokened_datastream_load(DSID, DSID, PID)
  *
  * @param mixed $datastream_id
- *   %islandora_tokened_datastream @see islandora_datastream_load
+ *   The datastream Identifier
+ * @see islandora_datastream_load()
  * @param array $map
  *   Used to extract the Fedora object's PID at $map[2].
  *
  * @return FedoraDatastream
  *   A datastream from Fedora.
  *
- * @see islandora_datastream_load
+ * @see islandora_datastream_load()
  */
 function islandora_tokened_datastream_load($datastream_id, $map) {
   return islandora_datastream_load($datastream_id, $map[2]);

--- a/islandora.rules.inc
+++ b/islandora.rules.inc
@@ -81,10 +81,10 @@ function islandora_rules_action_info() {
  * Checks that there is a relationship match on the given object.
  *
  * Takes a subject (either a FedoraObject or a FedoraDatastream), as well as
- * the parameters for FedoraRelsExt::get() or FedoraRelsInt::get(), to try to
+ * the parameters for FedoraRelsExt.get() or FedoraRelsInt.get(), to try to
  * find a match.
  *
- * @see FedoraRelsExt::get()
+ * @see FedoraRelsExt.get()
  */
 function islandora_object_has_relationship($sub, $pred_uri, $pred, $object, $type) {
   $relationships = $sub->relationships->get($pred_uri, $pred, $object, $type);
@@ -95,10 +95,10 @@ function islandora_object_has_relationship($sub, $pred_uri, $pred, $object, $typ
  * Remove a relationship from the given object.
  *
  * Takes a subject (either a FedoraObject or a FedoraDatastream), as well as
- * the parameters for FedoraRelsExt::remove() or FedoraRelsInt::remove(), to
+ * the parameters for FedoraRelsExt.remove() or FedoraRelsInt.remove(), to
  * try to find a match.
  *
- * @see FedoraRelsExt::get()
+ * @see FedoraRelsExt.get()
  */
 function islandora_object_remove_relationship($sub, $pred_uri, $pred, $object, $type) {
   $sub->relationships->remove($pred_uri, $pred, $object, $type);
@@ -108,10 +108,10 @@ function islandora_object_remove_relationship($sub, $pred_uri, $pred, $object, $
  * Add a relationship to the given object.
  *
  * Takes a subject (either a FedoraObject or a FedoraDatastream), as well as
- * the parameters for FedoraRelsExt::add() or FedoraRelsInt::add(), and adds
+ * the parameters for FedoraRelsExt.add() or FedoraRelsInt.add(), and adds
  * the represented relationship.
  *
- * @see FedoraRelsExt::get()
+ * @see FedoraRelsExt.get()
  */
 function islandora_object_add_relationship($sub, $pred_uri, $pred, $object, $type) {
   $sub->relationships->add($pred_uri, $pred, $object, $type);

--- a/tests/authtokens.test
+++ b/tests/authtokens.test
@@ -5,6 +5,10 @@
  * Test Authentication Tokens.
  */
 
+/**
+ * IslandoraAuthtokensTestCase
+ * @islandora
+ */
 class IslandoraAuthtokensTestCase extends IslandoraWebTestCase {
 
   /**

--- a/tests/hooks.test
+++ b/tests/hooks.test
@@ -11,12 +11,16 @@
  * To make sense of these tests reference islandora_hooks_test.module.
  */
 
+/**
+ * IslandoraHooksTestCase
+ * @islandora
+ */
 class IslandoraHooksTestCase extends IslandoraWebTestCase {
 
   /**
    * Gets info to display to describe this test.
    *
-   * @see IslandoraWebTestCase::getInfo()
+   * @see IslandoraWebTestCase.getInfo()
    */
   public static function getInfo() {
     return array(
@@ -29,7 +33,7 @@ class IslandoraHooksTestCase extends IslandoraWebTestCase {
   /**
    * Creates an admin user and a connection to a fedora repository.
    *
-   * @see IslandoraWebTestCase::setUp()
+   * @see IslandoraWebTestCase.setUp()
    */
   public function setUp() {
     parent::setUp('islandora_hooks_test');
@@ -40,7 +44,7 @@ class IslandoraHooksTestCase extends IslandoraWebTestCase {
   /**
    * Free any objects/resources created for this test.
    *
-   * @see IslandoraWebTestCase::tearDown()
+   * @see IslandoraWebTestCase.tearDown()
    */
   public function tearDown() {
     $this->purgeTestObjects();

--- a/tests/islandora_manage_permissions.test
+++ b/tests/islandora_manage_permissions.test
@@ -5,12 +5,16 @@
  * Tests islandora permissions, and permission related funcitons.
  */
 
+/**
+ * IslandoraPermissionsTestCase
+ * @islandora
+ */
 class IslandoraPermissionsTestCase extends IslandoraWebTestCase {
 
   /**
    * Gets info to display to describe this test.
    *
-   * @see IslandoraWebTestCase::getInfo()
+   * @see IslandoraWebTestCase.getInfo()
    */
   public static function getInfo() {
     return array(
@@ -23,7 +27,7 @@ class IslandoraPermissionsTestCase extends IslandoraWebTestCase {
   /**
    * Prepares enviroment for testing.
    *
-   * @see IslandoraWebTestCase::setUp()
+   * @see IslandoraWebTestCase.setUp()
    */
   public function setUp() {
     parent::setUp(array('islandora'));

--- a/tests/web_test_case.inc
+++ b/tests/web_test_case.inc
@@ -5,12 +5,16 @@
  * Defines the class IslandoraWebTestCase, which allows tests to access Fedora.
  */
 
+/**
+ * IslandoraWebTestCase
+ * @author discoverygarden
+ */
 class IslandoraWebTestCase extends DrupalWebTestCase {
 
   /**
    * Sets up the Drupal filter to access this test Drupal instances database.
    *
-   * @see DrupalWebTestCase::setUp()
+   * @see DrupalWebTestCase.setUp()
    */
   public function setUp() {
     $args = func_get_args();
@@ -116,7 +120,7 @@ class IslandoraWebTestCase extends DrupalWebTestCase {
   /**
    * Restores the original Drupal filter, frees any allocated resources.
    *
-   * @see DrupalWebTestCase::tearDown()
+   * @see DrupalWebTestCase.tearDown()
    */
   public function tearDown() {
     if ($this->configuration['use_drupal_filter']) {


### PR DESCRIPTION
Removed the majority of coding standards violations, however there remain some regarding the naming of one of our hooks (hook_CMODEL_PID_islandora_view_object()) using camel casing, and a potential problem with drupal_set_message(), suggesting the input text should be sanitized. However that cannot always work, and may not be the case. Committing pull request before continuing. 
