### PR TITLE
handling NULL source_dsids in datastream_access hook

### DIFF
--- a/islandora.module
+++ b/islandora.module
@@ -1853,7 +1853,8 @@ function islandora_islandora_datastream_access($op, AbstractDatastream $datastre
     $hooks = islandora_invoke_hook_list(ISLANDORA_DERVIATIVE_CREATION_HOOK, $object->models, array($object));
     $hooks = islandora_filter_derivatives($hooks, array('force' => TRUE), $object);
     foreach ($hooks as $hook) {
-      if ($hook['destination_dsid'] == $datastream->id && islandora_datastream_access(ISLANDORA_VIEW_OBJECTS, $object[$hook['source_dsid']], $user)) {
+      if ($hook['destination_dsid'] == $datastream->id &&
+        (is_null($hook['source_dsid']) || islandora_datastream_access(ISLANDORA_VIEW_OBJECTS, $object[$hook['source_dsid']], $user))) {
         $applicable_hook = TRUE;
         break;
       }


### PR DESCRIPTION
This commit will be coming shortly*TM to 7.x in another request.
