### PR TITLE
Grab 5.9 version of drush for now.

### DIFF
--- a/tests/scripts/travis_setup.sh
+++ b/tests/scripts/travis_setup.sh
@@ -20,7 +20,7 @@ pear channel-discover pear.phpqatools.org
 pear channel-discover pear.netpirates.net
 pear install pear/PHP_CodeSniffer
 pear install pear.phpunit.de/phpcpd
-pear install drush/drush
+pear install drush/drush-5.9.0
 phpenv rehash
 drush dl --yes drupal
 cd drupal-*


### PR DESCRIPTION
Regression in drush lead to SimpleTest failure not triggering a drush error. Is an open issue and pull request on drush, for now we will use 5.9.
