### PR TITLE
Chunking/byte-range datastream request race condition

### DIFF
--- a/includes/datastream.inc
+++ b/includes/datastream.inc
@@ -459,7 +459,8 @@ function islandora_view_datastream_retrieve_file_uri(AbstractDatastream $datastr
   $fp = fopen($file_uri, 'r+b');
   if (flock($fp, LOCK_SH)) {
     try {
-      if (feof($fp) && $datastream->size > 0) {
+      fseek($fp, 0, SEEK_END);
+      if (ftell($fp) === 0 && $datastream->size > 0) {
         // Just opened at beginning of file, if beginning == EOF, need to grab
         // it.
         if (!flock($fp, LOCK_EX | LOCK_NB)) {
@@ -482,6 +483,7 @@ function islandora_view_datastream_retrieve_file_uri(AbstractDatastream $datastr
 
           try {
             $datastream->getContent($file->uri);
+            clearstatcache($file->uri);
             $file = file_save($file);
             if ($file->filesize != $datastream->size) {
               throw new RepositoryException(t('Size of file downloaded for chunking does not match: Got @apparent bytes when expecting @actual.', array(

--- a/includes/datastream.inc
+++ b/includes/datastream.inc
@@ -440,6 +440,9 @@ function islandora_view_datastream_deliver_chunks(AbstractDatastream $datastream
  * File locks are used to ensure the datastream is completely downloaded before
  * attempting to serve up chunks from the file.
  *
+ * @throws RepositoryException|Exception
+ *   Exceptions may be thrown if the file was unable to be reliably acquired.
+ *
  * @param AbstractDatastream $datastream
  *   An AbstractDatastream representing a datastream on a Fedora object.
  *

--- a/includes/datastream.inc
+++ b/includes/datastream.inc
@@ -437,6 +437,9 @@ function islandora_view_datastream_deliver_chunks(AbstractDatastream $datastream
 /**
  * Creates/returns the file URI for the content of a datastream for chunking.
  *
+ * File locks are used to ensure the datastream is completely downloaded before
+ * attempting to serve up chunks from the file.
+ *
  * @param AbstractDatastream $datastream
  *   An AbstractDatastream representing a datastream on a Fedora object.
  *
@@ -451,44 +454,60 @@ function islandora_view_datastream_retrieve_file_uri(AbstractDatastream $datastr
   $file_uri = 'temporary://chunk_' . $datastream->parent->id . '_' . $datastream->id . '_' . $datastream->createdDate->getTimestamp() . '.' . $extension;
   touch(drupal_realpath($file_uri));
   $fp = fopen($file_uri, 'r+b');
-  drupal_register_shutdown_function('fclose', $fp);
   if (flock($fp, LOCK_SH)) {
-    if (feof($fp) && $datastream->size > 0) {
-      // Just opened at beginning of file, if beginning == EOF, need to grab it.
-      if (flock($fp, LOCK_EX)) {
-        // Upgrade to exclusive lock, write file.
-        $file = islandora_temp_file_entry($file_uri, $datastream->mimeType);
-        if ($file->filesize == $datastream->size) {
-          // Populated in another thread; downgrade lock and return.
-          flock($fp, LOCK_SH);
-          return $file_uri;
+    try {
+      if (feof($fp) && $datastream->size > 0) {
+        // Just opened at beginning of file, if beginning == EOF, need to grab
+        // it.
+        if (!flock($fp, LOCK_EX | LOCK_NB)) {
+          // Hypothetically, two threads could have a "shared" lock with an
+          // unpopulated file, so to avoid deadlock on the "exclusive" lock,
+          // drop the "shared" lock before blocking to obtain the "exclusive"
+          // lock.
+          flock($fp, LOCK_UN);
         }
-
-        try {
-          $datastream->getContent($file->uri);
-          $file = file_save($file);
-          if ($file->filesize != $datastream->size) {
-            throw new RepositoryException(t('Size of file downloaded for chunking does not match: Got @apparent bytes when expecting @actual.', array(
-              '@apparent' => $file->filesize,
-              '@actual' => $datastream->size,
-            )));
+        if (flock($fp, LOCK_EX)) {
+          // Get exclusive lock, write file.
+          $file = islandora_temp_file_entry($file_uri, $datastream->mimeType);
+          if ($file->filesize == $datastream->size) {
+            // Populated in another thread while we were waiting for the
+            // "exclusive" lock; drop lock and return.
+            flock($fp, LOCK_UN);
+            fclose($fp);
+            return $file_uri;
           }
-          // Downgrade to shared lock.
-          flock($fp, LOCK_SH);
+
+          try {
+            $datastream->getContent($file->uri);
+            $file = file_save($file);
+            if ($file->filesize != $datastream->size) {
+              throw new RepositoryException(t('Size of file downloaded for chunking does not match: Got @apparent bytes when expecting @actual.', array(
+                '@apparent' => $file->filesize,
+                '@actual' => $datastream->size,
+              )));
+            }
+          }
+          catch (RepositoryException $e) {
+            file_delete($file);
+            throw $e;
+          }
         }
-        catch (RepositoryException $e) {
-          file_delete($file);
-          throw $e;
+        else {
+          throw new Exception(t('Failed to acquire write lock when downloading @pid/@dsid for chunking.', array(
+            '@pid' => $datastream->parent->id,
+            '@dsid' => $datastream->id,
+          )));
         }
       }
-      else {
-        throw new Exception(t('Failed to acquire write lock when downloading @pid/@dsid for chunking.', array(
-          '@pid' => $datastream->parent->id,
-          '@dsid' => $datastream->id,
-        )));
-      }
+      flock($fp, LOCK_UN);
+      fclose($fp);
+      return $file_uri;
     }
-    return $file_uri;
+    catch (Exception $e) {
+      flock($fp, LOCK_UN);
+      fclose($fp);
+      throw $e;
+    }
   }
   throw new Exception(t('Failed to acquire shared lock when chunking @pid/@dsid.', array(
     '@pid' => $datastream->parent->id,

--- a/includes/datastream.inc
+++ b/includes/datastream.inc
@@ -445,17 +445,53 @@ function islandora_view_datastream_deliver_chunks(AbstractDatastream $datastream
  */
 function islandora_view_datastream_retrieve_file_uri(AbstractDatastream $datastream) {
   module_load_include('inc', 'islandora', 'includes/mimetype.utils');
+  module_load_include('inc', 'islandora', 'includes/utilities');
 
   $extension = islandora_get_extension_for_mimetype($datastream->mimetype);
   $file_uri = 'temporary://chunk_' . $datastream->parent->id . '_' . $datastream->id . '_' . $datastream->createdDate->getTimestamp() . '.' . $extension;
-  if (!file_exists($file_uri)) {
-    $file = new stdClass();
-    $file->uri = $file_uri;
-    $file->filename = drupal_basename($file_uri);
-    $file->filemime = $datastream->mimeType;
-    $file->status = 0;
-    $datastream->getContent($file_uri);
-    file_save($file);
+  touch(drupal_realpath($file_uri));
+  $fp = fopen($file_uri, 'r+b');
+  drupal_register_shutdown_function('fclose', $fp);
+  if (flock($fp, LOCK_SH)) {
+    if (feof($fp) && $datastream->size > 0) {
+      // Just opened at beginning of file, if beginning == EOF, need to grab it.
+      if (flock($fp, LOCK_EX)) {
+        // Upgrade to exclusive lock, write file.
+        $file = islandora_temp_file_entry($file_uri, $datastream->mimeType);
+        if ($file->filesize == $datastream->size) {
+          // Populated in another thread; downgrade lock and return.
+          flock($fp, LOCK_SH);
+          return $file_uri;
+        }
+
+        try {
+          $datastream->getContent($file->uri);
+          $file = file_save($file);
+          if ($file->filesize != $datastream->size) {
+            throw new RepositoryException(t('Size of file downloaded for chunking does not match: Got @apparent bytes when expecting @actual.', array(
+              '@apparent' => $file->filesize,
+              '@actual' => $datastream->size,
+            )));
+          }
+          // Downgrade to shared lock.
+          flock($fp, LOCK_SH);
+        }
+        catch (RepositoryException $e) {
+          file_delete($file);
+          throw $e;
+        }
+      }
+      else {
+        throw new Exception(t('Failed to acquire write lock when downloading @pid/@dsid for chunking.', array(
+          '@pid' => $datastream->parent->id,
+          '@dsid' => $datastream->id,
+        )));
+      }
+    }
+    return $file_uri;
   }
-  return $file_uri;
+  throw new Exception(t('Failed to acquire shared lock when chunking @pid/@dsid.', array(
+    '@pid' => $datastream->parent->id,
+    '@dsid' => $datastream->id,
+  )));
 }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1857

# What does this Pull Request do?

Closes up a race condition which could cause HTTP timeouts for datastream byte-range requests.

# What's new?

Introduces some file locking to ensure that the temporary files used in the byte-range response are not used before they are completely downloaded from Fedora. 

# How should this be tested?

Really, this should just get a regression test; make sure datastream byte-range requests still work.

If one want to try to see the present issue in action, firing up a pair of browser instances and attempting to play the same video with jwplayer may be able to produce the error, particularly with larger videos:

1. The first should load fine (if slowly, due to the large file)
2. The second, trying to load after the first was started while the first is still in progress (downloading the datastream to the temp directory), will likely see a shorter version of the file, and likely throw an error when hitting the end of the content it understands to be available.

With this pull request, this should no longer be possible... The second should now just wait until the file is complete, likely starting to play at approximately the same time as the first.

# Additional Notes:
* **Does this change require documentation to be updated?** No
* **Does this change add any new dependencies?** No.
* **Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)?** No
* **Could this change impact execution of existing code?** `islandora_view_datastream_retrieve_file_uri()` now may throw exceptions if it is unable to reliably grab datastream content.

At some point in the future, we may want to look at doing at conditionally piping through byte-range requests to Fedora, for those versions which support it... This could avoid the temp copies of files, possibly allowing the initial response to be delivered faster.

# Interested parties
@DiegoPino @willtp87 