### PR TITLE
ISLANDORA-1928: Updates erroneous hook names in islandora.api.php

### DIFF
--- a/islandora.api.php
+++ b/islandora.api.php
@@ -353,7 +353,7 @@ function hook_islandora_datastream_modified(AbstractObject $object, AbstractData
  *
  * @see hook_islandora_datastream_modified()
  */
-function hook_cmodel_pid_islandora_datastream_modified(AbstractObject $object, AbstractDatastream $datastream, array $params) {
+function hook_cmodel_pid_dsid_islandora_datastream_modified(AbstractObject $object, AbstractDatastream $datastream, array $params) {
 
 }
 
@@ -377,7 +377,7 @@ function hook_islandora_datastream_purged(AbstractObject $object, $dsid) {
  *
  * @see hook_islandora_datastream_purged()
  */
-function hook_cmodel_pid_islandora_datastream_purged(AbstractObject $object, $dsid) {
+function hook_cmodel_pid_dsid_islandora_datastream_purged(AbstractObject $object, $dsid) {
 
 }
 


### PR DESCRIPTION
**JIRA Ticket**: [ISLANDORA-1928](https://jira.duraspace.org/browse/ISLANDORA-1928)

# What does this Pull Request do?
Updates the hook name declarations in islandora.api.php

# What's new?
- s/[hook_cmodel_pid_islandora_datastream_modified](https://github.com/Islandora/islandora/blob/7.x/islandora.api.php#L356)/hook_cmodel_pid_dsid_islandora_datastream_modified/
- s/[hook_cmodel_pid_islandora_datastream_purged](https://github.com/Islandora/islandora/blob/7.x/islandora.api.php#L380)/hook_cmodel_pid_dsid_islandora_datastream_purged/

Notice the addition of "_dsid" after "hook_cmodel_pid" in each function name.

# How should this be tested?
Implement the hooks as documented and they never get triggered. Implement them with the DSID in the function name and they do.

This was discovered after a long struggle with [these lines](https://github.com/fsulib/islandora_solution_pack_comparative_edition/blob/master/islandora_comparative_edition.module#L430-L444), where I tried to use the hooks as they were documented and could only get them to work after adding the DSID to the function name (following the pattern of similar hooks like hook_cmodel_pid_dsid_islandora_datastream_ingested and hook_cmodel_pid_dsid_islandora_datastream_alter).

# Additional Notes:
This was discussed in the March 9 2017 committers call. This doesn't REQUIRE a release pull since it isn't a bug and really just glorified documentation, BUT I'll leave that decision to 7.x-1.9 overlord @DiegoPino.

# Interested parties
@Islandora/7-x-1-x-committers, @DiegoPino, @dannylamb
