### PR TITLE
Object context for permission check.

### DIFF
--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -21,7 +21,7 @@ function template_preprocess_islandora_default_edit(array &$variables) {
   $header[] = array('data' => t('Type'));
   $header[] = array('data' => t('Mime type'));
   $header[] = array('data' => t('Size'));
-  if (user_access(ISLANDORA_VIEW_DATASTREAM_HISTORY)) {
+  if (islandora_object_access(ISLANDORA_VIEW_DATASTREAM_HISTORY, $islandora_object)) {
     $header[] = array('data' => t('Versions'));
   }
 
@@ -61,7 +61,7 @@ function template_preprocess_islandora_default_edit(array &$variables) {
         )),
       );
     }
-    elseif (user_access(ISLANDORA_VIEW_DATASTREAM_HISTORY)) {
+    elseif (islandora_object_access(ISLANDORA_VIEW_DATASTREAM_HISTORY, $islandora_object)) {
       $row[] = array();
     }
     $row[] = array(


### PR DESCRIPTION
**JIRA Ticket**: [ISLANDORA-2064](https://jira.duraspace.org/browse/ISLANDORA-2064)

# What does this Pull Request do?

Add more context to access check, permitting overrides.

# What's new?

* Use `islandora_object_access()` instead of `user_access()` for access control to allow things to be influenced from our access hooks.

# How should this be tested?

Primarily, regression testing: Things should work as they did.

Simple test module exposing a block allowing the permissions to be denied via our hooks: https://github.com/adam-vessey/islandora_2064_test

# Additional Notes:

* **Does this change require documentation to be updated?** No.
* **Does this change add any new dependencies?** No.
* **Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)?** No.
* **Could this change impact execution of existing code?** Unlikely, but it _is_ possible.

# Interested parties

@willtp87 (as component manager), @DiegoPino (since this is bubbling out of other PRs), @Islandora/7-x-1-x-committers

---

The search:
```
islandora @ 100d8ddc05fe02fd339230ae33c11b2e45fb369b, comments with `#` inline:
/var/www/drupal7/sites/all/modules/islandora$ git grep -n user_access
# Unclear how to handle... is in a management form, controlling an action over multiple
# objects...
includes/manage_deleted_objects.inc:171:  if (user_access(ISLANDORA_PURGE)) {
# Unclear how to handle... maybe unnecessary, since it's just prompting for confirmation?
includes/object_properties.form.inc:123:        if (!user_access(ISLANDORA_ACCESS_INACTIVE_AND_DELETED_OBJECTS)) {
# Unrelated (chains to islandora_*_access underneath).
islandora.module:763:function islandora_user_access($object_or_datastream, array $permissions, $content_models = array(), $access_any = TRUE, $user = NULL) {
# Comment...
islandora.module:1692: * according to core Drupal permissions according to user_access().
# Base call to involve Drupal permission in islandora_object_access()
islandora.module:1696:  $access = (islandora_namespace_accessible($object->id) && user_access($op, $user));
# Should probably call islandora_object_access() instead.
islandora.module:1698:    $access = ($access && user_access(ISLANDORA_ACCESS_INACTIVE_AND_DELETED_OBJECTS, $user));
# Could possibly be made a call to islandora_islandora_object_access() explicitly, instead of copypasta. (Rosie did/is doing in https://github.com/Islandora/islandora/pull/685/commits/0f0e84ed357b5c272761c8ecac16bf4329115f23#diff-ab8875f550771e37425e399a32097fb0R1965) 
islandora.module:1966:  $result = islandora_namespace_accessible($datastream->parent->id) && user_access($op, $user);
# No object context applicable
islandora.module:2006:  return $found && user_access('administer site configuration');
# A number testing islandora_user_access()...
tests/islandora_manage_permissions.test:93:    // Test islandora_user_access().
tests/islandora_manage_permissions.test:95:    $ret = islandora_user_access(NULL, array());
tests/islandora_manage_permissions.test:98:    $ret = islandora_user_access($object, array());
tests/islandora_manage_permissions.test:102:    $ret = islandora_user_access($object, array(ISLANDORA_VIEW_OBJECTS), array(), TRUE, $user);
tests/islandora_manage_permissions.test:106:    $ret = islandora_user_access($object, array(ISLANDORA_VIEW_OBJECTS, ISLANDORA_PURGE), array(), FALSE, $user);
tests/islandora_manage_permissions.test:110:    $ret = islandora_user_access($object, array(ISLANDORA_VIEW_OBJECTS), array(), TRUE, $user);
tests/islandora_manage_permissions.test:116:    $ret = islandora_user_access($object, array(ISLANDORA_VIEW_OBJECTS), array($model), TRUE, $user);
tests/islandora_manage_permissions.test:120:    $ret = islandora_user_access($object, array(ISLANDORA_VIEW_OBJECTS), array('islandora:obviouslyNotACModel'), TRUE, $user);
tests/islandora_manage_permissions.test:127:    $ret = islandora_user_access($object, array(ISLANDORA_VIEW_OBJECTS, ISLANDORA_PURGE), array($model, 'islandora:obviouslyNotACModel'), FALSE, $user);
tests/islandora_manage_permissions.test:129:    $ret = islandora_user_access($object, array(ISLANDORA_VIEW_OBJECTS, ISLANDORA_PURGE), array($model), FALSE, $user);
tests/islandora_manage_permissions.test:133:    $ret = islandora_user_access($object['DC'], array(ISLANDORA_VIEW_OBJECTS), array(), TRUE, $user);
# Could change...
theme/theme.inc:24:  if (user_access(ISLANDORA_VIEW_DATASTREAM_HISTORY)) {
# Could change...
theme/theme.inc:64:    elseif (user_access(ISLANDORA_VIEW_DATASTREAM_HISTORY)) {
```

Presently handled in the PR is the last two:
* `theme/theme.inc:24` and
* `theme/theme.inc:64`
questionable are the first two:
* `includes/manage_deleted_objects.inc:171`
* `includes/object_properties.form.inc:123`