### PR TITLE
ISLANDORA-1985 Add a permission to access inactive or deleted objects.

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -138,6 +138,12 @@ function islandora_repository_admin(array $form, array &$form_state) {
           '#description' => t('During the ingest workflow, make the OBJ file upload step mandatory.'),
           '#default_value' => variable_get('islandora_require_obj_upload', TRUE),
         ),
+        'islandora_deny_inactive_and_deleted' => array(
+          '#type' => 'checkbox',
+          '#title' => t('Lock down inactive and deleted objects.'),
+          '#description' => t('Deny access to inactive or deleted objects using a separate permission than for active objects.'),
+          '#default_value' => variable_get('islandora_deny_inactive_and_deleted', FALSE),
+        ),
       ),
       'islandora_namespace' => array(
         '#type' => 'fieldset',

--- a/includes/object_properties.form.inc
+++ b/includes/object_properties.form.inc
@@ -118,7 +118,7 @@ function islandora_object_properties_form_submit(array $form, array &$form_state
   }
   else {
     // Confirm if user is about to lock themselves out of this object.
-    if (in_array($form_state['values']['object_state'], array('I', 'D'))) {
+    if (variable_get('islandora_deny_inactive_and_deleted', FALSE) && in_array($form_state['values']['object_state'], array('I', 'D'))) {
       if ($form_state['object']->state == 'A') {
         if (!user_access(ISLANDORA_ACCESS_INACTIVE_AND_DELETED_OBJECTS)) {
           $form_state['islandora']['needs_confirmation'] = TRUE;
@@ -240,7 +240,7 @@ function islandora_object_properties_regenerate_derivatives(array $form, array &
  * @param array $form_state
  *   The Drupal form state.
  */
-function islandora_object_properties_confirm_form(&$form_state) {
+function islandora_object_properties_confirm_form(array &$form_state) {
   $desc = t('You do not have permission to view Inactive or Deleted objects, so you will no longer be able to view or manage this object. Are you sure?');
   $path = "islandora/object/{$form_state['object']->id}/manage/properties";
   return confirm_form(array(),

--- a/includes/object_properties.form.inc
+++ b/includes/object_properties.form.inc
@@ -244,9 +244,9 @@ function islandora_object_properties_confirm_form(&$form_state) {
   $desc = t('You do not have permission to view Inactive or Deleted objects, so you will no longer be able to view or manage this object. Are you sure?');
   $path = "islandora/object/{$form_state['object']->id}/manage/properties";
   return confirm_form(array(),
-    'Are you sure you want to set the object state?',
+    t('Are you sure you want to set the object state?'),
     $path,
     $desc,
-    'Continue',
-    'Cancel');
+    t('Continue'),
+    t('Cancel'));
 }

--- a/includes/object_properties.form.inc
+++ b/includes/object_properties.form.inc
@@ -113,12 +113,12 @@ function islandora_object_properties_form(array $form, array &$form_state, Abstr
  *   The Drupal form state.
  */
 function islandora_object_properties_form_submit(array $form, array &$form_state) {
-  if (isset($form_state['islandora']['needs_confirmation'])){
+  if (isset($form_state['islandora']['needs_confirmation'])) {
     $form_state['values'] = $form_state['islandora']['values'];
   }
   else {
     // Confirm if user is about to lock themselves out of this object.
-    if (in_array($form_state['values']['object_state'], array('I','D'))) {
+    if (in_array($form_state['values']['object_state'], array('I', 'D'))) {
       if ($form_state['object']->state == 'A') {
         if (!user_access(ISLANDORA_ACCESS_INACTIVE_AND_DELETED_OBJECTS)) {
           $form_state['islandora']['needs_confirmation'] = TRUE;

--- a/includes/object_properties.form.inc
+++ b/includes/object_properties.form.inc
@@ -118,7 +118,7 @@ function islandora_object_properties_form_submit(array $form, array &$form_state
   }
   else {
     // Confirm if user is about to lock themselves out of this object.
-    if (in_array($form_state['values']['object_state'], ['I','D'])) {
+    if (in_array($form_state['values']['object_state'], array('I','D'))) {
       if ($form_state['object']->state == 'A') {
         if (!user_access(ISLANDORA_ACCESS_INACTIVE_AND_DELETED_OBJECTS)) {
           $form_state['islandora']['needs_confirmation'] = TRUE;

--- a/includes/object_properties.form.inc
+++ b/includes/object_properties.form.inc
@@ -19,6 +19,9 @@
  *   The drupal form definition.
  */
 function islandora_object_properties_form(array $form, array &$form_state, AbstractObject $object) {
+  if (isset($form_state['islandora']['needs_confirmation'])) {
+    return islandora_object_properties_confirm_form($form_state);
+  }
   $form_state['object'] = $object;
   $temp = islandora_invoke_hook_list(ISLANDORA_UPDATE_RELATED_OBJECTS_PROPERTIES_HOOK, $object->models, array($object));
   $related_objects_pids = array();
@@ -110,6 +113,22 @@ function islandora_object_properties_form(array $form, array &$form_state, Abstr
  *   The Drupal form state.
  */
 function islandora_object_properties_form_submit(array $form, array &$form_state) {
+  if (isset($form_state['islandora']['needs_confirmation'])){
+    $form_state['values'] = $form_state['islandora']['values'];
+  }
+  else {
+    // Confirm if user is about to lock themselves out of this object.
+    if (in_array($form_state['values']['object_state'], ['I','D'])) {
+      if ($form_state['object']->state == 'A') {
+        if (!user_access(ISLANDORA_ACCESS_INACTIVE_AND_DELETED_OBJECTS)) {
+          $form_state['islandora']['needs_confirmation'] = TRUE;
+          $form_state['islandora']['values'] = $form_state['values'];
+          $form_state['rebuild'] = TRUE;
+          return;
+        }
+      }
+    }
+  }
   $object = $form_state['object'];
   $owner = $form_state['values']['object_owner'];
   $state = $form_state['values']['object_state'];
@@ -213,4 +232,21 @@ function islandora_update_object_properties($pid, $update_states, $state, $updat
  */
 function islandora_object_properties_regenerate_derivatives(array $form, array &$form_state) {
   drupal_goto("islandora/object/{$form_state['object']}/regenerate");
+}
+
+/**
+ * Confirmation form for object properties admin form.
+ *
+ * @param array $form_state
+ *   The Drupal form state.
+ */
+function islandora_object_properties_confirm_form(&$form_state) {
+  $desc = t('You do not have permission to view Inactive or Deleted objects, so you will no longer be able to view or manage this object. Are you sure?');
+  $path = "islandora/object/{$form_state['object']->id}/manage/properties";
+  return confirm_form(array(),
+    'Are you sure you want to set the object state?',
+    $path,
+    $desc,
+    'Continue',
+    'Cancel');
 }

--- a/islandora.install
+++ b/islandora.install
@@ -60,6 +60,7 @@ function islandora_uninstall() {
     'islandora_require_obj_upload',
     'islandora_breadcrumbs_backends',
     'islandora_render_context_ingeststep',
+    'islandora_deny_inactive_and_deleted',
   );
   array_walk($variables, 'variable_del');
 }
@@ -131,19 +132,4 @@ function islandora_update_7001(&$sandbox) {
   drupal_install_schema('islandora');
   $t = get_t();
   return $t("Islandora database updates complete");
-}
-
-/**
- * Implements hook_update_N().
- *
- * Add default permissions for viewing inactive or deleted objects.
- * Match permissions for viewing all objects.
- */
-function islandora_update_7002(&$sandbox) {
-  $t = get_t();
-  return $t("A new permission 'view inactive or deleted objects' has been added 
-   to the system, and these objects can no longer be viewed by someone without 
-   this permission. If you have users who need to view inactive or deleted 
-   objects please add the new permission to appropriate roles. This is 
-   especially important for sites using the 'Islandora Simple Workflow' module");
 }

--- a/islandora.install
+++ b/islandora.install
@@ -140,10 +140,10 @@ function islandora_update_7001(&$sandbox) {
  * Match permissions for viewing all objects.
  */
 function islandora_update_7002(&$sandbox) {
-  $roles  = user_roles(FALSE, ISLANDORA_VIEW_OBJECTS);
-  foreach ($roles as $rid => $role) {
-    user_role_grant_permissions($rid, array(ISLANDORA_ACCESS_INACTIVE_AND_DELETED_OBJECTS));
-  }
   $t = get_t();
-  return $t("Islandora permission updates complete. Please manage permissions to assign the new permission, 'view inactive or deleted objects', to appropriate roles.");
+  return $t("A new permission 'view inactive or deleted objects' has been added " .
+    "to the system, and these objects can no longer be viewed by someone without " .
+    "this permission. If you have users who need to view inactive or deleted " .
+    "objects please add the new permission to appropriate roles. This is " .
+    "especially important for sites using the 'Islandora Simple Workflow' module");
 }

--- a/islandora.install
+++ b/islandora.install
@@ -132,3 +132,18 @@ function islandora_update_7001(&$sandbox) {
   $t = get_t();
   return $t("Islandora database updates complete");
 }
+
+/**
+ * Implements hook_update_N().
+ *
+ * Add default permissions for viewing inactive or deleted objects.
+ * Match permissions for viewing all objects.
+ */
+function islandora_update_7002(&$sandbox) {
+  $roles  = user_roles(FALSE, ISLANDORA_VIEW_OBJECTS);
+  foreach ($roles as $rid => $role) {
+    user_role_grant_permissions($rid, array(ISLANDORA_ACCESS_INACTIVE_AND_DELETED_OBJECTS));
+  }
+  $t = get_t();
+  return $t("Islandora permission updates complete. Please manage permissions to assign the new permission, 'view inactive or deleted objects', to appropriate roles.");
+}

--- a/islandora.install
+++ b/islandora.install
@@ -141,9 +141,9 @@ function islandora_update_7001(&$sandbox) {
  */
 function islandora_update_7002(&$sandbox) {
   $t = get_t();
-  return $t("A new permission 'view inactive or deleted objects' has been added " .
-    "to the system, and these objects can no longer be viewed by someone without " .
-    "this permission. If you have users who need to view inactive or deleted " .
-    "objects please add the new permission to appropriate roles. This is " .
-    "especially important for sites using the 'Islandora Simple Workflow' module");
+  return $t("A new permission 'view inactive or deleted objects' has been added 
+   to the system, and these objects can no longer be viewed by someone without 
+   this permission. If you have users who need to view inactive or deleted 
+   objects please add the new permission to appropriate roles. This is 
+   especially important for sites using the 'Islandora Simple Workflow' module");
 }

--- a/islandora.module
+++ b/islandora.module
@@ -1693,12 +1693,11 @@ function islandora_object_access($op, $object, $user = NULL) {
  */
 function islandora_islandora_object_access($op, $object, $user) {
   module_load_include('inc', 'islandora', 'includes/utilities');
+  $access = (islandora_namespace_accessible($object->id) && user_access($op, $user));
   if (($object->state != 'A') && variable_get('islandora_deny_inactive_and_deleted', FALSE)) {
-    return islandora_namespace_accessible($object->id) && user_access($op, $user) && user_access(ISLANDORA_ACCESS_INACTIVE_AND_DELETED_OBJECTS, $user);
+    $access = ($access && user_access(ISLANDORA_ACCESS_INACTIVE_AND_DELETED_OBJECTS, $user));
   }
-  else {
-    return islandora_namespace_accessible($object->id) && user_access($op, $user);
-  }
+  return $access;
 }
 
 /**

--- a/islandora.module
+++ b/islandora.module
@@ -34,6 +34,7 @@ define('ISLANDORA_INGEST', 'ingest fedora objects');
 define('ISLANDORA_PURGE', 'delete fedora objects and datastreams');
 define('ISLANDORA_MANAGE_PROPERTIES', 'manage object properties');
 define('ISLANDORA_VIEW_DATASTREAM_HISTORY', 'view old datastream versions');
+define('ISLANDORA_ACCESS_INACTIVE_AND_DELETED_OBJECTS', 'access inactive and deleted objects');
 define('ISLANDORA_MANAGE_DELETED_OBJECTS', 'manage deleted objects');
 define('ISLANDORA_REVERT_DATASTREAM', 'revert to old datastream');
 define('ISLANDORA_REGENERATE_DERIVATIVES', 'regenerate derivatives for an object');
@@ -610,6 +611,10 @@ function islandora_permission() {
     ISLANDORA_REVERT_DATASTREAM => array(
       'title' => t('Revert datastream history'),
       'description' => t('Revert to a previous version of a datastream.'),
+    ),
+    ISLANDORA_ACCESS_INACTIVE_AND_DELETED_OBJECTS => array(
+      'title' => t('Access inactive and deleted objects'),
+      'description' => t('Access objects with a Fedora state of Inactive or Deleted'),
     ),
     ISLANDORA_MANAGE_DELETED_OBJECTS => array(
       'title' => t('Manage deleted objects'),
@@ -1681,8 +1686,12 @@ function islandora_object_access($op, $object, $user = NULL) {
  */
 function islandora_islandora_object_access($op, $object, $user) {
   module_load_include('inc', 'islandora', 'includes/utilities');
-
-  return islandora_namespace_accessible($object->id) && user_access($op, $user);
+  if ($object->state != 'A') {
+    return islandora_namespace_accessible($object->id) && user_access($op, $user) && user_access(ISLANDORA_ACCESS_INACTIVE_AND_DELETED_OBJECTS, $user);
+  }
+  else {
+    return islandora_namespace_accessible($object->id) && user_access($op, $user);
+  }
 }
 
 /**

--- a/islandora.module
+++ b/islandora.module
@@ -579,7 +579,7 @@ function islandora_theme() {
  * Implements hook_permission().
  */
 function islandora_permission() {
-  return array(
+  $permissions = array(
     ISLANDORA_VIEW_OBJECTS => array(
       'title' => t('View repository objects'),
       'description' => t('View objects in the repository. Note: Fedora XACML security policies may override this permission.'),
@@ -612,10 +612,6 @@ function islandora_permission() {
       'title' => t('Revert datastream history'),
       'description' => t('Revert to a previous version of a datastream.'),
     ),
-    ISLANDORA_ACCESS_INACTIVE_AND_DELETED_OBJECTS => array(
-      'title' => t('Access inactive and deleted objects'),
-      'description' => t('Access objects with a Fedora state of Inactive or Deleted'),
-    ),
     ISLANDORA_MANAGE_DELETED_OBJECTS => array(
       'title' => t('Manage deleted objects'),
       'description' => t('Purge or revert deleted objects.'),
@@ -629,6 +625,13 @@ function islandora_permission() {
       'description' => t('Add new datastream content as latest version.'),
     ),
   );
+  if (variable_get('islandora_deny_inactive_and_deleted', FALSE)) {
+    $permissions[ISLANDORA_ACCESS_INACTIVE_AND_DELETED_OBJECTS] = array(
+      'title' => t('Access inactive and deleted objects'),
+      'description' => t('Access objects with a Fedora state of Inactive or Deleted.'),
+    );
+  }
+  return $permissions;
 }
 
 /**
@@ -1690,7 +1693,7 @@ function islandora_object_access($op, $object, $user = NULL) {
  */
 function islandora_islandora_object_access($op, $object, $user) {
   module_load_include('inc', 'islandora', 'includes/utilities');
-  if ($object->state != 'A') {
+  if (($object->state != 'A') && variable_get('islandora_deny_inactive_and_deleted', FALSE)) {
     return islandora_namespace_accessible($object->id) && user_access($op, $user) && user_access(ISLANDORA_ACCESS_INACTIVE_AND_DELETED_OBJECTS, $user);
   }
   else {


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1985

* See also discussion at: https://github.com/Islandora/islandora/pull/676

# What does this Pull Request do?

Blocks access to inactive or deleted objects unless you have special permission.

# What's new?
Added a new Drupal permission. Changed the implementation of hook_islandora_object_access to check for this permission.

# How should this be tested?

Set an object to "Inactive" or "Deleted". Notice that before this PR, anyone with "View repository objects" permission can see this object.

Apply this PR, then give yourself (or other administrator role) the ability to "Access inactive or deleted objects". See that other users who can "View repository objects" can no longer see the deleted/inactive object. 

# Additional Notes:
This'll probably lead to some admin users getting locked out of objects they should see. Not sure if we can/should grant this permission with this PR using hook_update()? But users of Manage Deleted Objects and Simple Workflow will be affected.

* Does this change require documentation to be updated? YES. The documentation that's affected is outlined in the Jira ticket. 
* Does this change add any new dependencies?  No.
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? No.
* Could this change impact execution of existing code? Yes. See caveat above.

# Interested parties
@DiegoPino , @bondjimbond, @Islandora/7-x-1-x-committers, @jordandukart maintainer of Simple Workflow, @ajstanley implementer of Manage Deleted Objects