### PR TITLE
Adding pid to object_mapper utility

### DIFF
--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -289,6 +289,7 @@ function islandora_objects_object_mapper($object_id) {
       'link' => l($o->label, $url, $link_options),
       'thumb' => l($img, $url, $link_options),
       'description' => $description,
+      'pid' => $o->id,
     );
   }
   else {
@@ -299,6 +300,7 @@ function islandora_objects_object_mapper($object_id) {
       'link' => l(t('(Unknown)'), $url, $link_options),
       'thumb' => '',
       'description' => '',
+      'pid' => $object_id,
     );
   }
 }

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -257,6 +257,7 @@ function template_preprocess_islandora_objects(array &$variables) {
  *   - link: A string containing a textual HTML link to the object.
  *   - thumb: A string containing an image HTML link to the object.
  *   - description: A string containing a description of the object.
+ *   - pid: The object's PID.
  */
 function islandora_objects_object_mapper($object_id) {
   $o = islandora_object_load($object_id);


### PR DESCRIPTION
**Jira:** https://jira.duraspace.org/browse/ISLANDORA-1576

# What does this Pull Request do?
Add the pid to the return array of the 'islandora_object_mapper' utility function.

# How should this be tested?
To test this one may enable SOLR as the default display generation,{SITE}/admin/islandora/solution_pack_config/basic_collection, implement a preprocess function for  grid or list ({MODULE/THEME}_preprocess_islandora_objects_grid($&vars)), and dd out the results (or dsm(), utilizing devel).

# Background context:
<Provide any background context relating to this pull request, this could be IRC logs, discussion on the list, email communication, etc. Basically anything you have that adds additional information as to why this pull request is being proposed>


# Additional Information 
It would be useful to add an objects PID to the return result of the utility funciton 'islandora_objects_object_mapper($object_id)', found here: https://github.com/Islandora/islandora/blob/7.x/theme/theme.inc#L261. My reasoning is pure convince while pre-processing the SOLR default display back end (grid view, list view). Implementing '{MODULE/THEME}_preprocess_islandora_basic_collection_grid(&$variables)' will not reveal the PID for each object in the result set (surprisingly). While it is possible to do this with additional theme functions and implementations, it would be unnecessary work for something simple.

**Tagging:** <@jordandukart @ruebot @rosiel @DiegoPino> 


----
Morgan Dawe
Theme Developer
_Developer_
**[discoverygarden inc.](http://www.discoverygarden.ca) | Managing Digital Content**