### PR TITLE
Can now uninstall islandora and dependant solution packs.

### DIFF
--- a/includes/solution_packs.inc
+++ b/includes/solution_packs.inc
@@ -28,7 +28,16 @@ function islandora_solution_packs_get_required_objects($module = NULL) {
 
   if (!$required_objects) {
     $connection = islandora_get_tuque_connection();
-    $required_objects = module_invoke_all('islandora_required_objects', $connection);
+    if (isset($module)) {
+      // The module may be disabled when this function runs, as modules must be
+      // disabled before they can be uninstalled. We must manually load the
+      // module file to use it's islandora_required_objects hook.
+      module_load_include('module', $module, $module);
+      $required_objects = module_invoke($module, 'islandora_required_objects', $connection);
+    }
+    else {
+      $required_objects = module_invoke_all('islandora_required_objects', $connection);
+    }
   }
 
   if ($module !== NULL) {

--- a/includes/tuque.inc
+++ b/includes/tuque.inc
@@ -85,6 +85,7 @@ class IslandoraTuque {
     }
 
     if (self::exists()) {
+      module_load_include('inc', 'islandora', 'includes/tuque_wrapper');
       $this->connection = new IslandoraRepositoryConnection($url, $user_string, $pass_string);
       $this->connection->reuseConnection = TRUE;
       $this->api = new IslandoraFedoraApi($this->connection);

--- a/islandora.module
+++ b/islandora.module
@@ -1113,6 +1113,7 @@ function islandora_default_islandora_printer_object($object, $alter) {
  *   A IslandoraTuque instance
  */
 function islandora_get_tuque_connection($user = NULL, $url = NULL) {
+  module_load_include('inc', 'islandora', 'includes/tuque');
   $tuque = &drupal_static(__FUNCTION__);
   if (!$tuque) {
     if (IslandoraTuque::exists()) {


### PR DESCRIPTION
Drupal requires modules to be disabled before uninstalling. Thus classes Drupal
would otherwise autoload when needed are no longer present in the registry
during the uninstall hook. Also the required hook for uninstalling
**islandora_required_objects** is not availible.

Now required classes for uninstalling are manually loaded, and the module file
which contains the **islandora_required_objects** hook is manually loaded as
well.

No changes are required on behalf of solution pack modules.
