### PR TITLE
7.x change /islandora menu item title to callback

### DIFF
--- a/includes/breadcrumb.inc
+++ b/includes/breadcrumb.inc
@@ -57,10 +57,17 @@ function islandora_get_breadcrumbs_recursive($pid, FedoraRepository $repository,
 
   $root = variable_get('islandora_repository_pid', 'islandora:root');
   if ($pid == $root) {
-    $item = menu_get_item('islandora');
+    $title = 'Islandora Repository';
+    $trail = menu_get_active_trail();
+    foreach ($trail as $key => $item) {
+      if ($item['link_path'] == 'islandora') {
+        $title = $item['link_title'];
+        break;
+      }
+    }
     return array(
       l(t('Home'), '<front>'),
-      l($item['title'], 'islandora'),
+      l($title, 'islandora'),
     );
   }
   else {

--- a/islandora.module
+++ b/islandora.module
@@ -88,7 +88,7 @@ function islandora_menu() {
     'type' => MENU_NORMAL_ITEM,
   );
   $items['islandora'] = array(
-    'title callback' => 'islandora_repository_root_label',
+    'title' => 'Islandora Repository',
     'page callback' => 'islandora_view_default_object',
     'type' => MENU_NORMAL_ITEM,
     'access arguments' => array(FEDORA_VIEW_OBJECTS),
@@ -1125,16 +1125,4 @@ function islandora_file_mimetype_mapping_alter(&$mapping) {
     end($mapping['mimetypes']);
     $mapping['extensions'][$ext] = key($mapping['mimetypes']);
   }
-}
-
-/**
- * A callback to get the root collection label.
- * @return text
- *   The object label of the root collection or the fallback.
- */
-function islandora_repository_root_label() {
-  $root = variable_get('islandora_repository_pid', 'islandora:root');
-  $object = islandora_object_load($root);
-  $label = ($object ? $object->label : 'Islandora Repository');
-  return $label;
 }


### PR DESCRIPTION
if menu_get_item() would return customizations (eg: title changed via gui), this change wouldn't be necessary. The breadcrumb AWLAYS display 'Islandora Repository' no matter what you change the menu link title to.  Maybe we should use menu_get_active_trail() instead of menu_get_item() here https://github.com/Islandora/islandora/blob/7.x/includes/breadcrumb.inc#L60
