### PR TITLE
Release PR for ISLANDORA-2043

### DIFF
--- a/islandora.module
+++ b/islandora.module
@@ -1226,7 +1226,12 @@ function islandora_object_load($object_id) {
       return $tuque->repository->getObject(urldecode($object_id));
     }
     catch (Exception $e) {
-      if ($e->getCode() == '404') {
+      // Check to see if tuque failure is due to invalid PID.
+      module_load_include('inc', 'islandora', 'includes/utilities');
+      if (!islandora_is_valid_pid($object_id)) {
+        return FALSE;
+      }
+      elseif ($e->getCode() == '404') {
         return FALSE;
       }
       else {


### PR DESCRIPTION
**JIRA Ticket**: [ISLANDORA-2043](https://jira.duraspace.org/browse/ISLANDORA-2043)

# What does this Pull Request do?
This is a release branch PR for https://github.com/Islandora/islandora/pull/689.

A check has been added to see if the PID passed to `islandora_object_load()` is malformed when tuque fails to load it, returning a 404 instead of a 403.

# What's new?
- Calls `islandora_is_valid_pid()` when `islandora_object_load()` catches an exception from tuque.

# How should this be tested?
Try to load malformed pids via `/islandora/object/<PID>` and check `/admin/reports/dblog` after.

The following malformed PIDs were tested:
- `islandora` (returned a 404 originally)
- `islandora:` (returned a 404 originally)
- `islandora:*`
- `islandora:test*ing`
- `islandora:islandora;`
- `islandora:islandora:islandora`

# Additional Notes:
While PIDS with two colons (eg, `islandora:islandora:islandora`) were returning a 403 from Fedora, PIDS with no colons (eg, `islandora` or `islandora_islandora`) were getting 404s and not yielding the 403 page. The check for invalid PIDs was added before a check to see if Fedora returned 404 in order to catch all malformed PIDs and log them.

# Interested parties
@Islandora/7-x-1-x-committers
