### PR TITLE
Added new function islandora_copy_object() can copy existing/new fedora objects.

### DIFF
--- a/islandora.module
+++ b/islandora.module
@@ -979,30 +979,17 @@ function islandora_copy_object(AbstractObject $object) {
       $clone->$property = $object->$property;
     }
   }
-  $datastream_properties = array(
-    'label',
-    'versionable',
-    'state',
-    'mimetype',
-    'format',
-    'size',
-    'checksum',
-    'checksumType',
-    'createdDate',
-    'content',
-    'url',
-    'location',
-  );
   // Copy Datastreams.
   foreach ($object as $dsid => $datastream) {
     if (empty($clone[$dsid])) {
-      $ds = $clone->constructDatastream($dsid, $datastream->controlGroup);
-      $clone->ingestDatastream($ds);
+      $clone->ingestDatastream($datastream);
     }
-    foreach ($datastream_properties as $property) {
-      if (isset($object[$dsid]->$property)) {
-        $clone[$dsid]->$property = $object[$dsid]->$property;
-      }
+    else {
+      // Get the content into a file, and add the file.
+      $temp_file = drupal_tempnam('temporary://', 'datastream');
+      $datastream->getContent($temp_file);
+      $clone[$dsid]->setContentFromFile($temp_file);
+      drupal_unlink($temp_file);
     }
   }
   return $clone;


### PR DESCRIPTION
It's a bit leaky in that it makes assumptions about the members that will
exist on AbstractObjects, but we can't make cloning work at the moment as
it doesn't really work well with inheritance, every decendent would have to
define __clone functions properly and I figured a wrapper function like
this would be easier to support in the long term, until we make the
movement to decorated objects.
