### PR TITLE
7.x automatic deletion of test objects, assertDatastreams return values.

### DIFF
--- a/tests/islandora_web_test_case.inc
+++ b/tests/islandora_web_test_case.inc
@@ -190,14 +190,14 @@ class IslandoraWebTestCase extends DrupalWebTestCase {
       $this->fail("Failed. Object passed in is invalid.", 'Islandora');
     }
     else {
-      $missing_datastreams = array_diff($datastreams, array_keys($this->admin->repository->api->a->listDatastreams($object->id)));
+      $missing_datastreams = array_diff_key(array_flip($datastreams), $this->admin->repository->api->a->listDatastreams($object->id));
 
       if (!empty($missing_datastreams)) {
-        $this->fail("Failed to find datastreams " . implode(', ', $missing_datastreams) . " in object {$object->id}.");
+        $this->fail("Failed to find datastream(s) " . implode(', ', array_flip($missing_datastreams)) . " in object {$object->id}.");
         return FALSE;
       }
 
-      $this->pass("Found all required datastreams in object {$object->id}");
+      $this->pass("Found required datastream(s) in object {$object->id}");
       return TRUE;
     }
   }


### PR DESCRIPTION
Two things in this update to the IslandoraWebTestCase:
- Most importantly, there's now a function to delete all objects created by a user. Plus, when you create a user for simpletest's internal browser using $this->createUser(), that user is automatically added to a list of test users whose objects will automatically be purged at the end of the test.
- Secondly, assertDatastreams() now returns TRUE if all datastreams were present, or FALSE if one or more were missing.
