### PR TITLE
Added a convience function for generated depreciated function messages.

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -825,7 +825,7 @@ function islandora_content_model_select_table_form_element($drupal_variable, $de
  *
  * @code
  *   $message = islandora_deprecated('7.x-1.1', t('Use more cowbell.'));
- *   trigger_error($message, E_USER_DEPRECATED);
+ *   trigger_error(check_plain($message), E_USER_DEPRECATED);
  * @endcode
  *
  * @param string $release


### PR DESCRIPTION
The message will only be displayed to the user if Drupal is configured to show these
warnings, regardless of the setting though it will be logged to the watchdog.
