### PR TITLE
Handle derivatives of itself.

### DIFF
--- a/includes/delete_datastream.form.inc
+++ b/includes/delete_datastream.form.inc
@@ -73,7 +73,7 @@ function islandora_datastream_to_purge(AbstractObject $object, $dsid) {
   module_load_include('inc', 'islandora', 'includes/utilities');
   $hooks = islandora_invoke_hook_list(ISLANDORA_DERIVATIVE_CREATION_HOOK, $object->models, array($object));
   $hook_filter = function ($hook_def) use ($dsid) {
-    return isset($hook_def['source_dsid']) && isset($hook_def['destination_dsid']) ?
+    return isset($hook_def['source_dsid']) && isset($hook_def['destination_dsid']) && $hook_def['destination_dsid'] != $dsid ?
       $hook_def['source_dsid'] == $dsid :
       FALSE;
   };

--- a/includes/delete_datastream.form.inc
+++ b/includes/delete_datastream.form.inc
@@ -73,8 +73,8 @@ function islandora_datastream_to_purge(AbstractObject $object, $dsid) {
   module_load_include('inc', 'islandora', 'includes/utilities');
   $hooks = islandora_invoke_hook_list(ISLANDORA_DERIVATIVE_CREATION_HOOK, $object->models, array($object));
   $hook_filter = function ($hook_def) use ($dsid) {
-    return isset($hook_def['source_dsid']) && isset($hook_def['destination_dsid']) && $hook_def['destination_dsid'] != $dsid ?
-      $hook_def['source_dsid'] == $dsid :
+    return isset($hook_def['source_dsid']) && isset($hook_def['destination_dsid']) ?
+      ($hook_def['source_dsid'] == $dsid && $hook_def['destination_dsid'] != $dsid) :
       FALSE;
   };
   $hooks = array_filter($hooks, $hook_filter);


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2119

# What does this Pull Request do?

When a derivative that has an equivalent source_dsid and destination_dsid the delete datastream form does not render as there's non-terminating recursion.

# What's new?
The form renders successfully when this case is encountered.

# How should this be tested?
Define a derivative hook implementation defined with the source_dsid and destination_dsid being equivalent (https://gist.github.com/jordandukart/b488ea8bdfe62a90754f9578ece1acb0 for an example).
If using the example Gist create a new datastream 'TEST' using the txt file as the content by going to /islandora/object/pid/manage/datastreams/add.
Navigate to /islandora/object/pid/datastream/TEST/delete
Note that you get a white screen with a recursion error.
Pull code attempt again, things work as expected.

# Interested parties
@Islandora/7-x-1-x-committers
