### PR TITLE
Fix step ordering

### DIFF
--- a/includes/ingest.form.inc
+++ b/includes/ingest.form.inc
@@ -78,6 +78,12 @@ function islandora_ingest_form_init_form_state_storage(array &$form_state, array
     if (empty($objects)) {
       $objects[] = islandora_ingest_form_prepare_new_object($configuration);
     }
+    // Make sure the models actually exist
+    foreach ($configuration['models'] as $key => $model) {
+      if (!islandora_object_load($model)) {
+        unset($configuration['models'][$key]);
+      }
+    }
     // No need to persist the 'objects' within the configuration.
     unset($configuration['objects']);
     // Required for step hooks.


### PR DESCRIPTION
Moving backwards though the form now brings the user to the expected step.

There was a mistake where a step was reverting its global changes before it was
actually selected as the previous step. Innocuous enough but it had strange
side effects on the global storage, since the step list would be rebuild with
this information, steps could insert themselves as previous steps even if they
weren't used by the user.
