### PR TITLE
Update default dublin core template

### DIFF
--- a/theme/islandora-dublin-core-description.tpl.php
+++ b/theme/islandora-dublin-core-description.tpl.php
@@ -15,6 +15,6 @@
 <div class="islandora-metadata-sidebar">
   <?php if (!empty($dc_array['dc:description']['value'])): ?>
     <h2><?php print $dc_array['dc:description']['label']; ?></h2>
-    <p property="description"><?php print nl2br(filter_xss($dc_array['dc:description']['value'])); ?></p>
+    <p property="description"><?php print $dc_array['dc:description']['value']; ?></p>
   <?php endif; ?>
 </div>

--- a/theme/islandora-dublin-core-description.tpl.php
+++ b/theme/islandora-dublin-core-description.tpl.php
@@ -15,6 +15,6 @@
 <div class="islandora-metadata-sidebar">
   <?php if (!empty($dc_array['dc:description']['value'])): ?>
     <h2><?php print $dc_array['dc:description']['label']; ?></h2>
-    <p property="description"><?php print $dc_array['dc:description']['value']; ?></p>
+    <p property="description"><?php print nl2br(filter_xss($dc_array['dc:description']['value'])); ?></p>
   <?php endif; ?>
 </div>

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -646,6 +646,7 @@ function islandora_preprocess_islandora_dublin_core_description(array &$variable
     }
   }
   $variables['dc_array'] = isset($dc_object) ? $dc_object->asArray() : array();
+  $variables['dc_array']['dc:description']['value'] = nl2br(filter_xss($variables['dc_array']['dc:description']['value']));
 }
 
 /**


### PR DESCRIPTION
**JIRA Ticket**:
https://jira.duraspace.org/browse/ISLANDORA-1839

# What does this Pull Request do?

This pull request adds a call to `nl2br` and `filter_xss` to the default metadata description template. This allows new lines in the Dublin Core to be preserved when displaying the description to the user.

# What's new?

- added call to `nl2br` to add <br> so that new lines are displayed with the description
- added call to `filter_xss` to make the metadata description tempalte the same as the default metadata template, and to ward off any nasty XSS.

# How should this be tested?

- Create new object, add new lines in description field in the metadata. 
  - Check that isn't displayed before pull request
  - Check that new lines are displayed once pull request is used
- Create object without newlines
  - Check that description does not change.


# Additional Notes:

Should be fairly minor change.

# Interested parties
@DiegoPino 
