### PR TITLE
ISLANDORA-1547

### DIFF
--- a/includes/datastream.inc
+++ b/includes/datastream.inc
@@ -295,6 +295,12 @@ function islandora_datastream_get_url(AbstractDatastream $datastream, $type = 'd
  */
 function islandora_edit_datastream(AbstractDatastream $datastream) {
   $edit_registry = module_invoke_all('islandora_edit_datastream_registry', $datastream->parent, $datastream);
+  $context = array(
+    'datastream_parent' => $datastream->parent,
+    'datastream' => $datastream,
+    'original_edit_registry' => $edit_registry,
+  );
+  drupal_alter(ISLANDORA_EDIT_DATASTREAM_MODIFY_REGISTRY_HOOK, $edit_registry, $context);
   $edit_count = count($edit_registry);
   switch ($edit_count) {
     case 0:
@@ -305,7 +311,8 @@ function islandora_edit_datastream(AbstractDatastream $datastream) {
 
     case 1:
       // One registry implementation, go there.
-      drupal_goto($edit_registry[0]['url']);
+      $edit_registry = reset($edit_registry);
+      drupal_goto($edit_registry['url']);
       break;
 
     default:

--- a/includes/datastream.inc
+++ b/includes/datastream.inc
@@ -296,7 +296,7 @@ function islandora_datastream_get_url(AbstractDatastream $datastream, $type = 'd
 function islandora_edit_datastream(AbstractDatastream $datastream) {
   module_load_include('inc', 'islandora', 'includes/utilities');
 
-  $edit_registry = islandora_build_datastream_edit_registry($datastream->parent, $datastream);
+  $edit_registry = islandora_build_datastream_edit_registry($datastream);
   $edit_count = count($edit_registry);
   switch ($edit_count) {
     case 0:

--- a/includes/datastream.inc
+++ b/includes/datastream.inc
@@ -307,8 +307,8 @@ function islandora_edit_datastream(AbstractDatastream $datastream) {
 
     case 1:
       // One registry implementation, go there.
-      $edit_registry = reset($edit_registry);
-      drupal_goto($edit_registry['url']);
+      $entry = reset($edit_registry);
+      drupal_goto($entry['url']);
       break;
 
     default:

--- a/includes/datastream.inc
+++ b/includes/datastream.inc
@@ -294,13 +294,9 @@ function islandora_datastream_get_url(AbstractDatastream $datastream, $type = 'd
  *   The datastream to edit.
  */
 function islandora_edit_datastream(AbstractDatastream $datastream) {
-  $edit_registry = module_invoke_all('islandora_edit_datastream_registry', $datastream->parent, $datastream);
-  $context = array(
-    'datastream_parent' => $datastream->parent,
-    'datastream' => $datastream,
-    'original_edit_registry' => $edit_registry,
-  );
-  drupal_alter(ISLANDORA_EDIT_DATASTREAM_MODIFY_REGISTRY_HOOK, $edit_registry, $context);
+  module_load_include('inc', 'islandora', 'includes/utilities');
+
+  $edit_registry = islandora_build_datastream_edit_registry($datastream->parent, $datastream);
   $edit_count = count($edit_registry);
   switch ($edit_count) {
     case 0:

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -946,3 +946,25 @@ function islandora_deployed_on_windows() {
   }
   return FALSE;
 }
+
+/**
+ * Build the edit registry for a given datastream.
+ *
+ * @param AbstractObject $object
+ *   The object being edited.
+ * @param AbstractDatastream $datastream
+ *   The datastream being edited.
+ *
+ * @return array
+ *   The built edit registry array.
+ */
+function islandora_build_datastream_edit_registry($object, $datastream) {
+  $edit_registry = module_invoke_all('islandora_edit_datastream_registry', $object, $datastream);
+  $context = array(
+    'object' => $object,
+    'datastream' => $datastream,
+    'original_edit_registry' => $edit_registry,
+  );
+  drupal_alter(ISLANDORA_EDIT_DATASTREAM_MODIFY_REGISTRY_HOOK, $edit_registry, $context);
+  return $edit_registry;
+}

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -950,18 +950,16 @@ function islandora_deployed_on_windows() {
 /**
  * Build the edit registry for a given datastream.
  *
- * @param AbstractObject $object
- *   The object being edited.
  * @param AbstractDatastream $datastream
  *   The datastream being edited.
  *
  * @return array
  *   The built edit registry array.
  */
-function islandora_build_datastream_edit_registry($object, $datastream) {
-  $edit_registry = module_invoke_all(ISLANDORA_EDIT_DATASTREAM_REGISTRY_HOOK, $object, $datastream);
+function islandora_build_datastream_edit_registry(AbstractDatastream $datastream) {
+  $edit_registry = module_invoke_all(ISLANDORA_EDIT_DATASTREAM_REGISTRY_HOOK, $datastream->parent, $datastream);
   $context = array(
-    'object' => $object,
+    'object' => $datastream->parent,
     'datastream' => $datastream,
     'original_edit_registry' => $edit_registry,
   );

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -959,12 +959,12 @@ function islandora_deployed_on_windows() {
  *   The built edit registry array.
  */
 function islandora_build_datastream_edit_registry($object, $datastream) {
-  $edit_registry = module_invoke_all('islandora_edit_datastream_registry', $object, $datastream);
+  $edit_registry = module_invoke_all(ISLANDORA_EDIT_DATASTREAM_REGISTRY_HOOK, $object, $datastream);
   $context = array(
     'object' => $object,
     'datastream' => $datastream,
     'original_edit_registry' => $edit_registry,
   );
-  drupal_alter(ISLANDORA_EDIT_DATASTREAM_MODIFY_REGISTRY_HOOK, $edit_registry, $context);
+  drupal_alter(ISLANDORA_EDIT_DATASTREAM_REGISTRY_HOOK, $edit_registry, $context);
   return $edit_registry;
 }

--- a/islandora.api.php
+++ b/islandora.api.php
@@ -849,3 +849,28 @@ function hook_islandora_get_breadcrumb_query_predicates() {
     'someotherpredicate',
   );
 }
+
+/**
+ * Use alter hook to modify registry paths before the paths are rendered.
+ *
+ * @param array $edit_registry
+ *   The array of registry paths.
+ * @param array $context
+ *   An associative array containing:
+ *   - datastream_parent: The datastream parent.
+ *   - datastream: The datastream being edited.
+ *   - original_edit_registry: The original edit_registry prior to any
+ *     modifications.
+ */
+function hook_islandora_edit_datastream_modify_registry_alter(&$edit_registry, $context) {
+  // Example: Remove xml form builder edit registry.
+  if (isset($edit_registry['xml_form_builder_edit_form_registry'])) {
+    unset($edit_registry['xml_form_builder_edit_form_registry']);
+  }
+  // Add custom form to replace the removed form builder edit_form.
+  $edit_registry['somemodule_custom_form'] =  array(
+    'name' => t('Somemodule Custom Form'),
+    'url' => "islandora/custom_form/{$context['datastream_parent']->id}/{$context['datastream']->id}",
+    'weight' => 1,
+  );
+}

--- a/islandora.api.php
+++ b/islandora.api.php
@@ -870,7 +870,7 @@ function hook_islandora_edit_datastream_modify_registry_alter(&$edit_registry, $
   // Add custom form to replace the removed form builder edit_form.
   $edit_registry['somemodule_custom_form'] =  array(
     'name' => t('Somemodule Custom Form'),
-    'url' => "islandora/custom_form/{$context['datastream_parent']->id}/{$context['datastream']->id}",
+    'url' => "islandora/custom_form/{$context['object']->id}/{$context['datastream']->id}",
     'weight' => 1,
   );
 }

--- a/islandora.api.php
+++ b/islandora.api.php
@@ -857,12 +857,12 @@ function hook_islandora_get_breadcrumb_query_predicates() {
  *   The array of registry paths.
  * @param array $context
  *   An associative array containing:
- *   - datastream_parent: The datastream parent.
+ *   - object: The object that owns the datastream being edited.
  *   - datastream: The datastream being edited.
  *   - original_edit_registry: The original edit_registry prior to any
  *     modifications.
  */
-function hook_islandora_edit_datastream_modify_registry_alter(&$edit_registry, $context) {
+function hook_islandora_edit_datastream_registry_alter(&$edit_registry, $context) {
   // Example: Remove xml form builder edit registry.
   if (isset($edit_registry['xml_form_builder_edit_form_registry'])) {
     unset($edit_registry['xml_form_builder_edit_form_registry']);
@@ -870,7 +870,6 @@ function hook_islandora_edit_datastream_modify_registry_alter(&$edit_registry, $
   // Add custom form to replace the removed form builder edit_form.
   $edit_registry['somemodule_custom_form'] =  array(
     'name' => t('Somemodule Custom Form'),
-    'url' => "islandora/custom_form/{$context['object']->id}/{$context['datastream']->id}",
-    'weight' => 1,
+    'url' => "islandora/custom_form/{$context['object']->id}/{$context['datastream']->id}"
   );
 }

--- a/islandora.module
+++ b/islandora.module
@@ -52,6 +52,7 @@ define('ISLANDORA_UPDATE_RELATED_OBJECTS_PROPERTIES_HOOK', 'islandora_update_rel
 define('ISLANDORA_METADATA_OBJECT_ALTER', 'islandora_metadata_object');
 define('ISLANDORA_METADATA_OBJECT_DESCRIPTION_ALTER', 'islandora_metadata_object_description');
 define('ISLANDORA_BREADCRUMB_FILTER_PREDICATE_HOOK', 'islandora_get_breadcrumb_query_predicates');
+define('ISLANDORA_EDIT_DATASTREAM_MODIFY_REGISTRY_HOOK', 'islandora_edit_datastream_modify_registry');
 
 // @todo Add Documentation.
 define('ISLANDORA_OBJECT_INGESTED_HOOK', 'islandora_object_ingested');

--- a/islandora.module
+++ b/islandora.module
@@ -52,7 +52,7 @@ define('ISLANDORA_UPDATE_RELATED_OBJECTS_PROPERTIES_HOOK', 'islandora_update_rel
 define('ISLANDORA_METADATA_OBJECT_ALTER', 'islandora_metadata_object');
 define('ISLANDORA_METADATA_OBJECT_DESCRIPTION_ALTER', 'islandora_metadata_object_description');
 define('ISLANDORA_BREADCRUMB_FILTER_PREDICATE_HOOK', 'islandora_get_breadcrumb_query_predicates');
-define('ISLANDORA_EDIT_DATASTREAM_MODIFY_REGISTRY_HOOK', 'islandora_edit_datastream_modify_registry');
+define('ISLANDORA_EDIT_DATASTREAM_REGISTRY_HOOK', 'islandora_edit_datastream_registry');
 
 // @todo Add Documentation.
 define('ISLANDORA_OBJECT_INGESTED_HOOK', 'islandora_object_ingested');

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -533,8 +533,9 @@ function theme_islandora_datastream_revert_link(array $vars) {
  */
 function theme_islandora_datastream_edit_link(array $vars) {
   $datastream = $vars['datastream'];
+  module_load_include('inc', 'islandora', 'includes/utilities');
 
-  $edit_registry = module_invoke_all('islandora_edit_datastream_registry', $datastream->parent, $datastream);
+  $edit_registry = islandora_build_datastream_edit_registry($datastream->parent, $datastream);
 
   $can_edit = count($edit_registry) > 0 && islandora_datastream_access(ISLANDORA_METADATA_EDIT, $datastream);
 

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -535,7 +535,7 @@ function theme_islandora_datastream_edit_link(array $vars) {
   $datastream = $vars['datastream'];
   module_load_include('inc', 'islandora', 'includes/utilities');
 
-  $edit_registry = islandora_build_datastream_edit_registry($datastream->parent, $datastream);
+  $edit_registry = islandora_build_datastream_edit_registry($datastream);
 
   $can_edit = count($edit_registry) > 0 && islandora_datastream_access(ISLANDORA_METADATA_EDIT, $datastream);
 


### PR DESCRIPTION
**Jira:** https://jira.duraspace.org/browse/ISLANDORA-1547

# What does this Pull Request do?
Adds a drupal_alter to allow for modification to the datastream edit registry.

# How should this be tested?
Pull down the pull both the islandora (core) pull request and the islandora_xml_forms pull request.

Test 1: Confirming the addition of an custom index value does not impact form loading.
Edit an existing object's datastream the process should function the same as before the pull and load
the registry item built in xml_form_builder_islandora_edit_datastream_registry. 

Test 2: Testing the drupal_alter.
Have a module implement hook_islandora_edit_datastream_modify_registry_alter() and test making changes to the edit_registry.

  1) Adding an edition registry item - this should load the default switch logic so that multiple routes are rendered.

  2) Removing unset the $edit_registry - this should trigger switch case 0 and return the user to the manage datastream page with a drupal message "There are no edit methods specified for this datastream."

  3) Assuming the registry has just the values for xml_form_builder_edit_form_registry. Edit the url path for $edit_registry['xml_form_builder_edit_form_registry']['url'] and point it to another page.  This page should load when you click edit on a datastream.

  4) Try the above 1-3 type changes but limit using the object's content model or the datastream being modified.



# Background context:
A way of loading a custom edit form when modifying a datastream without having to use a goto in a form_alter. While keeping the user from having to select the registry route manually.  By making modifications to the edit registry it helps avoid any potential confusion from building one form and redirecting to another.


**Tagging:** @Islandora/7-x-1-x-committers, @ruebot, @DiegoPino 


----
Matthew Perry
_Developer_
**[discoverygarden inc.](http://www.discoverygarden.ca) | Managing Digital Content**