### PR TITLE
Adds check for invalid PIDs to islandora_object_load fails

### DIFF
--- a/islandora.module
+++ b/islandora.module
@@ -1229,7 +1229,6 @@ function islandora_object_load($object_id) {
       // Check to see if tuque failure is due to invalid PID.
       module_load_include('inc', 'islandora', 'includes/utilities');
       if (!islandora_is_valid_pid($object_id)) {
-        watchdog('islandora', 'Failed to load invalid PID: @pid', array('@pid' => $object_id), WATCHDOG_ERROR);
         return FALSE;
       }
       elseif ($e->getCode() == '404') {

--- a/islandora.module
+++ b/islandora.module
@@ -1226,7 +1226,7 @@ function islandora_object_load($object_id) {
       return $tuque->repository->getObject(urldecode($object_id));
     }
     catch (Exception $e) {
-      // Check to see if invalid PID was passed
+      // Check to see if tuque failure is due to invalid PID.
       module_load_include('inc', 'islandora', 'includes/utilities');
       if (!islandora_is_valid_pid($object_id)) {
         watchdog('islandora', 'Failed to load invalid PID: @pid', array('@pid' => $object_id), WATCHDOG_ERROR);

--- a/islandora.module
+++ b/islandora.module
@@ -1230,7 +1230,14 @@ function islandora_object_load($object_id) {
         return FALSE;
       }
       else {
-        return NULL;
+        module_load_include('inc', 'islandora', 'includes/utilities');
+        if (!islandora_is_valid_pid($object_id)) {
+          watchdog('islandora', 'Failed to load invalid PID: @pid', array('@pid' => $object_id), WATCHDOG_ERROR);
+          return FALSE;
+        }
+        else {
+          return NULL;
+        }
       }
     }
   }

--- a/islandora.module
+++ b/islandora.module
@@ -1226,18 +1226,17 @@ function islandora_object_load($object_id) {
       return $tuque->repository->getObject(urldecode($object_id));
     }
     catch (Exception $e) {
-      if ($e->getCode() == '404') {
+      // Check to see if invalid PID was passed
+      module_load_include('inc', 'islandora', 'includes/utilities');
+      if (!islandora_is_valid_pid($object_id)) {
+        watchdog('islandora', 'Failed to load invalid PID: @pid', array('@pid' => $object_id), WATCHDOG_ERROR);
+        return FALSE;
+      }
+      elseif ($e->getCode() == '404') {
         return FALSE;
       }
       else {
-        module_load_include('inc', 'islandora', 'includes/utilities');
-        if (!islandora_is_valid_pid($object_id)) {
-          watchdog('islandora', 'Failed to load invalid PID: @pid', array('@pid' => $object_id), WATCHDOG_ERROR);
-          return FALSE;
-        }
-        else {
-          return NULL;
-        }
+        return NULL;
       }
     }
   }


### PR DESCRIPTION
**JIRA Ticket**: [ISLANDORA-2043](https://jira.duraspace.org/browse/ISLANDORA-2043)

# What does this Pull Request do?
A check has been added to see if the PID passed to `islandora_object_load()` is malformed when tuque fails to load it, returning a 404 instead of a 403.

# What's new?
- Calls `islandora_is_valid_pid()` when `islandora_object_load()` catches an exception from tuque, and logs a watchdog error noting the offending PID.

# How should this be tested?
Try to load malformed pids via `/islandora/object/<PID>` and check `/admin/reports/dblog` after.

The following malformed PIDs were tested:
- `islandora` (returned a 404 originally but was not logged, now it is)
- `islandora:` (returned a 404 originally but was not logged, now it is)
- `islandora:*`
- `islandora:test*ing`
- `islandora:islandora;`
- `islandora:islandora:islandora`

# Additional Notes:
While PIDS with two colons (eg, `islandora:islandora:islandora`) were returning a 403 from Fedora, PIDS with no colons (eg, `islandora` or `islandora_islandora`) were getting 404s and not yielding the 403 page. The check for invalid PIDs was added before a check to see if Fedora returned 404 in order to catch all malformed PIDs and log them.

# Interested parties
@Islandora/7-x-1-x-committers
