### PR TITLE
Use the replacements and less pasta.

### DIFF
--- a/includes/tuque_wrapper.inc
+++ b/includes/tuque_wrapper.inc
@@ -240,11 +240,12 @@ class IslandoraFedoraObject extends FedoraObject {
       return $ret;
     }
     catch (Exception $e) {
-      watchdog('islandora', 'Failed to ingest object: @pid</br>code: @code<br/>message: @msg', array(
-          '@pid' => $object->id,
-          '@dsid' => $datastream->id,
-          '@code' => $e->getCode(),
-          '@msg' => $e->getMessage()), WATCHDOG_ERROR);
+      watchdog('islandora', 'Failed to ingest datastream @datastream on object: @pid</br>code: @code<br/>message: @msg', array(
+        '@pid' => $object->id,
+        '@dsid' => $datastream->id,
+        '@code' => $e->getCode(),
+        '@msg' => $e->getMessage(),
+      ), WATCHDOG_ERROR);
       throw $e;
     }
   }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1995

# What does this Pull Request do?
Updates the exception catcher around the ingestDatastream call to be correct and provide some more info. Previously Tuque would return `FALSE` when ingestDatastreams were not successful and would attempt to invoke the `islandora_datastream_ingested` hooks on datastream objects that did not exist.

# What's new?
In https://github.com/Islandora/tuque/pull/157 a new exception is being thrown when we attempt to ingest a datastream to an object that already has that datastream. This corrects the text around the messaging.

# How should this be tested?
Enable the test module from: https://github.com/jordandukart/datastream_ingest_test
Re-ingest a collection that defines a TN from the required objects solution packs page (admin/islandora/solution_pack_config/solution_packs)
Note how the messages show that the Tuque wrapper from Islandora is invoking hooks with a `NewFedoraDatastream`
Pull Tuque code.
Repeat the process, note how we are now tossing an exception.
Pull the Islandora code, note how we are now catching the exception.

# Additional Notes:
Relates to: https://github.com/Islandora/islandora_solution_pack_collection/pull/191 and https://github.com/Islandora/tuque/pull/157
* Could this change impact execution of existing code? Yes.
It's possible that somewhere someone is relying upon these ingestDatastream calls returning `FALSE` as opposed to exceptions (https://github.com/Islandora/islandora/blob/7.x/includes/tuque_wrapper.inc#L238-L240). If we wish to preserve this behavior we could add another catch with the specific typed exception being tossed from Tuque and log accordingly and return FALSE and or have this behavior toggleable, up for discussion.

# Interested parties
@dannylamb, @DiegoPino, @jonathangreen 
