### PR TITLE
Don't need to check for properly-formed XML when just getting the diff

### DIFF
--- a/includes/solution_packs.inc
+++ b/includes/solution_packs.inc
@@ -582,11 +582,11 @@ function islandora_check_object_status(AbstractObject $object_definition) {
       $xslt->importStyleSheet($xsl);
       $object_definition_dom = new DOMDocument();
       $object_definition_dom->preserveWhiteSpace = FALSE;
-      $object_definition_dom->loadXML(str_replace('info:', 'http://', $ds->content));
+      $object_definition_dom->loadXML(str_replace('info:', 'http://', $ds->content), LIBXML_NOWARNING);
       $object_definition_dom = $xslt->transformToDoc($object_definition_dom);
       $object_actual_dom = new DOMDocument();
       $object_actual_dom->preserveWhiteSpace = FALSE;
-      $object_actual_dom->loadXML(str_replace('info:', 'http://', $existing_object[$ds->id]->content));
+      $object_actual_dom->loadXML(str_replace('info:', 'http://', $existing_object[$ds->id]->content), LIBXML_NOWARNING);
       $object_actual_dom = $xslt->transformToDoc($object_actual_dom);
 
       // Fedora changes the xml structure so we need to cannonize it.


### PR DESCRIPTION
https://jira.duraspace.org/browse/ISLANDORA-1461

Check the description there for details, but the core of it is that we shouldn't be checking that the XML is well-formed when Solution packs required objects is just getting the diff to see if the datastream has changed. It's not the job of that page to validate XML; XML should be validated when it is going to be used.