### PR TITLE
ISLANDORA-2053: Update travis.yml to force PHP 5.3.3 to run under Ubuntu Precise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,16 @@
 sudo: required
 dist: trusty
 language: php
+php:
+  - 5.4
+  - 5.5
+  - 5.6
+  - 7.0
+  - 7.1
+
 matrix:
   include:
-   #5.3.3 Precise block
+   #5.3.3 Ubuntu Precise exceptions
     - php: 5.3.3
       dist: precise
       env: FEDORA_VERSION="3.5"
@@ -16,51 +23,12 @@ matrix:
     - php: 5.3.3
       dist: precise
       env: FEDORA_VERSION="3.8.1"
-   # 5.4 Trusty block      
-    - php: 5.4
-      env: FEDORA_VERSION="3.5"
-    - php: 5.4
-      env: FEDORA_VERSION="3.6.2"
-    - php: 5.4
-      env: FEDORA_VERSION="3.7.0"
-    - php: 5.4
-      env: FEDORA_VERSION="3.8.1"  
-  # 5.5 Trusty block      
-    - php: 5.5
-      env: FEDORA_VERSION="3.5"
-    - php: 5.5
-      env: FEDORA_VERSION="3.6.2"
-    - php: 5.5
-      env: FEDORA_VERSION="3.7.0"
-    - php: 5.5
-      env: FEDORA_VERSION="3.8.1"
-  # 5.6 Trusty block      
-    - php: 5.6
-      env: FEDORA_VERSION="3.5"
-    - php: 5.6
-      env: FEDORA_VERSION="3.6.2"
-    - php: 5.6
-      env: FEDORA_VERSION="3.7.0"
-    - php: 5.6
-      env: FEDORA_VERSION="3.8.1"
-  # 7.0 Trusty block      
-    - php: 7.0
-      env: FEDORA_VERSION="3.5"
-    - php: 7.0
-      env: FEDORA_VERSION="3.6.2"
-    - php: 7.0
-      env: FEDORA_VERSION="3.7.0"
-    - php: 7.0
-      env: FEDORA_VERSION="3.8.1"
-  # 7.1 Trusty block      
-    - php: 7.1
-      env: FEDORA_VERSION="3.5"
-    - php: 7.1
-      env: FEDORA_VERSION="3.6.2"
-    - php: 7.1
-      env: FEDORA_VERSION="3.7.0"
-    - php: 7.1
-      env: FEDORA_VERSION="3.8.1"    
+env:
+  - FEDORA_VERSION="3.5"
+  - FEDORA_VERSION="3.6.2"
+  - FEDORA_VERSION="3.7.0"
+  - FEDORA_VERSION="3.8.1"
+
 branches:
   only:
     - /^7.x/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,6 @@
 sudo: required
 dist: trusty
 language: php
-php:
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
 
 matrix:
   include:
@@ -23,6 +17,12 @@ matrix:
     - php: 5.3.3
       dist: precise
       env: FEDORA_VERSION="3.8.1"
+php:
+  - 5.4
+  - 5.5
+  - 5.6
+  - 7.0
+  - 7.1
 env:
   - FEDORA_VERSION="3.5"
   - FEDORA_VERSION="3.6.2"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,22 +3,67 @@ dist: trusty
 language: php
 matrix:
   include:
+   #5.3.3 Precise block
     - php: 5.3.3
       dist: precise
+      env: FEDORA_VERSION="3.5"
+    - php: 5.3.3
+      dist: precise
+      env: FEDORA_VERSION="3.6.2"
+    - php: 5.3.3
+      dist: precise
+      env: FEDORA_VERSION="3.7.0"
+    - php: 5.3.3
+      dist: precise
+      env: FEDORA_VERSION="3.8.1"
+   # 5.4 Trusty block      
     - php: 5.4
+      env: FEDORA_VERSION="3.5"
+    - php: 5.4
+      env: FEDORA_VERSION="3.6.2"
+    - php: 5.4
+      env: FEDORA_VERSION="3.7.0"
+    - php: 5.4
+      env: FEDORA_VERSION="3.8.1"  
+  # 5.5 Trusty block      
     - php: 5.5
+      env: FEDORA_VERSION="3.5"
+    - php: 5.5
+      env: FEDORA_VERSION="3.6.2"
+    - php: 5.5
+      env: FEDORA_VERSION="3.7.0"
+    - php: 5.5
+      env: FEDORA_VERSION="3.8.1"
+  # 5.6 Trusty block      
     - php: 5.6
+      env: FEDORA_VERSION="3.5"
+    - php: 5.6
+      env: FEDORA_VERSION="3.6.2"
+    - php: 5.6
+      env: FEDORA_VERSION="3.7.0"
+    - php: 5.6
+      env: FEDORA_VERSION="3.8.1"
+  # 7.0 Trusty block      
     - php: 7.0
+      env: FEDORA_VERSION="3.5"
+    - php: 7.0
+      env: FEDORA_VERSION="3.6.2"
+    - php: 7.0
+      env: FEDORA_VERSION="3.7.0"
+    - php: 7.0
+      env: FEDORA_VERSION="3.8.1"
+  # 7.1 Trusty block      
     - php: 7.1
+      env: FEDORA_VERSION="3.5"
+    - php: 7.1
+      env: FEDORA_VERSION="3.6.2"
+    - php: 7.1
+      env: FEDORA_VERSION="3.7.0"
+    - php: 7.1
+      env: FEDORA_VERSION="3.8.1"    
 branches:
   only:
     - /^7.x/
-env:
-  matrix:
-    - FEDORA_VERSION="3.5"
-    - FEDORA_VERSION="3.6.2"
-    - FEDORA_VERSION="3.7.0"
-    - FEDORA_VERSION="3.8.1"
   global:
     # This key is unique to the Islandora/islandora repository; logging will
     # fail on forked repositories unless a new unique key is generated for them.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 sudo: required
+dist: trusty
 language: php
 php:
   - 5.3.3
+    dist: precise
   - 5.4
   - 5.5
   - 5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,15 @@
 sudo: required
 dist: trusty
 language: php
-php:
-  - 5.3.3
-    dist: precise
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
+matrix:
+  include:
+    - php: 5.3.3
+      dist: precise
+    - php: 5.4
+    - php: 5.5
+    - php: 5.6
+    - php: 7.0
+    - php: 7.1
 branches:
   only:
     - /^7.x/


### PR DESCRIPTION
**ISLANDORA-2053**: (https://jira.duraspace.org/browse/ISLANDORA-2053)
http://irclogs.islandora.ca/2017-09-05.html
https://github.com/travis-ci/travis-ci/issues/2963

As of September 2017, Travis-CI has removed support for PHP 5.3 (and 5.2) for their Ubuntu Trusty Images, forcing us, in order  to keep Drupal's compatibility matrix tested, to run Travis-CI test for 5.3 on Ubuntu Precise


# What does this Pull Request do?

This pull Fixes our failing Travis-CI tests: 
Should allow PHP 5.3.3 to run under Ubuntu Precise and Higher versions under Ubuntu Trusty.
Changes the way we define which PHP versions and Fedora ones run in Travis

# What's new?
We moved PHP 5.3.3 version and the corresponding Fedora versions into the matrix section of the Travis YAML file. 


# How should this be tested?
 Travis-CI should pass and everything single PHP/FEDORA version combination should look good and very green.

# Interested parties
@Islandora/7-x-1-x-committers