### PR TITLE
cleanup, and additional function for binary tests

### DIFF
--- a/tests/islandora_web_test_case.inc
+++ b/tests/islandora_web_test_case.inc
@@ -182,7 +182,7 @@ class IslandoraWebTestCase extends DrupalWebTestCase {
    * @param string $button
    *   The label of the first 'Delete' button
    */
-  public function deleteObject($pid, $button='Delete') {
+  public function deleteObject($pid, $button = 'Delete') {
     $path = 'islandora/object/' . $pid . '/manage/properties';
     $edit = array();
     $this->drupalPost($path, $edit, $button);


### PR DESCRIPTION
In addition, I've removed the addition of a new user with different permissions being performed every time and created a new test in islandora_solution_pack_collection called islandora_basic_collection_usage_permissions.test; this test runs through each step of an object ingest and purge, creating a new user in each step. Segregating this test so that we only do it once should make the other tests run faster and cleaner. 
