### PR TITLE
Remove unneeded download path and clip function.

### DIFF
--- a/islandora.module
+++ b/islandora.module
@@ -360,14 +360,6 @@ function islandora_menu() {
     'access arguments' => array(ISLANDORA_REGENERATE_DERIVATIVES, 4),
     'load arguments' => array(2),
   );
-  $items['islandora/object/%islandora_object/download_clip'] = array(
-    'page callback' => 'islandora_download_clip',
-    'page arguments' => array(2),
-    'type' => MENU_CALLBACK,
-    'access callback' => 'islandora_object_access',
-    'access arguments' => array(ISLANDORA_VIEW_OBJECTS, 2),
-    'load arguments' => array(2),
-  );
   $items['islandora/event-status'] = array(
     'title' => 'Event Status',
     'page callback' => 'islandora_event_status',

--- a/islandora.module
+++ b/islandora.module
@@ -1615,31 +1615,6 @@ function islandora_entity_property_info() {
 }
 
 /**
- * Menu callback downloads the given clip.
- */
-function islandora_download_clip(AbstractObject $object) {
-  if (isset($_GET['clip'])) {
-    $url = $_GET['clip'];
-    if (!preg_match('/^https?:\/\//', $url)) {
-      $is_https = isset($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) == 'on';
-      $http_protocol = $is_https ? 'https' : 'http';
-      $url = $http_protocol . '://' . $_SERVER['HTTP_HOST'] . $url;
-    }
-    $filename = $object->label;
-    header("Content-Disposition: attachment; filename=\"{$filename}.jpg\"");
-    header("Content-type: image/jpeg");
-    header("Content-Transfer-Encoding: binary");
-    $ch = curl_init();
-    curl_setopt($ch, CURLOPT_BINARYTRANSFER, 1);
-    curl_setopt($ch, CURLOPT_HEADER, 0);
-    curl_setopt($ch, CURLOPT_URL, $url);
-    $response = curl_exec($ch);
-    curl_close($ch);
-  }
-  exit();
-}
-
-/**
  * Implements hook_file_mimetype_mapping_alter().
  *
  * Grab custom Islandora mime type list


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1696

* Other Relevant Links (Google Groups discussion, related pull requests, Release pull requests, etc.)
https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/islandora-dev/8eSxcOtSlX4/pw_VAFZbAgAJ

# What does this Pull Request do?
Removes the download_clip endpoint from the Islandora core module as only solution packs using OpenSeadragon use it and the offending callback function.

# Interested parties
@Islandora/7-x-1-x-committers
