### PR TITLE
Check for hostname

### DIFF
--- a/islandora.module
+++ b/islandora.module
@@ -1541,7 +1541,7 @@ function islandora_entity_property_info() {
 function islandora_download_clip(AbstractObject $object) {
   if (isset($_GET['clip'])) {
     $url = $_GET['clip'];
-    if (!preg_match('/^https?:\/\//',$url)) {
+    if (!preg_match('/^https?:\/\//', $url)) {
       $is_https = isset($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) == 'on';
       $http_protocol = $is_https ? 'https' : 'http';
       $url = $http_protocol . '://' . $_SERVER['HTTP_HOST'] . $url;


### PR DESCRIPTION
You can enter the Djatoka URL as a relative path or full hostname. I did hostname and didn't get any errors. But this function assumes it is a path and sticks http(s)://<SERVER NAME> in front which causes you to get a blank Jpeg when downloading the clip.
