### PR TITLE
7.x solr thumbnail

### DIFF
--- a/css/islandora.base.css
+++ b/css/islandora.base.css
@@ -5,8 +5,7 @@
         Purpose of the stylesheet follows.
 */
 
-.islandora img,
-.islandora-object-thumb img {
+.islandora img {
   max-width: 100%;
   *width: 100%;
 }

--- a/css/islandora.base.css
+++ b/css/islandora.base.css
@@ -5,7 +5,8 @@
         Purpose of the stylesheet follows.
 */
 
-.islandora img {
+.islandora img,
+.islandora-object-thumb img {
   max-width: 100%;
   *width: 100%;
 }

--- a/css/islandora.objects.css
+++ b/css/islandora.objects.css
@@ -14,7 +14,7 @@ div.islandora-objects > div {
  * does not exceed that of its parent container (ex: 20%).
  *
  * img styling (max-height) - Avoid making assumptions on max height here, allowing auto
- * height based on max-width of 100%. Consider overrideing this file in your theme,
+ * height based on max-width of 100%. Consider overriding this file in your theme,
  * or adding your own CSS to address a maximum thumbnail height.
  */
 .islandora-object img {

--- a/css/islandora.objects.css
+++ b/css/islandora.objects.css
@@ -12,6 +12,7 @@ div.islandora-objects > div {
 
 .islandora-object img {
   max-width: 100%;
+  max-height: 12em;
 }
 
 .islandora-objects-list-item {

--- a/css/islandora.objects.css
+++ b/css/islandora.objects.css
@@ -10,9 +10,15 @@ div.islandora-objects > div {
   display: inline-block;
 }
 
+/* img styling (max-width) - Setting a max width to ensure a thumbnails width
+ * does not exceed that of its parent container (ex: 20%).
+ *
+ * img styling (max-height) - Avoid making assumptions on max height here, allowing auto
+ * height based on max-width of 100%. Consider overrideing this file in your theme,
+ * or adding your own CSS to address a maximum thumbnail height.
+ */
 .islandora-object img {
   max-width: 100%;
-  max-height: 12em;
 }
 
 .islandora-objects-list-item {

--- a/css/islandora.objects.css
+++ b/css/islandora.objects.css
@@ -10,6 +10,10 @@ div.islandora-objects > div {
   display: inline-block;
 }
 
+.islandora-object img {
+  max-width: 100%;
+}
+
 .islandora-objects-list-item {
   clear: both;
   width: 100%;


### PR DESCRIPTION
**JIRA Ticket**: (https://jira.duraspace.org/browse/ISLANDORA-1870)

# What does this Pull Request do?

Basic fix for SPARQL and SOLR thumbnail display width.

# What's new?
Add a max-width to thumbnails using the SOLR Backend display

Example:
* Added .islandora-object img max-width rule

# How should this be tested?

* Add a large .png as a thumbnail for an object (large as in 'width')
* View object in a collection grid using the SOLR backend display (maintains aspect)
* View object in a collection grid using SPARQL Legacy display (maintains aspect) 

# Note

Related in part to this ticket: https://jira.duraspace.org/browse/ISLANDORA-1609, i believe the ultimate solution is to ensure both displays are run thru the same preprocess functions, using the same HTML and CSS as each other. However, that may be to dramatic of a change outside of a major release. 

# Interested parties
Tag @Islandora/7-x-1-x-committers
