### PR TITLE
ISLANDORA-1522 global UUID setting enforcement

### DIFF
--- a/includes/tuque_wrapper.inc
+++ b/includes/tuque_wrapper.inc
@@ -128,13 +128,13 @@ class IslandoraFedoraRepository extends FedoraRepository {
 
   /**
    * Constructs a Fedora Object.
+   *
    * @see FedoraRepository::constructObject
    */
   public function constructObject($id = NULL, $create_uuid = NULL) {
-    // Enforces uuid when set, but allows to override if called
+    // Enforces UUID when set, but allows to override if called
     // with $create_uuid set to bool.
-    $create_uuid = is_null($create_uuid) ? variable_get('islandora_basic_collection_generate_uuid', FALSE) : $create_uuid;
-    return parent::constructObject($id, $create_uuid);
+    return parent::constructObject($id, static::useUUIDs($create_uuid));
   }
 
   /**
@@ -143,10 +143,26 @@ class IslandoraFedoraRepository extends FedoraRepository {
    * @see FedoraRepository::getNextIdentifier()
    */
   public function getNextIdentifier($namespace = NULL, $create_uuid = NULL, $count = 1) {
-    // Enforces uuid when set, but allows to override if called
+    // Enforces UUID when set, but allows to override if called
     // with $create_uuid set to bool.
-    $create_uuid = is_null($create_uuid) ? variable_get('islandora_basic_collection_generate_uuid', FALSE) : $create_uuid;
-    return parent::getNextIdentifier($namespace, $create_uuid, $count);
+    return parent::getNextIdentifier($namespace, static::useUUIDs($create_uuid), $count);
+  }
+
+  /**
+   * Helper for three-valued logic with UUIDs.
+   *
+   * @param bool|NULL $to_create
+   *   The variable to test.
+   *
+   * @return bool
+   *   If $to_create is NULL, the value of the
+   *   'islandora_basic_collection_generate_uuid' Drupal variable; otherwise,
+   *   the value of $to_create itself.
+   */
+  protected static function useUUIDs($to_create) {
+    return is_null($to_create) ?
+      variable_get('islandora_basic_collection_generate_uuid', FALSE) :
+      $to_create;
   }
 }
 

--- a/includes/tuque_wrapper.inc
+++ b/includes/tuque_wrapper.inc
@@ -125,6 +125,29 @@ class IslandoraFedoraRepository extends FedoraRepository {
       throw $e;
     }
   }
+
+  /**
+   * Constructs a Fedora Object.
+   * @see FedoraRepository::constructObject
+   */
+  public function constructObject($id = NULL, $create_uuid = NULL) {
+    // Enforces uuid when set, but allows to override if called
+    // with $create_uuid set to bool.
+    $create_uuid = is_null($create_uuid) ? variable_get('islandora_basic_collection_generate_uuid', FALSE) : $create_uuid;
+    return parent::constructObject($id, $create_uuid);
+  }
+
+  /**
+   * Get the next PID(s) from Repo.
+   *
+   * @see FedoraRepository::getNextIdentifier()
+   */
+  public function getNextIdentifier($namespace = NULL, $create_uuid = NULL, $count = 1) {
+    // Enforces uuid when set, but allows to override if called
+    // with $create_uuid set to bool.
+    $create_uuid = is_null($create_uuid) ? variable_get('islandora_basic_collection_generate_uuid', FALSE) : $create_uuid;
+    return parent::getNextIdentifier($namespace, $create_uuid, $count);
+  }
 }
 
 class IslandoraRepositoryQuery extends RepositoryQuery {}


### PR DESCRIPTION
Addresses https://jira.duraspace.org/browse/ISLANDORA-1522

Added local methods(override) to handle global UUID settings. Changed
default valued for $create_uuid to NULL to allow developers to override
the global setting if needed.

This pull is part of a series of other pulls to make this change apply
to other modules

Depends on https://github.com/Islandora/tuque/pull/128 for "good coding practices"