### PR TITLE
ISLANDORA-1960 Allow NULL abstract object in derivative alter hook

### DIFF
--- a/islandora.api.php
+++ b/islandora.api.php
@@ -746,7 +746,7 @@ function hook_cmodel_pid_islandora_derivative() {
 /**
  * Allows for the altering of defined derivative functions.
  */
-function hook_islandora_derivative_alter(&$derivatives, AbstractObject $object, $ds_modified_params = array()) {
+function hook_islandora_derivative_alter(&$derivatives, AbstractObject $object = NULL, $ds_modified_params = array()) {
   foreach ($derivatives as $key => $derivative) {
     if ($derivative['destination_dsid'] == 'TN') {
       unset($derivatives[$key]);

--- a/tests/islandora_derivatives_test.module
+++ b/tests/islandora_derivatives_test.module
@@ -48,7 +48,7 @@ function islandora_derivatives_test_some_cmodel_islandora_derivative() {
 /**
  * Implements hook_islandora_CMODEL_PID_derivative_alter().
  */
-function islandora_derivatives_test_some_cmodel_islandora_derivative_alter(&$derivatives, AbstractObject $object, $ds_modified_params) {
+function islandora_derivatives_test_some_cmodel_islandora_derivative_alter(&$derivatives, AbstractObject $object = NULL, $ds_modified_params = array()) {
   // Use a mask to determine if only the label has been modified.
   $diff = array_diff_key($ds_modified_params, array(
     'label' => NULL,


### PR DESCRIPTION
JIRA Ticket: https://jira.duraspace.org/browse/ISLANDORA-1960
https://github.com/Islandora/islandora_checksum/pull/52

# What does this Pull Request do?

Allows derivative alter hooks to exist which don't depend or even use Objects. 
At API level, it is more a convention than something enforced. But anyway needed.
The reason for this is that derivatives as they are defined in Islandora Land are not bound to an Islandora Object, its existence or even its execution context.

# What's new?
This allows for third party modules to invoke and alter derivatives if needed (for example to fetch all possible derivatives for a given Content Model) without having to pass an abstract Object.

# How should this be tested?

Really nothing to test here. The whole idea is to match the function signature of the derivative hook. If the main one does not require an Object to be present, why would the alter one impose one?

If you feel compulsively thrown into testing, a code like this using DEVEL (vagrant http://localhost:8000/devel/php)

```PHP
module_load_include('inc', 'islandora', 'includes/utilities');
$derivatives = islandora_invoke_hook_list(
      ISLANDORA_DERIVATIVE_CREATION_HOOK,
      array('islandora:pageCModel'), //Look! i can drive without an object!
      array()
    );
dpm($derivatives);
````

Will give you all derivatives for our pageCModel.

Now extend that and try yo alter it.
```PHP
$object = NULL; // lets try to pass null
module_load_include('inc', 'islandora', 'includes/utilities');
$derivatives = islandora_invoke_hook_list(
      ISLANDORA_DERIVATIVE_CREATION_HOOK,
      array('islandora:pageCModel'),
      array() 
    );
dpm($derivatives);

 foreach (islandora_build_hook_list(ISLANDORA_DERIVATIVE_CREATION_HOOK,  array('islandora:pageCModel')) as $hook) {
    drupal_alter($hook, $derivatives, $object );
  }

dpm($derivatives);
````

would give you:
````
Recoverable fatal error: Argument 2 passed to islandora_checksum_islandora_derivative_alter() must be an instance of AbstractObject, null given, 
````

And any combination the same. Only solution would be to load a really not needed, arbitrary object, which even so could lead to error, because maybe an alter hook could be really really tied to that object and mess all your expected input!

This instead of the $object = NULL would to the trick, if you have islandora:3..
```PHP
$object = islandora_object_load("islandora:3");
dpm ($object->id);
````

Once the parent pull (checksum) is merged or in your testing instances is merged you can safely list all hooks and then alter them without touching an abstract object, just passing a NULL variable.

Other dangers of the current implementations: alters run on variables on reference, that means that a bad written hook could eventually change a passed object. (picky i know)

# Additional Notes:
This is the political correct one pull request. There is an associated https://github.com/Islandora/islandora_checksum/pull/52 one that is an actual implementation fix allowing a null object.

Could this change impact execution of existing code? No

# Interested parties
@Islandora/7-x-1-x-committers