### PR TITLE
Revert "ISLANDORA-1985 Permission to access inactive or deleted"

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -138,12 +138,6 @@ function islandora_repository_admin(array $form, array &$form_state) {
           '#description' => t('During the ingest workflow, make the OBJ file upload step mandatory.'),
           '#default_value' => variable_get('islandora_require_obj_upload', TRUE),
         ),
-        'islandora_deny_inactive_and_deleted' => array(
-          '#type' => 'checkbox',
-          '#title' => t('Lock down inactive and deleted objects.'),
-          '#description' => t('Deny access to inactive or deleted objects using a separate permission than for active objects.'),
-          '#default_value' => variable_get('islandora_deny_inactive_and_deleted', FALSE),
-        ),
       ),
       'islandora_namespace' => array(
         '#type' => 'fieldset',

--- a/includes/object_properties.form.inc
+++ b/includes/object_properties.form.inc
@@ -19,9 +19,6 @@
  *   The drupal form definition.
  */
 function islandora_object_properties_form(array $form, array &$form_state, AbstractObject $object) {
-  if (isset($form_state['islandora']['needs_confirmation'])) {
-    return islandora_object_properties_confirm_form($form_state);
-  }
   $form_state['object'] = $object;
   $temp = islandora_invoke_hook_list(ISLANDORA_UPDATE_RELATED_OBJECTS_PROPERTIES_HOOK, $object->models, array($object));
   $related_objects_pids = array();
@@ -113,22 +110,6 @@ function islandora_object_properties_form(array $form, array &$form_state, Abstr
  *   The Drupal form state.
  */
 function islandora_object_properties_form_submit(array $form, array &$form_state) {
-  if (isset($form_state['islandora']['needs_confirmation'])) {
-    $form_state['values'] = $form_state['islandora']['values'];
-  }
-  else {
-    // Confirm if user is about to lock themselves out of this object.
-    if (variable_get('islandora_deny_inactive_and_deleted', FALSE) && in_array($form_state['values']['object_state'], array('I', 'D'))) {
-      if ($form_state['object']->state == 'A') {
-        if (!user_access(ISLANDORA_ACCESS_INACTIVE_AND_DELETED_OBJECTS)) {
-          $form_state['islandora']['needs_confirmation'] = TRUE;
-          $form_state['islandora']['values'] = $form_state['values'];
-          $form_state['rebuild'] = TRUE;
-          return;
-        }
-      }
-    }
-  }
   $object = $form_state['object'];
   $owner = $form_state['values']['object_owner'];
   $state = $form_state['values']['object_state'];
@@ -232,21 +213,4 @@ function islandora_update_object_properties($pid, $update_states, $state, $updat
  */
 function islandora_object_properties_regenerate_derivatives(array $form, array &$form_state) {
   drupal_goto("islandora/object/{$form_state['object']}/regenerate");
-}
-
-/**
- * Confirmation form for object properties admin form.
- *
- * @param array $form_state
- *   The Drupal form state.
- */
-function islandora_object_properties_confirm_form(array &$form_state) {
-  $desc = t('You do not have permission to view Inactive or Deleted objects, so you will no longer be able to view or manage this object. Are you sure?');
-  $path = "islandora/object/{$form_state['object']->id}/manage/properties";
-  return confirm_form(array(),
-    t('Are you sure you want to set the object state?'),
-    $path,
-    $desc,
-    t('Continue'),
-    t('Cancel'));
 }

--- a/islandora.module
+++ b/islandora.module
@@ -34,7 +34,6 @@ define('ISLANDORA_INGEST', 'ingest fedora objects');
 define('ISLANDORA_PURGE', 'delete fedora objects and datastreams');
 define('ISLANDORA_MANAGE_PROPERTIES', 'manage object properties');
 define('ISLANDORA_VIEW_DATASTREAM_HISTORY', 'view old datastream versions');
-define('ISLANDORA_ACCESS_INACTIVE_AND_DELETED_OBJECTS', 'access inactive and deleted objects');
 define('ISLANDORA_MANAGE_DELETED_OBJECTS', 'manage deleted objects');
 define('ISLANDORA_REVERT_DATASTREAM', 'revert to old datastream');
 define('ISLANDORA_REGENERATE_DERIVATIVES', 'regenerate derivatives for an object');
@@ -579,7 +578,7 @@ function islandora_theme() {
  * Implements hook_permission().
  */
 function islandora_permission() {
-  $permissions = array(
+  return array(
     ISLANDORA_VIEW_OBJECTS => array(
       'title' => t('View repository objects'),
       'description' => t('View objects in the repository. Note: Fedora XACML security policies may override this permission.'),
@@ -625,13 +624,6 @@ function islandora_permission() {
       'description' => t('Add new datastream content as latest version.'),
     ),
   );
-  if (variable_get('islandora_deny_inactive_and_deleted', FALSE)) {
-    $permissions[ISLANDORA_ACCESS_INACTIVE_AND_DELETED_OBJECTS] = array(
-      'title' => t('Access inactive and deleted objects'),
-      'description' => t('Access objects with a Fedora state of Inactive or Deleted.'),
-    );
-  }
-  return $permissions;
 }
 
 /**
@@ -1698,11 +1690,8 @@ function islandora_object_access($op, $object, $user = NULL) {
  */
 function islandora_islandora_object_access($op, $object, $user) {
   module_load_include('inc', 'islandora', 'includes/utilities');
-  $access = (islandora_namespace_accessible($object->id) && user_access($op, $user));
-  if (($object->state != 'A') && variable_get('islandora_deny_inactive_and_deleted', FALSE)) {
-    $access = ($access && user_access(ISLANDORA_ACCESS_INACTIVE_AND_DELETED_OBJECTS, $user));
-  }
-  return $access;
+
+  return islandora_namespace_accessible($object->id) && user_access($op, $user);
 }
 
 /**


### PR DESCRIPTION
This reverts commit 4f3aefd5ecf222173ce0a66bbc22767aabe9597c. It did not work, and
to make it work requires fixing an underlying issue of datastream permissions being
independent from object permissions.

**JIRA Ticket**: This undoes the problematic fix for https://jira.duraspace.org/browse/ISLANDORA-1985
because of https://jira.duraspace.org/browse/ISLANDORA-2073 

and discussion on https://github.com/Islandora/islandora/pull/685

# What does this Pull Request do?

Removes the permission to view inactive and deleted objects (but leaves it in the uninstall hook, since it was added before code freeze). 

# How should this be tested?
Ensure the new permission is not listed, the toggle is not available, and a user with "view fedora objects" permissions can directly navigate to (and see) an inactive or deleted object. 


# Additional Notes:
Any additional information that you think would be helpful when reviewing this PR.

Example:
* Does this change require documentation to be updated? Yes, for the release only.
* Does this change add any new dependencies? no.
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)?  no. 
* Could this change impact execution of existing code? no. 

# Interested parties
@DiegoPino @Islandora/7-x-1-x-committers 