### PR TITLE
Windows-compatibility: New function for OS detection

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -981,3 +981,17 @@ function islandora_scale_thumbnail($file, $width, $height) {
   }
   return FALSE;
 }
+
+/**
+ * Determines if the server operating system is Windows.
+ *
+ * @return bool
+ *   TRUE if Windows, FALSE otherwise.
+ */
+function islandora_deployed_on_windows() {
+  // Determine if PHP is currently running on Windows.
+  if (strpos(strtolower(php_uname('s')), 'windows') !== FALSE) {
+    return TRUE;
+  }
+  return FALSE;
+}

--- a/islandora.module
+++ b/islandora.module
@@ -1865,17 +1865,3 @@ function islandora_islandora_datastream_access($op, AbstractDatastream $datastre
   }
   return $result;
 }
-
-/**
- * Determines the server's operating system.
- *
- * @return string
- *   The name of the operating system being used.
- */
-function islandora_os_check() {
-  // Determine if PHP is currently running on Windows.
-  if (strpos(strtolower(php_uname('s')), 'windows') !== FALSE) {
-    return 'Windows';
-  }
-  return 'Linux';
-}


### PR DESCRIPTION
Some Windows-incompatibilities have crept into the Islandora codebase ([additional background can be found here](https://groups.google.com/d/msg/islandora/0MAhLDjbago/9knbOynlyIcJ)).

This patch introduces a new function -- one that identifies the server's operating system. Several other [patched] modules will make use of this function, including:
-  [Compound Solution Pack](https://github.com/Islandora/islandora_solution_pack_compound/pull/29)
-  [Large Image Solution Pack](https://github.com/Islandora/islandora_solution_pack_large_image/pull/87)
-  [FITS Extractor](https://github.com/Islandora/islandora_fits/pull/29)
-  [Islandora OCR](https://github.com/Islandora/islandora_ocr/pull/32)
-  [Islandora Paged Content](https://github.com/Islandora/islandora_paged_content/pull/42)

_NOTE:_ This pull request replaces PR https://github.com/Islandora/islandora/pull/441, which became severely messed up.
