### PR TITLE
Fixes incorrect assumption

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -96,6 +96,12 @@ function islandora_repository_admin(array $form, array &$form_state) {
             useful if derivatives are to be created by an external service.'),
           '#default_value' => variable_get('islandora_defer_derivatives_on_ingest', FALSE),
         ),
+        'islandora_render_context_ingeststep' => array(
+          '#type' => 'checkbox',
+          '#title' => t('Render applicable Content Model label(s) during ingest steps'),
+          '#description' => t('This enables contextual titles, displaying Content Model label(s), to be added on top of ingest forms.'),
+          '#default_value' => variable_get('islandora_render_context_ingeststep', FALSE),
+        ),
         'islandora_show_print_option' => array(
           '#type' => 'checkbox',
           '#title' => t('Show print option on objects'),

--- a/includes/ingest.form.inc
+++ b/includes/ingest.form.inc
@@ -477,9 +477,10 @@ function islandora_ingest_form_stepify(array $form, array &$form_state, array $s
     $form['hidden_next']['#suffix'] = '</div>';
   }
 
-  // Add active CModel header to the form.
-  islandora_ingest_form_add_step_context($form, $form_state);
-
+  if (variable_get('islandora_render_context_ingeststep', FALSE)) {
+    // Add active CModel header to the form.
+    islandora_ingest_form_add_step_context($form, $form_state);
+  }
   // Allow for a hook_form_FORM_ID_alter().
   drupal_alter(array('form_' . $step['form_id'], 'form'), $form, $form_state, $step['form_id']);
   return $form;
@@ -495,7 +496,7 @@ function islandora_ingest_form_stepify(array $form, array &$form_state, array $s
  */
 function islandora_ingest_form_add_step_context(array &$form, array $form_state) {
   $items = array();
-  $get_label = function(AbstractObject $collection, AbstractObject $fedora_cmodel) {
+  $get_label = function(AbstractObject $collection = NULL, AbstractObject $fedora_cmodel) {
     if (isset($collection['COLLECTION_POLICY'])) {
       $policy = new CollectionPolicy($collection['COLLECTION_POLICY']->content);
       $policy_content_models = $policy->getContentModels();
@@ -505,6 +506,13 @@ function islandora_ingest_form_add_step_context(array &$form, array $form_state)
       $fedora_cmodel->label;
   };
   $shared_storage = islandora_ingest_form_get_shared_storage($form_state);
+
+  // Ingest steps also work for newspaper children and
+  // pages of books which don't pass a collection object
+  // and of course don't use collection policies.
+  if (!isset($shared_storage['collection'])) {
+    $shared_storage['collection'] = NULL;
+  }
   foreach ($shared_storage['models'] as $key => $value) {
     $fedora_cmodel = islandora_object_load($value);
     if ($fedora_cmodel) {

--- a/islandora.install
+++ b/islandora.install
@@ -59,6 +59,7 @@ function islandora_uninstall() {
     'islandora_semaphore_period',
     'islandora_require_obj_upload',
     'islandora_breadcrumbs_backends',
+    'islandora_render_context_ingeststep',
   );
   array_walk($variables, 'variable_del');
 }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1876

https://github.com/Islandora/islandora/pull/656

https://github.com/Islandora/islandora_solution_pack_newspaper/pull/146

# What does this Pull Request do?

Fixes failing TRAVIS-CI tests on Newspaper and Book solution packs after a small bug introduced by https://github.com/Islandora/islandora/pull/656 that i, myself, merged 😢. Also adds a drupal variable to enable/disable this contextual titles in ingests steps.

# What's new?
Nothing really. Just fixing a merge i should have tested in more details. And allowing also previous existing functionality (like no CMODEL titles in forms) to co-exist.

# How should this be tested?

There are two ways: After this changes, all non collection based ingest steps(book pages, newspaper issues, should not throw errors anymore. Also Drupal automated test suits for those modules should pass without notices and errors. Lastly using the provided islandora-drupal variable, which can be set and disabled on the islandora admin form, you can now disable or enable CMODEL label(s) titles on ingest forms.

# Interested parties
@dannylamb @jonathangreen @MorganDawe 