### PR TITLE
ISLANDORA-2001 Adds JSON-LD MIME type to islandora_mime_mapping function.

### DIFF
--- a/includes/mimetype.utils.inc
+++ b/includes/mimetype.utils.inc
@@ -268,5 +268,7 @@ function islandora_mime_mapping() {
     // Web Archives:
     "warc" => "application/warc",
     "json" => "application/json",
+    // JSON-LD
+    "jsonld" => "application/ld+json",
   );
 }


### PR DESCRIPTION
ISLANDORA-2001 Adds JSON-LD MIME type to islandora_mime_mapping function.

**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2001

# What does this Pull Request do?

Adds the [JSON-LD MIME type](https://www.w3.org/TR/json-ld-syntax/#iana-considerations) to the `islandora_mime_mapping` function.   The result is that when downloading a JSON-LD datastream through the datastream management interface, the proper .jsonld extension will be added to the downloaded file (rather than .bin).

# What's new?
Any JSON-LD datastreams with the proper MIME type will be downloaded with the .jsonld file extension when downloading through the manage datastreams interface.

# How should this be tested?
* Review the changed file for syntax errors that may cause PHP notices, warnings or errors.  
* Optional: If you have access to an Islandora instance that has objects with JSON-LD datastreams with the proper JSON-LD MIME type, try downloading the datastream through the manage datastreams interface for that object.  The file should be assigned the .jsonld file extension. 

# Additional Notes:
Related to [issue 200 of the Islandora Web Annotation module](https://github.com/digitalutsc/islandora_web_annotations/issues/200).   @MarcusBarnes has tested on his development machine that has JSON-LD datastreams created by the Islandora Web Annotation module.

# Interested parties
@Islandora/7-x-1-x-committers
