### PR TITLE
Make Tuque connection parameters available for configuration

### DIFF
--- a/includes/tuque_wrapper.inc
+++ b/includes/tuque_wrapper.inc
@@ -322,7 +322,21 @@ class IslandoraFedoraObject extends FedoraObject {
   }
 }
 
-class IslandoraRepositoryConnection extends RepositoryConnection {}
+class IslandoraRepositoryConnection extends RepositoryConnection {
+  /**
+   * Constructor.
+   *
+   * Invokes parent, but additionally invokes an alter to allow modules to
+   * effect the configuration of the connection.
+   */
+  public function __construct($url = NULL, $username = NULL, $password = NULL) {
+    if ($url === NULL) {
+      $url = static::FEDORA_URL;
+    }
+    parent::__construct($url, $username, $password);
+    drupal_alter('islandora_repository_connection_construction', $this);
+  }
+}
 
 class IslandoraFedoraApi extends FedoraApi {
 

--- a/islandora.api.php
+++ b/islandora.api.php
@@ -877,12 +877,12 @@ function hook_islandora_edit_datastream_registry_alter(&$edit_registry, $context
 /**
  * Permit configuration of connection parameters.
  *
- * @param IslandoraRepositoryConnection $instance
+ * @param RepositoryConnection $instance
  *   The connection being constructed. See the relevant Tuque ancestor classes
  *   for the particulars.
  *
  * @see https://github.com/Islandora/tuque/blob/1.x/HttpConnection.php
  */
-function hook_islandora_repository_connection_construction_alter($instance) {
+function hook_islandora_repository_connection_construction_alter(RepositoryConnection $instance) {
   $instance->userAgent = "Tuque/cURL";
 }

--- a/islandora.api.php
+++ b/islandora.api.php
@@ -873,3 +873,16 @@ function hook_islandora_edit_datastream_registry_alter(&$edit_registry, $context
     'url' => "islandora/custom_form/{$context['object']->id}/{$context['datastream']->id}"
   );
 }
+
+/**
+ * Permit configuration of connection parameters.
+ *
+ * @param IslandoraRepositoryConnection $instance
+ *   The connection being constructed. See the relevant Tuque ancestor classes
+ *   for the particulars.
+ *
+ * @see https://github.com/Islandora/tuque/blob/1.x/HttpConnection.php
+ */
+function hook_islandora_repository_connection_construction_alter($instance) {
+  $instance->userAgent = "Tuque/cURL";
+}

--- a/islandora.api.php
+++ b/islandora.api.php
@@ -868,9 +868,9 @@ function hook_islandora_edit_datastream_registry_alter(&$edit_registry, $context
     unset($edit_registry['xml_form_builder_edit_form_registry']);
   }
   // Add custom form to replace the removed form builder edit_form.
-  $edit_registry['somemodule_custom_form'] =  array(
+  $edit_registry['somemodule_custom_form'] = array(
     'name' => t('Somemodule Custom Form'),
-    'url' => "islandora/custom_form/{$context['object']->id}/{$context['datastream']->id}"
+    'url' => "islandora/custom_form/{$context['object']->id}/{$context['datastream']->id}",
   );
 }
 


### PR DESCRIPTION
**Jira:** [ISLANDORA-1590](https://jira.duraspace.org/browse/ISLANDORA-1590)

# What does this Pull Request do?

Adds an alter invocation to permit the configuration of presently-unavailable Tuque connection parameters.

# How should this be tested?

Implement the hook and set some of the parameters... A module has been created to do this: [islandora_repository_connection_config](https://github.com/discoverygarden/islandora_repository_connection_config): [implementation](https://github.com/discoverygarden/islandora_repository_connection_config/pull/1)

# Additional Notes: 
* **Does this change require documentation to be updated?** No? (updated the relevant api.php)
* **Does this change add any new dependencies?** No.
* **Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)?** No.
* **Could this change impact execution of existing code?** Unlikely.

**Tagging:** @jordandukart (as maintainer)


----
Adam Vessey
_Developer_
**[discoverygarden inc.](http://www.discoverygarden.ca) | Managing Digital Content**