### PR TITLE
7.1-1.10 ISLANDORA-2073 block datastreams for inactive or deleted. (take 2)

### DIFF
--- a/islandora.api.php
+++ b/islandora.api.php
@@ -597,8 +597,8 @@ function hook_cmodel_pid_islandora_object_access($op, $object, $user) {
  * @param string $op
  *   A string define an operation to check. Should be defined via
  *   hook_permission().
- * @param AbstractDatastream $object
- *   An object to check the operation on.
+ * @param AbstractDatastream $datastream
+ *   A datastream to check the operation on.
  * @param object $user
  *   A loaded user object, as the global $user variable might contain.
  *
@@ -608,7 +608,7 @@ function hook_cmodel_pid_islandora_object_access($op, $object, $user) {
  *   about the outcome. Can also be an array containing multiple
  *   TRUE/FALSE/NULLs, due to how hooks work.
  */
-function hook_islandora_datastream_access($op, AbstractObject $object, $user) {
+function hook_islandora_datastream_access($op, AbstractDatastream $datastream, $user) {
   switch ($op) {
     case 'create stuff':
       return TRUE;
@@ -626,7 +626,7 @@ function hook_islandora_datastream_access($op, AbstractObject $object, $user) {
  *
  * @see hook_islandora_datastream_access()
  */
-function hook_cmodel_pid_islandora_datastream_access($op, $object, $user) {
+function hook_cmodel_pid_islandora_datastream_access($op, $datastream, $user) {
 
 }
 

--- a/islandora.api.php
+++ b/islandora.api.php
@@ -562,8 +562,14 @@ function hook_cmodel_pid_islandora_ingest_steps_alter(array &$steps, array &$for
  *   the given object, or NULL to indicate that we are making no assertion
  *   about the outcome. Can also be an array containing multiple
  *   TRUE/FALSE/NULLs, due to how hooks work.
+ *
+ *   If denying an action (such as ISLANDORA_VIEW_OBJECTS) on an object,
+ *   it will not be automatically denied for the individual datastreams.
+ *   Operations on datastreams must be explicitly denied in
+ *   hook_islandora_datastream_access().
+ *
  */
-function hook_islandora_object_access($op, $object, $user) {
+function hook_islandora_object_access($op, AbstractObject $object, $user) {
   switch ($op) {
     case 'create stuff':
       return TRUE;
@@ -602,7 +608,7 @@ function hook_cmodel_pid_islandora_object_access($op, $object, $user) {
  *   about the outcome. Can also be an array containing multiple
  *   TRUE/FALSE/NULLs, due to how hooks work.
  */
-function hook_islandora_datastream_access($op, $object, $user) {
+function hook_islandora_datastream_access($op, AbstractObject $object, $user) {
   switch ($op) {
     case 'create stuff':
       return TRUE;

--- a/islandora.module
+++ b/islandora.module
@@ -1962,12 +1962,7 @@ function islandora_islandora_metadata_display_info() {
  * Implements hook_islandora_datastream_access().
  */
 function islandora_islandora_datastream_access($op, AbstractDatastream $datastream, $user) {
-  module_load_include('inc', 'islandora', 'includes/utilities');
-  $result = islandora_namespace_accessible($datastream->parent->id) && user_access($op, $user);
-
-  if (($datastream->parent->state != 'A') && variable_get('islandora_deny_inactive_and_deleted', FALSE)) {
-    $result = ($result && user_access(ISLANDORA_ACCESS_INACTIVE_AND_DELETED_OBJECTS, $user));
-  }
+  $result = islandora_islandora_object_access($op, $datastream->parent, $user);
 
   if ($result && $op == ISLANDORA_REGENERATE_DERIVATIVES) {
     module_load_include('inc', 'islandora', 'includes/derivatives');

--- a/islandora.module
+++ b/islandora.module
@@ -1965,6 +1965,10 @@ function islandora_islandora_datastream_access($op, AbstractDatastream $datastre
   module_load_include('inc', 'islandora', 'includes/utilities');
   $result = islandora_namespace_accessible($datastream->parent->id) && user_access($op, $user);
 
+  if (($datastream->parent->state != 'A') && variable_get('islandora_deny_inactive_and_deleted', FALSE)) {
+    $result = ($result && user_access(ISLANDORA_ACCESS_INACTIVE_AND_DELETED_OBJECTS, $user));
+  }
+
   if ($result && $op == ISLANDORA_REGENERATE_DERIVATIVES) {
     module_load_include('inc', 'islandora', 'includes/derivatives');
     $applicable_hook = FALSE;

--- a/islandora.module
+++ b/islandora.module
@@ -1966,6 +1966,7 @@ function islandora_islandora_datastream_access($op, AbstractDatastream $datastre
 
   if ($result && $op == ISLANDORA_REGENERATE_DERIVATIVES) {
     module_load_include('inc', 'islandora', 'includes/derivatives');
+    module_load_include('inc', 'islandora', 'includes/utilities');
     $applicable_hook = FALSE;
     $object = $datastream->parent;
     $hooks = islandora_invoke_hook_list(ISLANDORA_DERIVATIVE_CREATION_HOOK, $object->models, array($object));


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2073

Related to new feature to block inactive/deleted objects in https://jira.duraspace.org/browse/ISLANDORA-1985

Sister (7x) pull request #685 

# What does this Pull Request do?

Blocks datastream access for objects that have Fedora state "inactive" or "deleted" and the user is not allowed to see inactive or deleted objects. Also updates API documentation.

# What's new?

Added the same check in islandora_islandora_object_access() to islandora_islandora_datasbtream_access().

# How should this be tested?

* Mark an object as inactive or deleted.
* Configure Islandora (Islandora > Configuration) to "Lock down inactive and deleted objects."
* Configure permissions so that a non-admin user or anonymous can "View repository objects" but not "Access inactive and deleted objects".
* Before this PR:  that non-admin user can not see the object, but can see its datastreams.
* After this PR: No DS for you.


# Additional Notes:
It would be easier to change how islandora_datastream_access works, and deny access to the datastream if access was denied to the object. But that would break IP embargo, which locks down objects but requires the TN datastream to get through. 

* Does this change require documentation to be updated? *I updated the API documentation to reflect how this works.*
* Does this change add any new dependencies? *no*
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? *no*
* Could this change impact execution of existing code? *no*

**Apologies for the second pull request; the other one still had extra commits that shouldn't have been in there. **

# Interested parties
Tag! @kayakr (discoverer!) @adam-vessey (explained why code worked that way!) @Islandora/7-x-1-x-committers  