### PR TITLE
Now supports the Tuque interface required for Fedora 4 development.

### DIFF
--- a/includes/breadcrumb.inc
+++ b/includes/breadcrumb.inc
@@ -50,7 +50,7 @@ function islandora_get_breadcrumbs($object) {
  * @return array
  *   An array of links representing the breadcrumb trail, "root" first.
  */
-function islandora_get_breadcrumbs_recursive($pid, FedoraRepository $repository, array &$context = NULL) {
+function islandora_get_breadcrumbs_recursive($pid, AbstractRepository $repository, array &$context = NULL) {
   // Before executing the query, we have a base case of accessing the top-level
   // collection.
   if ($context === NULL) {

--- a/includes/tuque.inc
+++ b/includes/tuque.inc
@@ -7,27 +7,9 @@
 
 $islandora_module_path = drupal_get_path('module', 'islandora');
 
+include_once 'sites/all/libraries/tuque/Bootstrap.php';
+
 // Do this until we expose these in a module or library.
-@include_once 'sites/all/libraries/tuque/Datastream.php';
-@include_once 'sites/all/libraries/tuque/FedoraApi.php';
-@include_once 'sites/all/libraries/tuque/FedoraApiSerializer.php';
-@include_once 'sites/all/libraries/tuque/Object.php';
-@include_once 'sites/all/libraries/tuque/RepositoryConnection.php';
-@include_once 'sites/all/libraries/tuque/Cache.php';
-@include_once 'sites/all/libraries/tuque/RepositoryException.php';
-@include_once 'sites/all/libraries/tuque/Repository.php';
-@include_once 'sites/all/libraries/tuque/FedoraRelationships.php';
-
-@include_once "$islandora_module_path/libraries/tuque/Datastream.php";
-@include_once "$islandora_module_path/libraries/tuque/FedoraApi.php";
-@include_once "$islandora_module_path/libraries/tuque/FedoraApiSerializer.php";
-@include_once "$islandora_module_path/libraries/tuque/Object.php";
-@include_once "$islandora_module_path/libraries/tuque/RepositoryConnection.php";
-@include_once "$islandora_module_path/libraries/tuque/Cache.php";
-@include_once "$islandora_module_path/libraries/tuque/RepositoryException.php";
-@include_once "$islandora_module_path/libraries/tuque/Repository.php";
-@include_once "$islandora_module_path/libraries/tuque/FedoraRelationships.php";
-
 class IslandoraTuque {
 
   /**
@@ -86,11 +68,12 @@ class IslandoraTuque {
 
     if (self::exists()) {
       module_load_include('inc', 'islandora', 'includes/tuque_wrapper');
-      $this->connection = new IslandoraRepositoryConnection($url, $user_string, $pass_string);
-      $this->connection->reuseConnection = TRUE;
-      $this->api = new IslandoraFedoraApi($this->connection);
-      $this->cache = new IslandoraSimpleCache();
-      $this->repository = new IslandoraFedoraRepository($this->api, $this->cache);
+      $config = new Tuque\RepositoryConfig($url, $user_string, $pass_string);
+      $this->repository = IslandoraFedoraRepository::fromConfig($config);
+      // @todo Eventualy remove these public properties.
+      $this->api = $this->repository->api;
+      $this->connection = $this->api->connection;
+      $this->cache = $config->getCache();
     }
   }
 
@@ -101,7 +84,7 @@ class IslandoraTuque {
    *   TRUE if the Connection class exists FALSE otherwise.
    */
   public static function exists() {
-    return class_exists('RepositoryConnection');
+    return class_exists('Tuque\Repository');
   }
 
   /**

--- a/includes/tuque_wrapper.inc
+++ b/includes/tuque_wrapper.inc
@@ -10,26 +10,7 @@
 
 $islandora_module_path = drupal_get_path('module', 'islandora');
 
-// @todo this until we expost these in a module or library
-@include_once 'sites/all/libraries/tuque/Datastream.php';
-@include_once 'sites/all/libraries/tuque/FedoraApi.php';
-@include_once 'sites/all/libraries/tuque/FedoraApiSerializer.php';
-@include_once 'sites/all/libraries/tuque/Object.php';
-@include_once 'sites/all/libraries/tuque/RepositoryConnection.php';
-@include_once 'sites/all/libraries/tuque/Cache.php';
-@include_once 'sites/all/libraries/tuque/RepositoryException.php';
-@include_once 'sites/all/libraries/tuque/Repository.php';
-@include_once 'sites/all/libraries/tuque/FedoraRelationships.php';
-
-@include_once "$islandora_module_path/libraries/tuque/Datastream.php";
-@include_once "$islandora_module_path/libraries/tuque/FedoraApi.php";
-@include_once "$islandora_module_path/libraries/tuque/FedoraApiSerializer.php";
-@include_once "$islandora_module_path/libraries/tuque/Object.php";
-@include_once "$islandora_module_path/libraries/tuque/RepositoryConnection.php";
-@include_once "$islandora_module_path/libraries/tuque/Cache.php";
-@include_once "$islandora_module_path/libraries/tuque/RepositoryException.php";
-@include_once "$islandora_module_path/libraries/tuque/Repository.php";
-@include_once "$islandora_module_path/libraries/tuque/FedoraRelationships.php";
+@include_once 'sites/all/libraries/tuque/Bootstrap.php';
 
 /**
  * Allow modules to alter an object before a mutable event occurs.
@@ -71,17 +52,41 @@ function islandora_invoke_datastream_hooks($hook, array $models, $dsid) {
   return islandora_invoke_hook_list($hook, $refinements, array_slice(func_get_args(), 3));
 }
 
-class IslandoraFedoraRepository extends FedoraRepository {
-  protected $queryClass = 'IslandoraRepositoryQuery';
-  protected $newObjectClass = 'IslandoraNewFedoraObject';
-  protected $objectClass = 'IslandoraFedoraObject';
+class IslandoraFedoraRepository extends Tuque\Repository {
+
+  /**
+   * The decorator class to wrap existing objects.
+   * @var string
+   */
+  protected $objectDecorator = 'IslandoraFedoraObject';
+  protected $newObjectDecorator = 'IslandoraNewFedoraObject';
+
+  /**
+   * Creates a repository from the given configuration.
+   */
+  public static function fromConfig(Tuque\RepositoryConfig $config) {
+    return new IslandoraFedoraRepository(Tuque\RepositoryFactory::getRepository($config));
+  }
+
+  /**
+   * Constructor for the Repository object.
+   *
+   * @param AbstractRepository $repository
+   *   The configuration setting that defines what kind of repository to
+   *   instantiate.
+   */
+  public function __construct(AbstractRepository $repository) {
+    parent::__construct($repository);
+    // @todo Get rid of this class at some point.
+    $this->api->m = new IslandoraFedoraApiM($this->api->m);
+  }
 
   /**
    * Ingest the given object.
    *
    * @see FedoraRepository::ingestObject()
    */
-  public function ingestObject(NewFedoraObject &$object) {
+  public function ingestObject(AbstractObject &$object) {
     try {
       foreach ($object as $dsid => $datastream) {
         $datastream_context = array(
@@ -91,11 +96,10 @@ class IslandoraFedoraRepository extends FedoraRepository {
         islandora_alter_datastream($object, $datastream, $datastream_context);
         if ($datastream_context['block']) {
           throw new Exception(t('Object ingest blocked due to ingest of @dsid being blocked.', array(
-            '@dsid' => $dsid,
-          )));
+                '@dsid' => $dsid,
+              )));
         }
       }
-
       $object_context = array(
         'action' => 'ingest',
         'block' => FALSE,
@@ -105,6 +109,7 @@ class IslandoraFedoraRepository extends FedoraRepository {
         throw new Exception('Ingest Object was blocked.');
       }
       $ret = parent::ingestObject($object);
+
       islandora_invoke_object_hooks(ISLANDORA_OBJECT_INGESTED_HOOK, $object->models, $object);
       // Call the ingested datastream hooks for NewFedoraObject's after the
       // object had been ingested.
@@ -123,18 +128,13 @@ class IslandoraFedoraRepository extends FedoraRepository {
   }
 }
 
-class IslandoraRepositoryQuery extends RepositoryQuery {}
+class IslandoraFedoraObject extends Tuque\Object {
 
-class IslandoraNewFedoraObject extends NewFedoraObject {
-  protected $newFedoraDatastreamClass = 'IslandoraNewFedoraDatastream';
-  protected $fedoraDatastreamClass = 'IslandoraFedoraDatastream';
-  protected $fedoraRelsExtClass = 'IslandoraFedoraRelsExt';
-}
-
-class IslandoraFedoraObject extends FedoraObject {
-  protected $newFedoraDatastreamClass = 'IslandoraNewFedoraDatastream';
-  protected $fedoraDatastreamClass = 'IslandoraFedoraDatastream';
-  protected $fedoraRelsExtClass = 'IslandoraFedoraRelsExt';
+  /**
+   * The decorator class to wrap the repository reference.
+   * @var string
+   */
+  protected $repositoryDecorator = 'IslandoraFedoraRepository';
 
   /**
    * Ingest the given datastream.
@@ -165,28 +165,37 @@ class IslandoraFedoraObject extends FedoraObject {
       throw $e;
     }
   }
-}
-
-class IslandoraRepositoryConnection extends RepositoryConnection {}
-
-class IslandoraFedoraApi extends FedoraApi {
 
   /**
-   * Instantiate a IslandoraFedoraApi object.
-   *
-   * @see FedoraApi::__construct()
+   * Get the string repersentation of this object.
    */
-  public function __construct(IslandoraRepositoryConnection $connection, FedoraApiSerializer $serializer = NULL) {
-    if (!$serializer) {
-      $serializer = new FedoraApiSerializer();
-    }
-    $this->a = new FedoraApiA($connection, $serializer);
-    $this->m = new IslandoraFedoraApiM($connection, $serializer);
-    $this->connection = $connection;
+  public function __tostring() {
+    return $this->id;
   }
+
 }
 
-class IslandoraFedoraApiM extends FedoraApiM {
+class IslandoraNewFedoraObject extends Tuque\NewObject {
+
+  /**
+   * The decorator class to wrap the repository reference.
+   * @var string
+   */
+  protected $repositoryDecorator = 'IslandoraFedoraRepository';
+
+  /**
+   * Get the string repersentation of this object.
+   */
+  public function __tostring() {
+    return $this->id;
+  }
+
+}
+
+/**
+ * @todo Find a way to use this without referencing the implementation class.
+ */
+class IslandoraFedoraApiM extends Tuque\Delegate {
 
   /**
    * Update a datastream.
@@ -351,24 +360,3 @@ class IslandoraFedoraApiM extends FedoraApiM {
   }
 
 }
-
-class IslandoraSimpleCache extends SimpleCache {}
-
-class IslandoraNewFedoraDatastream extends NewFedoraDatastream {
-  protected $fedoraRelsIntClass = 'IslandoraFedoraRelsInt';
-  protected $fedoraDatastreamVersionClass = 'IslandoraFedoraDatastreamVersion';
-}
-
-class IslandoraFedoraDatastream extends FedoraDatastream {
-  protected $fedoraRelsIntClass = 'IslandoraFedoraRelsInt';
-  protected $fedoraDatastreamVersionClass = 'IslandoraFedoraDatastreamVersion';
-}
-
-class IslandoraFedoraDatastreamVersion extends FedoraDatastreamVersion {
-  protected $fedoraRelsIntClass = 'IslandoraFedoraRelsInt';
-  protected $fedoraDatastreamVersionClass = 'IslandoraFedoraDatastreamVersion';
-}
-
-class IslandoraFedoraRelsExt extends FedoraRelsExt {}
-
-class IslandoraFedoraRelsInt extends FedoraRelsInt {}

--- a/islandora.info
+++ b/islandora.info
@@ -18,6 +18,7 @@ files[] = tests/authtokens.test
 files[] = tests/hooks.test
 files[] = tests/ingest.test
 files[] = tests/hooked_access.test
+files[] = tests/tuque_wrapper.test
 files[] = tests/islandora_manage_permissions.test
 files[] = tests/datastream_versions.test
 files[] = tests/datastream_cache.test

--- a/tests/derivatives.test
+++ b/tests/derivatives.test
@@ -37,12 +37,7 @@ class IslandoraDerivativesTestCase extends IslandoraWebTestCase {
         'islandora_derivatives_test',
       )
     );
-    $url = variable_get('islandora_base_url', 'http://localhost:8080/fedora');
-    $this->connection = new RepositoryConnection($url, $this->admin->name, $this->admin->pass);
-    $this->connection->reuseConnection = TRUE;
-    $this->api = new FedoraApi($this->connection);
-    $this->cache = new SimpleCache();
-    $this->repository = new FedoraRepository($this->api, $this->cache);
+    $this->repository = $this->admin->repository->getDelegate();
     $this->pid = $this->randomName() . ":" . $this->randomName();
   }
 
@@ -52,7 +47,6 @@ class IslandoraDerivativesTestCase extends IslandoraWebTestCase {
    * @see IslandoraWebTestCase::tearDown()
    */
   public function tearDown() {
-    $tuque = islandora_get_tuque_connection();
     parent::tearDown();
   }
 

--- a/tests/scripts/travis_setup.sh
+++ b/tests/scripts/travis_setup.sh
@@ -5,7 +5,7 @@ mysql -u root -e "create database fedora;"
 mysql -u root -e "GRANT ALL PRIVILEGES ON fedora.* To 'fedora'@'localhost' IDENTIFIED BY 'fedora';"
 mysql -u root -e "GRANT ALL PRIVILEGES ON drupal.* To 'drupal'@'localhost' IDENTIFIED BY 'drupal';"
 cd $HOME
-git clone git://github.com/Islandora/tuque.git
+git clone -b 1.x-futures-rebase git://github.com/nigelgbanks/tuque.git
 git clone -b $FEDORA_VERSION git://github.com/Islandora/islandora_tomcat.git
 cd islandora_tomcat
 export CATALINA_HOME='.'

--- a/tests/tuque_wrapper.test
+++ b/tests/tuque_wrapper.test
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * @file
+ * Test Authentication Tokens.
+ */
+
+class IslandoraTuqueWrapperTestCase extends IslandoraWebTestCase {
+
+  /**
+   * Get test information for display.
+   */
+  public static function getInfo() {
+    return array(
+      'name' => 'Islandora Tuque Wrapper',
+      'description' => 'Ensure that the Tuque Wrapper functions correctly.',
+      'group' => 'Islandora',
+    );
+  }
+
+  /**
+   * Set up data for the tests.
+   */
+  public function setUp() {
+    parent::setUp();
+    $this->repository = $this->admin->repository;
+    $this->purgeTestObjects();
+  }
+
+
+  /**
+   * Free any objects/resources created for this test.
+   *
+   * @see IslandoraWebTestCase::tearDown()
+   */
+  public function tearDown() {
+    $this->purgeTestObjects();
+    parent::tearDown();
+  }
+
+  /**
+   * Purge any objects created by the test's in this class.
+   */
+  public function purgeTestObjects() {
+    $objects = array(
+      'test:test',
+    );
+    foreach ($objects as $object) {
+      try {
+        $object = $this->repository->getObject($object);
+        $this->repository->purgeObject($object->id);
+      }
+      catch (Exception $e) {
+        // Meh... Either it didn't exist or the purge failed.
+      }
+    }
+  }
+
+  /**
+   * Test the wrapper wraps the classes correctly.
+   */
+  public function testWrapper() {
+    global $user;
+    $url = variable_get('islandora_base_url', $this->configuration['fedora_url']);
+    $connection = islandora_get_tuque_connection($user, $url);
+    $this->assertTrue($connection instanceOf IslandoraTuque);
+    $this->assertTrue($connection->repository instanceOf IslandoraFedoraRepository);
+    $this->assertTrue($connection->repository->api->m instanceOf IslandoraFedoraApiM);
+    $repository = $connection->repository;
+    $object = $repository->constructObject('test:test');
+    $this->assertTrue($object instanceOf Tuque\NewObject);
+    $repository->ingestObject($object);
+    $this->assertTrue($object instanceOf IslandoraFedoraObject);
+    $object = $repository->getObject('test:test');
+    $this->assertTrue($object instanceOf IslandoraFedoraObject);
+    $datastream = $object->constructDatastream('test');
+    $this->assertTrue($datastream instanceOf Tuque\NewDatastream);
+    $object->ingestDatastream($datastream);
+    $this->assertTrue($datastream instanceOf Tuque\Datastream);
+  }
+
+}


### PR DESCRIPTION
Changes have been localized to the tuque wrapper objects which now
extend wrapper objects that tuque provides for each version of fedora.

All of these pull request should be merged at once:
https://github.com/Islandora/tuque/pull/77
https://github.com/Islandora/islandora/pull/426
https://github.com/Islandora/islandora_paged_content/pull/37
