### PR TITLE
Remove extra breadcrumb and set title calls.

### DIFF
--- a/includes/object_properties.form.inc
+++ b/includes/object_properties.form.inc
@@ -19,7 +19,6 @@
  *   The drupal form definition.
  */
 function islandora_object_properties_form(array $form, array &$form_state, AbstractObject $object) {
-  drupal_set_title($object->label);
   $form_state['object'] = $object;
   $temp = islandora_invoke_hook_list(ISLANDORA_UPDATE_RELATED_OBJECTS_PROPERTIES_HOOK, $object->models, array($object));
   $related_objects_pids = array();

--- a/islandora.module
+++ b/islandora.module
@@ -979,8 +979,6 @@ function islandora_default_islandora_manage_overview_object(AbstractObject $obje
 function islandora_edit_object(AbstractObject $object) {
   module_load_include('inc', 'islandora', 'includes/breadcrumb');
   module_load_include('inc', 'islandora', 'includes/utilities');
-  drupal_set_title($object->label);
-  drupal_set_breadcrumb(islandora_get_breadcrumbs($object));
   $output = array();
   foreach (islandora_build_hook_list(ISLANDORA_EDIT_HOOK, $object->models) as $hook) {
     $temp = module_invoke_all($hook, $object);
@@ -1043,9 +1041,6 @@ function islandora_view_default_object() {
 function islandora_view_object(AbstractObject $object) {
   module_load_include('inc', 'islandora', 'includes/breadcrumb');
   module_load_include('inc', 'islandora', 'includes/utilities');
-
-  drupal_set_title($object->label);
-  drupal_set_breadcrumb(islandora_get_breadcrumbs($object));
 
   // Optional pager parameters.
   $page_number = (empty($_GET['page'])) ? '1' : $_GET['page'];


### PR DESCRIPTION
**Jira:** <https://jira.duraspace.org/browse/ISLANDORA-1596> 

# What does this Pull Request do?
Removes unneeded calls to the breadcrumb functions that are being called previously in the menu router.

# How should this be tested?
View an object and any and all of the tabs underneath it. Note how the title and breadcrumbs stay the same as they were before.

# Background context:
Reduce the amount of times we are performing requests out against resources.

# Additional Notes: 
* **Does this change require documentation to be updated?** No.
* **Does this change add any new dependencies?** No.
* **Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)?** No.
* **Could this change impact execution of existing code?** Any modules that call islandora_view_object directly will need to set their own title within the callback such as compound.

# Additional Information 
As I'm the maintainer on core will need someone else to look at this.

----
Jordan Dukart
_Developer_
**[discoverygarden inc.](http://www.discoverygarden.ca) | Managing Digital Content**