### PR TITLE
ISLANDORA-1781 display that an object is not active.

### DIFF
--- a/islandora.module
+++ b/islandora.module
@@ -1024,7 +1024,7 @@ function islandora_view_object(AbstractObject $object) {
   module_load_include('inc', 'islandora', 'includes/breadcrumb');
   module_load_include('inc', 'islandora', 'includes/utilities');
 
-  // Warn if object is unpublished
+  // Warn if object is inactive or deleted. 
   if ($object->state != 'A') {
     drupal_set_message(t('This object is not active. Metadata may not display correctly.'), 'warning');
   }

--- a/islandora.module
+++ b/islandora.module
@@ -1024,7 +1024,7 @@ function islandora_view_object(AbstractObject $object) {
   module_load_include('inc', 'islandora', 'includes/breadcrumb');
   module_load_include('inc', 'islandora', 'includes/utilities');
 
-  // Warn if object is inactive or deleted. 
+  // Warn if object is inactive or deleted.
   if ($object->state != 'A') {
     drupal_set_message(t('This object is not active. Metadata may not display correctly.'), 'warning');
   }

--- a/islandora.module
+++ b/islandora.module
@@ -1024,6 +1024,10 @@ function islandora_view_object(AbstractObject $object) {
   module_load_include('inc', 'islandora', 'includes/breadcrumb');
   module_load_include('inc', 'islandora', 'includes/utilities');
 
+  // Warn if object is unpublished
+  if ($object->state != 'A') {
+    drupal_set_message(t('This object is not active. Metadata may not display correctly.'), 'warning');
+  }
   // Optional pager parameters.
   $page_number = (empty($_GET['page'])) ? '1' : $_GET['page'];
   $page_size = (empty($_GET['pagesize'])) ? '10' : $_GET['pagesize'];


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1781

Related ticket that this is the documentation fix for: https://jira.duraspace.org/browse/ISLANDORA-1776

# What does this Pull Request do?

Notifies the user that the object they're looking at is not active.

# What's new?

A drupal_set_message ("warning") in islandora_view_object().

# How should this be tested?

Set an object as "Inactive" or "Deleted" (under Manage > Properties). Load the object, and you should see this warning. If you have Solr metadata enabled, watch as the metadata vanishes as this object is removed from the index. 

# Additional Notes:

Changes to the wording welcome. There is scarce documentation about the "Inactive" and "Deleted" states, so there is no place to change documentation, but that is another issue in itself: https://jira.duraspace.org/browse/ISLANDORA-1985 


# Interested parties

 @Islandora/7-x-1-x-committers and @dannylamb  who reported the ticket.