### PR TITLE
Grab Drush from git.

### DIFF
--- a/tests/scripts/travis_setup.sh
+++ b/tests/scripts/travis_setup.sh
@@ -27,8 +27,8 @@ git clone https://github.com/drush-ops/drush.git
 pushd drush
 git checkout 5.9.0
 chmod +x drush
-ln -s $HOME/drush/drush /usr/local/sbin
 popd
+sudo ln -s $HOME/drush/drush /usr/local/sbin
 
 phpenv rehash
 drush dl --yes drupal


### PR DESCRIPTION
Our patch for simple test stuff still isn't into Drush 6 (it is in 7, though there's no 7 release)...  Can go do something more like https://github.com/Islandora/islandora/pull/458 after https://github.com/drush-ops/drush/pull/458 gets merged and into a 6 release.
