### PR TITLE
7.x islandora 1724

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ The `islandora_drupal_filter` passes the username of 'anonymous' through to Fedo
 
 Drupal's cron can be run to remove expired authentication tokens.
 
+**Breadcrumb Generation** on the configuration page, allows you to choose the default breadcrumb generation
+ or a custom method (if implemented). 
+
 ### Customization
 
 [Customize ingest forms](http://github.com/Islandora/islandora/wiki/Multi-paged-Ingest-Forms)

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -103,7 +103,7 @@ function islandora_repository_admin(array $form, array &$form_state) {
           '#description' => t('Larger sites may experience a notable performance improvement when disabled due to how breadcrumbs are constructed.'),
           '#default_value' => variable_get('islandora_render_drupal_breadcrumbs', TRUE),
         ),
-        'islandora_breadcrumbs_backend' => array(
+        'islandora_breadcrumbs_backends' => array(
           '#type' => 'radios',
           '#title' => t('Breadcrumb generation'),
           '#description' => t('How breadcrumbs for Islandora objects are generated for display.'),
@@ -111,7 +111,7 @@ function islandora_repository_admin(array $form, array &$form_state) {
           '#options' => array_map($map_to_title, $breadcrumb_backend_options),
           '#states' => array(
             'visible' => array(
-              'islandora_render_drupal_breadcrumbs' => array('checked' => TRUE),
+              ':input[name="islandora_render_drupal_breadcrumbs"]' => array('checked' => TRUE),
             ),
           ),
         ),

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -27,6 +27,11 @@ function islandora_repository_admin(array $form, array &$form_state) {
   $map_to_title = function ($backend) {
     return $backend['title'];
   };
+  // In case the selected breadcrumb backend is no longer available.
+  $breadcrumb_backend = variable_get('islandora_breadcrumbs_backends', ISLANDORA_BREADCRUMB_LEGACY_BACKEND);
+  if (!isset($breadcrumb_backend_options[$breadcrumb_backend])) {
+    $breadcrumb_backend = ISLANDORA_BREADCRUMB_LEGACY_BACKEND;
+  }
 
   $form = array(
     'islandora_tabs' => array(
@@ -107,7 +112,7 @@ function islandora_repository_admin(array $form, array &$form_state) {
           '#type' => 'radios',
           '#title' => t('Breadcrumb generation'),
           '#description' => t('How breadcrumbs for Islandora objects are generated for display.'),
-          '#default_value' => variable_get('islandora_breadcrumbs_backends', ISLANDORA_BREADCRUMB_LEGACY_BACKEND),
+          '#default_value' => $breadcrumb_backend,
           '#options' => array_map($map_to_title, $breadcrumb_backend_options),
           '#states' => array(
             'visible' => array(

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -22,6 +22,12 @@ function islandora_repository_admin(array $form, array &$form_state) {
   $url = islandora_system_settings_form_default_value('islandora_base_url', 'http://localhost:8080/fedora', $form_state);
   $restrict_namespaces = islandora_system_settings_form_default_value('islandora_namespace_restriction_enforced', FALSE, $form_state);
   $confirmation_message = islandora_admin_settings_form_repository_access_message($url);
+
+  $breadcrumb_backend_options = module_invoke_all('islandora_breadcrumbs_backends');
+  $map_to_title = function ($backend) {
+    return $backend['title'];
+  };
+
   $form = array(
     'islandora_tabs' => array(
       '#type' => 'vertical_tabs',
@@ -96,6 +102,18 @@ function islandora_repository_admin(array $form, array &$form_state) {
           '#title' => t('Render Drupal breadcrumbs'),
           '#description' => t('Larger sites may experience a notable performance improvement when disabled due to how breadcrumbs are constructed.'),
           '#default_value' => variable_get('islandora_render_drupal_breadcrumbs', TRUE),
+        ),
+        'islandora_breadcrumbs_backend' => array(
+          '#type' => 'radios',
+          '#title' => t('Breadcrumb generation'),
+          '#description' => t('How breadcrumbs for Islandora objects are generated for display.'),
+          '#default_value' => variable_get('islandora_breadcrumbs_backends', ISLANDORA_BREADCRUMB_LEGACY_BACKEND),
+          '#options' => array_map($map_to_title, $breadcrumb_backend_options),
+          '#states' => array(
+            'visible' => array(
+              'islandora_render_drupal_breadcrumbs' => array('checked' => TRUE),
+            ),
+          ),
         ),
         'islandora_risearch_use_itql_when_necessary' => array(
           '#type' => 'checkbox',

--- a/includes/breadcrumb.inc
+++ b/includes/breadcrumb.inc
@@ -25,9 +25,20 @@
  *   drupal_set_breadcrumb().
  */
 function islandora_get_breadcrumbs($object) {
-  $breadcrumbs = array();
+
   if (variable_get('islandora_render_drupal_breadcrumbs', TRUE)) {
-    $breadcrumbs = islandora_get_breadcrumbs_recursive($object->id, $object->repository);
+    $backend = variable_get('islandora_breadcrumbs_backends', ISLANDORA_BREADCRUMB_LEGACY_BACKEND);
+    $backends = module_invoke_all('islandora_breadcrumbs_backends');
+    if ($backend === ISLANDORA_BREADCRUMB_LEGACY_BACKEND || !isset($backends[$backend])) {
+      $breadcrumbs = islandora_get_breadcrumbs_recursive($object->id, $object->repository);
+    }
+    else {
+      if (isset($backends[$backend]['file'])) {
+        require_once $backends[$backend]['file'];
+      }
+      $breadcrumbs = call_user_func($backends[$backend]['callable'], $object);
+    }
+    
     array_pop($breadcrumbs);
     $context = 'islandora';
     drupal_alter('islandora_breadcrumbs', $breadcrumbs, $context, $object);

--- a/includes/breadcrumb.inc
+++ b/includes/breadcrumb.inc
@@ -47,10 +47,11 @@ function islandora_get_breadcrumbs(AbstractObject $object) {
 /**
  * Call the legacy SPARQL recursive function and return the correct breadcrumbs.
  *
- * @param $pid
+ * @param string $pid
  *   The object id whose parent will be fetched for the next link.
  * @param \IslandoraFedoraRepository $repository
  *   The fedora repository.
+ *
  * @return array
  *   An array of links representing the breadcrumb trail, "root" first.
  */

--- a/includes/breadcrumb.inc
+++ b/includes/breadcrumb.inc
@@ -30,8 +30,7 @@ function islandora_get_breadcrumbs(AbstractObject $object) {
     $backend = variable_get('islandora_breadcrumbs_backends', ISLANDORA_BREADCRUMB_LEGACY_BACKEND);
     $backends = module_invoke_all('islandora_breadcrumbs_backends');
     if ($backend === ISLANDORA_BREADCRUMB_LEGACY_BACKEND || !isset($backends[$backend])) {
-      $breadcrumbs = islandora_get_breadcrumbs_recursive($object->id, $object->repository);
-      array_pop($breadcrumbs);
+      $breadcrumbs = islandora_get_breadcrumbs_legacy($object->id, $object->repository);
     }
     else {
       if (isset($backends[$backend]['file'])) {
@@ -42,6 +41,22 @@ function islandora_get_breadcrumbs(AbstractObject $object) {
     $context = 'islandora';
     drupal_alter('islandora_breadcrumbs', $breadcrumbs, $context, $object);
   }
+  return $breadcrumbs;
+}
+
+/**
+ * Call the legacy SPARQL recursive function and return the correct breadcrumbs.
+ *
+ * @param $pid
+ *   The object id whose parent will be fetched for the next link.
+ * @param \IslandoraFedoraRepository $repository
+ *   The fedora repository.
+ * @return array
+ *   An array of links representing the breadcrumb trail, "root" first.
+ */
+function islandora_get_breadcrumbs_legacy($pid, IslandoraFedoraRepository $repository) {
+  $breadcrumbs = islandora_get_breadcrumbs_recursive($pid, $repository);
+  array_pop($breadcrumbs);
   return $breadcrumbs;
 }
 

--- a/includes/breadcrumb.inc
+++ b/includes/breadcrumb.inc
@@ -24,8 +24,7 @@
  *   not including the given object. For use in the function
  *   drupal_set_breadcrumb().
  */
-function islandora_get_breadcrumbs($object) {
-
+function islandora_get_breadcrumbs(AbstractObject $object) {
   if (variable_get('islandora_render_drupal_breadcrumbs', TRUE)) {
     $backend = variable_get('islandora_breadcrumbs_backends', ISLANDORA_BREADCRUMB_LEGACY_BACKEND);
     $backends = module_invoke_all('islandora_breadcrumbs_backends');
@@ -38,7 +37,6 @@ function islandora_get_breadcrumbs($object) {
       }
       $breadcrumbs = call_user_func($backends[$backend]['callable'], $object);
     }
-    
     array_pop($breadcrumbs);
     $context = 'islandora';
     drupal_alter('islandora_breadcrumbs', $breadcrumbs, $context, $object);

--- a/includes/breadcrumb.inc
+++ b/includes/breadcrumb.inc
@@ -25,11 +25,13 @@
  *   drupal_set_breadcrumb().
  */
 function islandora_get_breadcrumbs(AbstractObject $object) {
+  $breadcrumbs = array();
   if (variable_get('islandora_render_drupal_breadcrumbs', TRUE)) {
     $backend = variable_get('islandora_breadcrumbs_backends', ISLANDORA_BREADCRUMB_LEGACY_BACKEND);
     $backends = module_invoke_all('islandora_breadcrumbs_backends');
     if ($backend === ISLANDORA_BREADCRUMB_LEGACY_BACKEND || !isset($backends[$backend])) {
       $breadcrumbs = islandora_get_breadcrumbs_recursive($object->id, $object->repository);
+      array_pop($breadcrumbs);
     }
     else {
       if (isset($backends[$backend]['file'])) {
@@ -37,7 +39,6 @@ function islandora_get_breadcrumbs(AbstractObject $object) {
       }
       $breadcrumbs = call_user_func($backends[$backend]['callable'], $object);
     }
-    array_pop($breadcrumbs);
     $context = 'islandora';
     drupal_alter('islandora_breadcrumbs', $breadcrumbs, $context, $object);
   }

--- a/islandora.api.php
+++ b/islandora.api.php
@@ -911,7 +911,7 @@ function hook_islandora_repository_connection_construction_alter(RepositoryConne
 /**
  * Allow a overridable backend for generating breadcrumbs.
  *
- * Stolen shamelessly from @adam-vessey
+ * Stolen shamelessly from @adam-vessey.
  *
  * @return array
  *   Should return an associative array mapping unique (module-prefixed,
@@ -922,25 +922,21 @@ function hook_islandora_repository_connection_construction_alter(RepositoryConne
  *   - file: An optional file to load before attempting to call the callable.
  */
 function hook_islandora_breadcrumbs_backends() {
-  $a_callable = function ($object) {
-    // Do something to get an array of breadcrumb links for $object, root first.
-    return array($root_link, $collection_link, $object_link);
-  };
   return array(
     'awesome_backend' => array(
       'title' => t('Awesome Backend'),
-      'callable' => $a_callable,
+      'callable' => callback_islandora_breadcrumbs_backends($object),
     ),
   );
 }
 
 /**
- * Generate an array of links for breadcrumbs leading to $object, root level first.
+ * Generate an array of links for breadcrumbs leading to $object, root first.
  *
- * Stolen shamelessly from @adam-vessey
+ * Stolen shamelessly from @adam-vessey.
  *
  * @param AbstractObject $object
- *   The object to generate breadcrumbs for
+ *   The object to generate breadcrumbs for.
  *
  * @return array
  *   Array of links from root to $object.

--- a/islandora.api.php
+++ b/islandora.api.php
@@ -925,7 +925,7 @@ function hook_islandora_breadcrumbs_backends() {
   return array(
     'awesome_backend' => array(
       'title' => t('Awesome Backend'),
-      'callable' => callback_islandora_breadcrumbs_backends($object),
+      'callable' => 'callback_islandora_breadcrumbs_backends',
     ),
   );
 }
@@ -939,7 +939,7 @@ function hook_islandora_breadcrumbs_backends() {
  *   The object to generate breadcrumbs for.
  *
  * @return array
- *   Array of links from root to $object.
+ *   Array of links from root to the parent of $object.
  */
 function callback_islandora_breadcrumbs_backends(AbstractObject $object) {
   // Do something to get an array of breadcrumb links for $object, root first.

--- a/islandora.api.php
+++ b/islandora.api.php
@@ -937,6 +937,8 @@ function hook_islandora_breadcrumbs_backends() {
 /**
  * Generate an array of links for breadcrumbs leading to $object, root level first.
  *
+ * Stolen shamelessly from @adam-vessey
+ *
  * @param AbstractObject $object
  *   The object to generate breadcrumbs for
  *

--- a/islandora.api.php
+++ b/islandora.api.php
@@ -907,3 +907,43 @@ function hook_islandora_edit_datastream_registry_alter(&$edit_registry, $context
 function hook_islandora_repository_connection_construction_alter(RepositoryConnection $instance) {
   $instance->userAgent = "Tuque/cURL";
 }
+
+/**
+ * Allow a overridable backend for generating breadcrumbs.
+ *
+ * Stolen shamelessly from @adam-vessey
+ *
+ * @return array
+ *   Should return an associative array mapping unique (module-prefixed,
+ *   preferably) keys to associative arrays containing:
+ *   - title: A human-readable title for the backend.
+ *   - callable: A PHP callable to call for this backend, implementing
+ *     callback_islandora_basic_collection_query_backends().
+ *   - file: An optional file to load before attempting to call the callable.
+ */
+function hook_islandora_breadcrumbs_backends() {
+  $a_callable = function ($object) {
+    // Do something to get an array of breadcrumb links for $object, root first.
+    return array($root_link, $collection_link, $object_link);
+  };
+  return array(
+    'awesome_backend' => array(
+      'title' => t('Awesome Backend'),
+      'callable' => $a_callable,
+    ),
+  );
+}
+
+/**
+ * Generate an array of links for breadcrumbs leading to $object, root level first.
+ *
+ * @param AbstractObject $object
+ *   The object to generate breadcrumbs for
+ *
+ * @return array
+ *   Array of links from root to $object.
+ */
+function callback_islandora_breadcrumbs_backends(AbstractObject $object) {
+  // Do something to get an array of breadcrumb links for $object, root first.
+  return array($root_link, $collection_link, $object_link);
+}

--- a/islandora.install
+++ b/islandora.install
@@ -58,6 +58,7 @@ function islandora_uninstall() {
     'islandora_use_object_semaphores',
     'islandora_semaphore_period',
     'islandora_require_obj_upload',
+    'islandora_breadcrumbs_backends',
   );
   array_walk($variables, 'variable_del');
 }

--- a/islandora.module
+++ b/islandora.module
@@ -68,6 +68,8 @@ define('ISLANDORA_DERIVATIVE_CREATION_HOOK', 'islandora_derivative');
 define('ISLANDORA_CONTENT_MODELS_AUTOCOMPLETE', 'islandora/autocomplete/content-models');
 define('ISLANDORA_MIME_TYPES_AUTOCOMPLETE', 'islandora/autocomplete/mime-types');
 
+const ISLANDORA_BREADCRUMB_LEGACY_BACKEND = 'islandora_breadcrumbs_legacy_sparql';
+
 /**
  * Implements hook_menu().
  *
@@ -2170,4 +2172,18 @@ function islandora_islandora_get_breadcrumb_query_predicates(AbstractObject $obj
 function islandora_create_manage_overview(AbstractObject $object) {
   $output = theme('islandora_object_overview', array('islandora_object' => $object));
   return array('cmodels' => $output);
+}
+
+/**
+ * Implements hook_islandora_breadcrumbs_backends().
+ */
+function islandora_islandora_breadcrumbs_backends() {
+  $module_path = drupal_get_path('module', 'islandora');
+  return array(
+    ISLANDORA_BREADCRUMB_LEGACY_BACKEND => array(
+      'title' => t('Resource Index - Default'),
+      // Callback not needed as this is our legacy process and the
+      // default incase anything goes wrong.
+    ),
+  );
 }

--- a/islandora.module
+++ b/islandora.module
@@ -2178,7 +2178,6 @@ function islandora_create_manage_overview(AbstractObject $object) {
  * Implements hook_islandora_breadcrumbs_backends().
  */
 function islandora_islandora_breadcrumbs_backends() {
-  $module_path = drupal_get_path('module', 'islandora');
   return array(
     ISLANDORA_BREADCRUMB_LEGACY_BACKEND => array(
       'title' => t('Resource Index - Default'),

--- a/islandora.module
+++ b/islandora.module
@@ -2154,9 +2154,9 @@ function islandora_schedule_cache_clear_for_batch() {
  */
 function islandora_islandora_get_breadcrumb_query_predicates(AbstractObject $object) {
   return array(
-    'fedora-rels-ext:isPartOf',
-    'fedora-rels-ext:isMemberOfCollection',
-    'fedora-rels-ext:isMemberOf',
+    'info:fedora/fedora-system:def/relations-external#isPartOf',
+    'info:fedora/fedora-system:def/relations-external#isMemberOfCollection',
+    'info:fedora/fedora-system:def/relations-external#isMemberOf',
   );
 }
 


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1724
# What does this Pull Request do?

This PR allows other modules to implement a hook to replace the default generation of breadcrumbs with whatever method they wish. It adds an admin form space to choose which implementation to use.
# What's new?
- Adds a new hook `hook_islandora_breadcrumbs_backends` to add a custom breadcrumb method.
- Adds a new section to the Islandora admin form to choose which breadcrumb method to use.
- Makes the current method of `islandora_get_breadcrumbs()` invoke the above hook and based on the above Admin form selection invoke that callback function.
- The existing `islandora_get_breadcrumbs_recursive()` Sparql function remains and is the default method.
# How should this be tested?

If everything works as expected this PR should have no effect, unless you create a module that implements the hook.

Breadcrumbs should still render properly, but you will see the new section on the admin form.

If you do implement a module with the hook, you should see it appears as an option on the admin form.

Choosing the new implementation should change generation over.

For my testing example hook see:
https://github.com/uml-digitalinitiatives/islandora_custom_solr/blob/7.x-hookable-breadcrumbs/islandora_custom_solr.module#L170-L179
# Additional Notes:

Example:
- Does this change require documentation to be updated? 
  
   Yes - It adds a new option to the admin form which should be documented.
- Does this change add any new dependencies? 
  
   No
- Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? 
  
  No
- Could this change impact execution of existing code?
  
  No
# Interested parties

@DiegoPino (because you suggested this method)
@adam-vessey (because I copied your implementation in basic collection to do this) 
