### PR TITLE
ISLANDORA-1998 Check correct permission for replace ds link.

### DIFF
--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -64,7 +64,7 @@ function template_preprocess_islandora_default_edit(array &$variables) {
     elseif (user_access(ISLANDORA_VIEW_DATASTREAM_HISTORY)) {
       $row[] = array();
     }
-    if (islandora_datastream_access(ISLANDORA_VIEW_DATASTREAM_HISTORY, $ds)) {
+    if (islandora_datastream_access(ISLANDORA_REPLACE_DATASTREAM_CONTENT, $ds)) {
       // Add new datastream content as the lastest version.
       $row[] = array(
         'class' => 'datastream-replace',

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -64,18 +64,12 @@ function template_preprocess_islandora_default_edit(array &$variables) {
     elseif (user_access(ISLANDORA_VIEW_DATASTREAM_HISTORY)) {
       $row[] = array();
     }
-    if (islandora_datastream_access(ISLANDORA_REPLACE_DATASTREAM_CONTENT, $ds)) {
-      // Add new datastream content as the lastest version.
-      $row[] = array(
-        'class' => 'datastream-replace',
-        'data' => theme('islandora_datastream_replace_link', array(
-          'datastream' => $ds,
-        )),
-      );
-    }
-    else {
-      $row[] = array();
-    }
+    $row[] = array(
+      'class' => 'datastream-replace',
+      'data' => theme('islandora_datastream_replace_link', array(
+        'datastream' => $ds,
+      )),
+    );
     $row[] = array(
       'class' => 'datastream-download',
       'data' => theme('islandora_datastream_download_link', array(


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1998

* Discussion in Islandora Mailing List: https://groups.google.com/forum/#!topic/islandora/E0q3e-ZiK7Q 

# What does this Pull Request do?

Checks the right permission when deciding whether to show "Replace" datastream link.

# What's new?

ISLANDORA_REPLACE_DATASTREAM_CONTENT

# How should this be tested?

A description of what steps someone could take to:
* Give a user permission to replace datastreams, but not to view datastream history.
* Before this PR: That user can't replace datastreams in [object]/manage/datastreams.
* After this PR: That user sees the 'Replace' links and can replace a datastream.


# Interested parties
@jordandukart or @Islandora/7-x-1-x-committers 
