### PR TITLE
Add orphaned objects capability to core

### DIFF
--- a/includes/orphaned_objects.inc
+++ b/includes/orphaned_objects.inc
@@ -6,7 +6,7 @@
  */
 
 /**
- * Builds the management form for the Orphaned Objects module.
+ * Builds the Orphaned Islandora Objects management form.
  *
  * @param array $form
  *   An array representing a form within Drupal.
@@ -37,7 +37,7 @@ function islandora_orphaned_objects_manage_form($form, $form_state) {
     );
   }
   else {
-    $orphaned_objects = islandora_orphaned_objects_get_orphaned_objects();
+    $orphaned_objects = islandora_get_orphaned_objects();
     $rows = array();
     foreach ($orphaned_objects as $orphaned_object) {
       $pid = $orphaned_object['object']['value'];
@@ -124,7 +124,7 @@ function islandora_orphaned_objects_manage_confirm_submit($form, &$form_state) {
  * @return array
  *   An array containing the results of the orphaned objects queries.
  */
-function islandora_orphaned_objects_get_orphaned_objects() {
+function islandora_get_orphaned_objects() {
   $connection = islandora_get_tuque_connection();
   // SPARQL: get orphaned objects, exclude any with a living parent.
   $object_query = <<<EOQ
@@ -196,7 +196,7 @@ function islandora_orphaned_objects_delete_create_batch($pids) {
     'progress_message' => t('Time elapsed: @elapsed <br/>Estimated time remaining @estimate.'),
     'error_message' => t('An error has occurred.'),
     'finished' => 'islandora_orphaned_objects_delete_batch_finished',
-    'file' => drupal_get_path('module', 'islandora_orphaned_objects') . '/includes/batch.inc',
+    'file' => drupal_get_path('module', 'islandora') . '/includes/orphaned_objects.inc',
   );
   return $batch;
 }

--- a/includes/orphaned_objects.inc
+++ b/includes/orphaned_objects.inc
@@ -243,7 +243,13 @@ function islandora_delete_orphaned_objects_batch_operation($pids, &$context) {
         '@total' => $context['sandbox']['total'],
     ));
     islandora_delete_object($target_object);
-    $context['results']['success'][] = $target_pid;
+    $object_check = islandora_object_load($target_pid);
+    if ($object_check) {
+      drupal_set_message(t('Could not delete ' . $target_pid . '. You may not have permission to manage this object.'), 'error');
+    }
+    else {
+      $context['results']['success'][] = $target_pid;
+    }
     $context['sandbox']['progress']++;
   }
   $context['finished'] = ($context['sandbox']['total'] == 0) ? 1 : ($context['sandbox']['progress'] / $context['sandbox']['total']);

--- a/includes/orphaned_objects.inc
+++ b/includes/orphaned_objects.inc
@@ -140,29 +140,17 @@ function islandora_orphaned_objects_get_orphaned_objects() {
   $connection = islandora_get_tuque_connection();
   // First query: get standard objects.
   $object_query = <<<EOQ
-SELECT ?object ?collection ?title
+SELECT ?object ?otherobject ?title ?p
 WHERE {
   ?object <fedora-model:hasModel> <info:fedora/fedora-system:FedoraObject-3.0> ;
-               <fedora-rels-ext:isMemberOfCollection> ?collection .
-  ?object <fedora-model:label> ?title;
-  OPTIONAL {
-    ?collection <fedora-model:hasModel> ?model .
-  }
-  FILTER(!bound(?model))
-}
-EOQ;
-  // Second query: get paged objects.
-  $paged_query = <<<EOQ
-SELECT ?object ?book ?title
-WHERE {
-  ?object <fedora-model:hasModel> <info:fedora/fedora-system:FedoraObject-3.0> ;
-             <fedora-rels-ext:isMemberOf> ?book .
-  ?object <fedora-model:label> ?title;
-  OPTIONAL {
-    ?book <fedora-model:hasModel> ?model .
-  }
+               ?p ?otherobject .
+   ?object <fedora-model:label> ?title;
+   FILTER( regex( str(?p), "/fedora-system:def/relations-external#"))
+   OPTIONAL {
+     ?otherobject <fedora-model:hasModel> ?model .
+   }
    FILTER(!bound(?model))
-  }
+}
 EOQ;
   $optionals = (array) module_invoke('islandora_xacml_api', 'islandora_basic_collection_get_query_optionals', 'view');
   $filter_modules = array(
@@ -181,14 +169,7 @@ EOQ;
     '!optionals' => !empty($optionals) ? ('OPTIONAL {{' . implode('} UNION {', $optionals) . '}}') : '',
     '!filters' => !empty($filters) ? implode(' ', array_map($filter_map, $filters)) : '',
   ));
-  $sparql_query_paged = format_string($paged_query, array(
-    '!optionals' => !empty($optionals) ? ('OPTIONAL {{' . implode('} UNION {', $optionals) . '}}') : '',
-    '!filters' => !empty($filters) ? implode(' ', array_map($filter_map, $filters)) : '',
-  ));
-  $object_results = $connection->repository->ri->sparqlQuery($sparql_query_objects);
-  $paged_results = $connection->repository->ri->sparqlQuery($sparql_query_paged);
-  // Merge results of both queries into a single variable and return.
-  $results = array_merge($object_results, $paged_results);
+  $results = $connection->repository->ri->sparqlQuery($sparql_query_objects);
   return $results;
 }
 

--- a/includes/orphaned_objects.inc
+++ b/includes/orphaned_objects.inc
@@ -129,7 +129,7 @@ function islandora_orphaned_objects_get_orphaned_objects() {
   // SPARQL: get orphaned objects, exclude any with a living parent.
   $object_query = <<<EOQ
 PREFIX islandora: <http://islandora.ca/ontology/relsext#>
-SELECT ?object ?p ?otherobject ?title 
+SELECT DISTINCT ?object ?title 
 WHERE {
   ?object <fedora-model:hasModel> <info:fedora/fedora-system:FedoraObject-3.0> ;
                ?p ?otherobject .

--- a/includes/orphaned_objects.inc
+++ b/includes/orphaned_objects.inc
@@ -18,11 +18,23 @@
  */
 function islandora_orphaned_objects_manage_form($form, $form_state) {
   if (isset($form_state['show_confirm'])) {
+    $pids = $form_state['pids_to_delete'];
+    if (count($form_state['pids_to_delete']) == 1) {
+      $pid_paths = '<a href="/islandora/object/' . $pids[0] . '" target="_blank">' . $pids[0] . '</a>';
+    } 
+   elseif (count($form_state['pids_to_delete']) <= 10) {
+      $pid_paths = '<ul>';
+      foreach($pids as $pid) {
+        $pid_paths = $pid_paths . '<li><a href="/islandora/object/' . $pid . '" target="_blank">' . $pid . '</a></li>';
+        $pid_links[] = '<a href="/islandora/object/' . $pid . '">' . $pid . '</a>';
+      }
+      $pid_paths = $pid_paths . '</ul>';
+    }
     $form['confirm_message'] = array(
       '#type' => 'item',
       '#markup' => format_plural(count($form_state['pids_to_delete']),
-      'Are you sure you want to delete the 1 object?',
-      'Are you sure you want to delete the @count objects?'),
+      'Are you sure you want to delete the object ' . $pid_paths . '? This action cannot be reversed.',
+      'Are you sure you want to delete these @count objects? This action cannot be reversed.' . $pid_paths),
     );
     $form['confirm_submit'] = array(
       '#type' => 'submit',

--- a/includes/orphaned_objects.inc
+++ b/includes/orphaned_objects.inc
@@ -138,20 +138,33 @@ function islandora_orphaned_objects_manage_confirm_submit($form, &$form_state) {
  */
 function islandora_orphaned_objects_get_orphaned_objects() {
   $connection = islandora_get_tuque_connection();
-  // First query: get standard objects.
+  // SPARQL: get orphaned objects, exclude any with a living parent.
   $object_query = <<<EOQ
-SELECT ?object ?otherobject ?title ?p
+PREFIX islandora: <http://islandora.ca/ontology/relsext#>
+SELECT ?object ?p ?otherobject ?title 
 WHERE {
   ?object <fedora-model:hasModel> <info:fedora/fedora-system:FedoraObject-3.0> ;
                ?p ?otherobject .
    ?object <fedora-model:label> ?title;
-   FILTER( regex( str(?p), "/fedora-system:def/relations-external#"))
-   OPTIONAL {
-     ?otherobject <fedora-model:hasModel> ?model .
-   }
-   FILTER(!bound(?model))
+  OPTIONAL {
+    ?otherobject <fedora-model:hasModel> ?model .
+  } .
+  FILTER (!bound(?model))
+
+  # Filter by "parent" relationships - isMemberOf, isMemberOfCollection, isPageOf. 
+  FILTER (?p = <fedora-rels-ext:isMemberOfCollection> || ?p = <fedora-rels-ext:isMemberOf> || ?p = <islandora:isPageOf>)
+ 
+# Exclude objects with live parents - isMemberOf, isMemberOfCollection, isPageOf.
+ OPTIONAL {
+    {?object <fedora-rels-ext:isMemberOfCollection> ?liveparent }
+    UNION {?object <fedora-rels-ext:isMemberOf> ?liveparent } 
+    UNION { ?object <islandora:isPageOf> ?liveparent } .
+   ?liveparent <fedora-model:hasModel> <info:fedora/fedora-system:FedoraObject-3.0> .
+  }
+  FILTER (!bound(?liveparent))
 }
 EOQ;
+
   $optionals = (array) module_invoke('islandora_xacml_api', 'islandora_basic_collection_get_query_optionals', 'view');
   $filter_modules = array(
     'islandora_xacml_api',

--- a/includes/orphaned_objects.inc
+++ b/includes/orphaned_objects.inc
@@ -6,18 +6,6 @@
  */
 
 /**
- * Implements hook_permission().
- */
-function islandora_orphaned_objects_permission() {
-  return array(
-    'manage orphaned objects' => array(
-      'title' => t('Manage orphaned Islandora objects'),
-      'description' => t('View a list of orphaned Islandora objects.'),
-    ),
-  );
-}
-
-/**
  * Builds the management form for the Orphaned Objects module.
  *
  * @param array $form

--- a/includes/orphaned_objects.inc
+++ b/includes/orphaned_objects.inc
@@ -49,6 +49,8 @@ function islandora_orphaned_objects_manage_form($form, $form_state) {
     );
   }
   else {
+    drupal_set_message(t('Some objects may intentionally have no parents. If deleting objects, please be 
+    absolutely sure that these objects are no longer required.'), 'warning');
     $orphaned_objects = islandora_get_orphaned_objects();
     $rows = array();
     foreach ($orphaned_objects as $orphaned_object) {

--- a/includes/orphaned_objects.inc
+++ b/includes/orphaned_objects.inc
@@ -149,8 +149,10 @@ WHERE {
     UNION { ?object <islandora:isPageOf> ?liveparent } .
    ?liveparent <fedora-model:hasModel> <info:fedora/fedora-system:FedoraObject-3.0> .
   }
+  !optionals
+  !filters
   FILTER (!bound(?liveparent))
-}
+} ORDER BY ?object
 EOQ;
 
   $optionals = (array) module_invoke('islandora_xacml_api', 'islandora_basic_collection_get_query_optionals', 'view');

--- a/includes/orphaned_objects.inc
+++ b/includes/orphaned_objects.inc
@@ -19,22 +19,18 @@
 function islandora_manage_orphaned_objects_form($form, $form_state) {
   if (isset($form_state['show_confirm'])) {
     $pids = $form_state['pids_to_delete'];
-    if (count($form_state['pids_to_delete']) == 1) {
-      $pid_paths = '<a href="/islandora/object/' . $pids[0] . '" target="_blank">' . $pids[0] . '</a>';
-    }
-    elseif (count($form_state['pids_to_delete']) <= 10) {
+    if (count($form_state['pids_to_delete']) <= 10) {
       $pid_paths = '<ul>';
       foreach ($pids as $pid) {
         $pid_paths = $pid_paths . '<li><a href="/islandora/object/' . $pid . '" target="_blank">' . $pid . '</a></li>';
-        $pid_links[] = '<a href="/islandora/object/' . $pid . '">' . $pid . '</a>';
       }
       $pid_paths = $pid_paths . '</ul>';
     }
     $form['confirm_message'] = array(
       '#type' => 'item',
       '#markup' => format_plural(count($form_state['pids_to_delete']),
-      'Are you sure you want to delete the object ' . $pid_paths . '? This action cannot be reversed.',
-      'Are you sure you want to delete these @count objects? This action cannot be reversed.' . $pid_paths),
+      'Are you sure you want to delete this object? This action cannot be reversed.',
+      'Are you sure you want to delete these @count objects? This action cannot be reversed.') . $pid_paths,
     );
     $form['confirm_submit'] = array(
       '#type' => 'submit',

--- a/includes/orphaned_objects.inc
+++ b/includes/orphaned_objects.inc
@@ -238,7 +238,7 @@ function islandora_delete_orphaned_objects_batch_operation($pids, &$context) {
     $target_object = islandora_object_load($target_pid);
     $context['message'] = t('Deleting @label (@pid) (@current of @total)...', array(
         '@label' => $target_object->label,
-        '@pid' => $target_object->pid,
+        '@pid' => $target_pid,
         '@current' => $context['sandbox']['progress'],
         '@total' => $context['sandbox']['total'],
     ));

--- a/includes/orphaned_objects.inc
+++ b/includes/orphaned_objects.inc
@@ -11,8 +11,8 @@
 function islandora_orphaned_objects_permission() {
   return array(
     'manage orphaned objects' => array(
-      'title' => t('Manage orphaned objects'),
-      'description' => t('View a list of orphaned objects.'),
+      'title' => t('Manage orphaned Islandora objects'),
+      'description' => t('View a list of orphaned Islandora objects.'),
     ),
   );
 }

--- a/includes/orphaned_objects.inc
+++ b/includes/orphaned_objects.inc
@@ -1,0 +1,268 @@
+<?php
+
+/**
+ * @file
+ * A list of orphaned Islandora objects.
+ */
+
+/**
+ * Implements hook_permission().
+ */
+function islandora_orphaned_objects_permission() {
+  return array(
+    'manage orphaned objects' => array(
+      'title' => t('Manage orphaned objects'),
+      'description' => t('View a list of orphaned objects.'),
+    ),
+  );
+}
+
+/**
+ * Builds the management form for the Orphaned Objects module.
+ *
+ * @param array $form
+ *   An array representing a form within Drupal.
+ * @param array $form_state
+ *   An array containing the Drupal form state.
+ *
+ * @return array
+ *   An array containing the form to be rendered.
+ */
+function islandora_orphaned_objects_manage_form($form, $form_state) {
+  if (isset($form_state['show_confirm'])) {
+    $form['confirm_message'] = array(
+      '#type' => 'item',
+      '#markup' => format_plural(count($form_state['pids_to_delete']),
+      'Are you sure you want to delete the 1 object?',
+      'Are you sure you want to delete the @count objects?'),
+    );
+    $form['confirm_submit'] = array(
+      '#type' => 'submit',
+      '#value' => t('Confirm'),
+      '#weight' => 2,
+      '#submit' => array('islandora_orphaned_objects_manage_confirm_submit'),
+    );
+    $form['cancel_submit'] = array(
+      '#type' => 'submit',
+      '#value' => t('Cancel'),
+      '#weight' => 3,
+    );
+  }
+  else {
+    $orphaned_objects = islandora_orphaned_objects_get_orphaned_objects();
+    $rows = array();
+    foreach ($orphaned_objects as $orphaned_object) {
+      $pid = $orphaned_object['object']['value'];
+      if (islandora_namespace_accessible($pid)) {
+        $rows[$pid] = array(l($orphaned_object['title']['value'] . " (" . $pid . ")", "islandora/object/$pid"));
+      }
+    }
+    ksort($rows);
+    $form['management_table'] = array(
+      '#type' => 'tableselect',
+      '#header' => array(t('Object')),
+      '#options' => $rows,
+      '#attributes' => array(),
+      '#empty' => t('No orphaned objects were found.'),
+    );
+    if (!empty($rows)) {
+      $form['submit_selected'] = array(
+        '#type' => 'submit',
+        '#name' => 'islandora-orphaned-objects-submit-selected',
+        '#validate' => array('islandora_orphaned_objects_manage_delete_selected_validate'),
+        '#submit' => array('islandora_orphaned_objects_manage_delete_submit'),
+        '#value' => t('Delete Selected'),
+      );
+      $form['submit_all'] = array(
+        '#type' => 'submit',
+        '#name' => 'islandora-orphaned-objects-submit-all',
+        '#submit' => array('islandora_orphaned_objects_manage_delete_submit'),
+        '#value' => t('Delete All'),
+      );
+    }
+  }
+  return $form;
+}
+/**
+ * Validation for the Islandora Orphaned Objects management form.
+ *
+ * @param array $form
+ *   An array representing a form within Drupal.
+ * @param array $form_state
+ *   An array containing the Drupal form state.
+ */
+function islandora_orphaned_objects_manage_delete_selected_validate($form, $form_state) {
+  $selected = array_filter($form_state['values']['management_table']);
+  if (empty($selected)) {
+    form_error($form['management_table'], t('At least one object must be selected to delete!'));
+  }
+}
+/**
+ * Submit handler for the delete buttons in the workflow management form.
+ *
+ * @param array $form
+ *   An array representing a form within Drupal.
+ * @param array $form_state
+ *   An array containing the Drupal form state.
+ */
+function islandora_orphaned_objects_manage_delete_submit(&$form, &$form_state) {
+  if ($form_state['triggering_element']['#name'] == 'islandora-orphaned-objects-submit-selected') {
+    $selected = array_keys(array_filter($form_state['values']['management_table']));
+  }
+  else {
+    $selected = array_keys($form_state['values']['management_table']);
+  }
+  $form_state['pids_to_delete'] = $selected;
+  // Rebuild to show the confirm form.
+  $form_state['rebuild'] = TRUE;
+  $form_state['show_confirm'] = TRUE;
+}
+/**
+ * Submit handler for the workflow management confirm form.
+ *
+ * @param array $form
+ *   An array representing a form within Drupal.
+ * @param array $form_state
+ *   An array containing the Drupal form state.
+ */
+function islandora_orphaned_objects_manage_confirm_submit($form, &$form_state) {
+  $batch = islandora_orphaned_objects_delete_create_batch($form_state['pids_to_delete']);
+  batch_set($batch);
+}
+
+/**
+ * Query for orphaned objects.
+ *
+ * @return array
+ *   An array containing the results of the orphaned objects queries.
+ */
+function islandora_orphaned_objects_get_orphaned_objects() {
+  $connection = islandora_get_tuque_connection();
+  // First query: get standard objects.
+  $object_query = <<<EOQ
+SELECT ?object ?collection ?title
+WHERE {
+  ?object <fedora-model:hasModel> <info:fedora/fedora-system:FedoraObject-3.0> ;
+               <fedora-rels-ext:isMemberOfCollection> ?collection .
+  ?object <fedora-model:label> ?title;
+  OPTIONAL {
+    ?collection <fedora-model:hasModel> ?model .
+  }
+  FILTER(!bound(?model))
+}
+EOQ;
+  // Second query: get paged objects.
+  $paged_query = <<<EOQ
+SELECT ?object ?book ?title
+WHERE {
+  ?object <fedora-model:hasModel> <info:fedora/fedora-system:FedoraObject-3.0> ;
+             <fedora-rels-ext:isMemberOf> ?book .
+  ?object <fedora-model:label> ?title;
+  OPTIONAL {
+    ?book <fedora-model:hasModel> ?model .
+  }
+   FILTER(!bound(?model))
+  }
+EOQ;
+  $optionals = (array) module_invoke('islandora_xacml_api', 'islandora_basic_collection_get_query_optionals', 'view');
+  $filter_modules = array(
+    'islandora_xacml_api',
+    'islandora',
+  );
+  $filters = array();
+  foreach ($filter_modules as $module) {
+    $filters = array_merge_recursive($filters, (array) module_invoke($module, 'islandora_basic_collection_get_query_filters', 'view'));
+  }
+  $filter_map = function ($filter) {
+    return "FILTER($filter)";
+  };
+  // Use separate queries for different object types.
+  $sparql_query_objects = format_string($object_query, array(
+    '!optionals' => !empty($optionals) ? ('OPTIONAL {{' . implode('} UNION {', $optionals) . '}}') : '',
+    '!filters' => !empty($filters) ? implode(' ', array_map($filter_map, $filters)) : '',
+  ));
+  $sparql_query_paged = format_string($paged_query, array(
+    '!optionals' => !empty($optionals) ? ('OPTIONAL {{' . implode('} UNION {', $optionals) . '}}') : '',
+    '!filters' => !empty($filters) ? implode(' ', array_map($filter_map, $filters)) : '',
+  ));
+  $object_results = $connection->repository->ri->sparqlQuery($sparql_query_objects);
+  $paged_results = $connection->repository->ri->sparqlQuery($sparql_query_paged);
+  // Merge results of both queries into a single variable and return.
+  $results = array_merge($object_results, $paged_results);
+  return $results;
+}
+
+/**
+ * Constructs the batch that will go out and delete objects.
+ *
+ * @param array $pids
+ *   The array of pids to be deleted.
+ *
+ * @return array
+ *   An array detailing the batch that is about to be run.
+ */
+function islandora_orphaned_objects_delete_create_batch($pids) {
+  // Set up a batch operation.
+  $batch = array(
+    'operations' => array(
+      array('islandora_orphaned_objects_delete_batch_operation', array($pids)),
+    ),
+    'title' => t('Deleting the selected objects...'),
+    'init_message' => t('Preparing to delete objects.'),
+    'progress_message' => t('Time elapsed: @elapsed <br/>Estimated time remaining @estimate.'),
+    'error_message' => t('An error has occurred.'),
+    'finished' => 'islandora_orphaned_objects_delete_batch_finished',
+    'file' => drupal_get_path('module', 'islandora_orphaned_objects') . '/includes/batch.inc',
+  );
+  return $batch;
+}
+/**
+ * Constructs and performs the deleting batch operation.
+ *
+ * @param array $pids
+ *   An array of pids to be deleted.
+ * @param array $context
+ *   The context of the Drupal batch.
+ */
+function islandora_orphaned_objects_delete_batch_operation($pids, &$context) {
+  if (empty($context['sandbox'])) {
+    $context['sandbox'] = array();
+    $context['sandbox']['progress'] = 0;
+    $context['sandbox']['pids'] = $pids;
+    $context['sandbox']['total'] = count($pids);
+    $context['results']['success'] = array();
+  }
+  if (!empty($context['sandbox']['pids'])) {
+    $target_pid = array_pop($context['sandbox']['pids']);
+    $target_object = islandora_object_load($target_pid);
+    $context['message'] = t('Deleting @label (@pid) (@current of @total)...', array(
+        '@label' => $target_object->label,
+        '@pid' => $target_object->pid,
+        '@current' => $context['sandbox']['progress'],
+        '@total' => $context['sandbox']['total'],
+    ));
+    islandora_delete_object($target_object);
+    $context['results']['success'][] = $target_pid;
+    $context['sandbox']['progress']++;
+  }
+  $context['finished'] = ($context['sandbox']['total'] == 0) ? 1 : ($context['sandbox']['progress'] / $context['sandbox']['total']);
+}
+/**
+ * Finished function for the orphaned objects delete batch.
+ *
+ * @param bool $success
+ *   Whether the batch was successful or not.
+ * @param array $results
+ *   An array containing the results of the batch operations.
+ * @param array $operations
+ *   The operations array that was used in the batch.
+ */
+function islandora_orphaned_objects_delete_batch_finished($success, $results, $operations) {
+  if ($success) {
+    $message = format_plural(count($results['success']), 'One object deleted.', '@count objects deleted.');
+  }
+  else {
+    $message = t('Finished with an error.');
+  }
+  drupal_set_message($message);
+}

--- a/includes/orphaned_objects.inc
+++ b/includes/orphaned_objects.inc
@@ -21,10 +21,10 @@ function islandora_manage_orphaned_objects_form($form, $form_state) {
     $pids = $form_state['pids_to_delete'];
     if (count($form_state['pids_to_delete']) == 1) {
       $pid_paths = '<a href="/islandora/object/' . $pids[0] . '" target="_blank">' . $pids[0] . '</a>';
-    } 
-   elseif (count($form_state['pids_to_delete']) <= 10) {
+    }
+    elseif (count($form_state['pids_to_delete']) <= 10) {
       $pid_paths = '<ul>';
-      foreach($pids as $pid) {
+      foreach ($pids as $pid) {
         $pid_paths = $pid_paths . '<li><a href="/islandora/object/' . $pid . '" target="_blank">' . $pid . '</a></li>';
         $pid_links[] = '<a href="/islandora/object/' . $pid . '">' . $pid . '</a>';
       }

--- a/includes/orphaned_objects.inc
+++ b/includes/orphaned_objects.inc
@@ -20,18 +20,28 @@ function islandora_manage_orphaned_objects_form($form, $form_state) {
   if (isset($form_state['show_confirm'])) {
     $pids = $form_state['pids_to_delete'];
     if (count($form_state['pids_to_delete']) <= 10) {
-      $pid_paths = '<ul>';
+      $pid_paths = array();
       foreach ($pids as $pid) {
-        $pid_paths = $pid_paths . '<li><a href="/islandora/object/' . $pid . '" target="_blank">' . $pid . '</a></li>';
+        $pid_paths[] = l($pid, '/islandora/object/' . $pid);
       }
-      $pid_paths = $pid_paths . '</ul>';
     }
     $form['confirm_message'] = array(
       '#type' => 'item',
       '#markup' => format_plural(count($form_state['pids_to_delete']),
       'Are you sure you want to delete this object? This action cannot be reversed.',
-      'Are you sure you want to delete these @count objects? This action cannot be reversed.') . $pid_paths,
+      'Are you sure you want to delete these @count objects? This action cannot be reversed.'),
     );
+    if (count($pids) <= 10) {
+      $form['pids_to_delete'] = array(
+        '#type' => 'markup',
+        '#theme' => 'item_list',
+        '#list_type' => 'ol',
+      );
+      $options = array('attributes' => array('target' => '_blank'));
+      foreach ($pids as $pid) {
+        $form['pids_to_delete']['#items'][] = l($pid, "/islandora/object/{$pid}", $options);
+      }
+    }
     $form['confirm_submit'] = array(
       '#type' => 'submit',
       '#value' => t('Confirm'),
@@ -45,8 +55,10 @@ function islandora_manage_orphaned_objects_form($form, $form_state) {
     );
   }
   else {
-    drupal_set_message(t('Some objects may intentionally have no parents. If deleting objects, please be 
-    absolutely sure that these objects are no longer required.'), 'warning');
+    drupal_set_message(t('This page lists objects that have at least one parent, according to their RELS-EXT, that does not
+    exist in the Fedora repository. These orphans might exist due to a failed batch ingest, their parents being deleted,
+    or a variety of other reasons. Some of these orphans may exist intentionally.
+    Please be cautious when deleting, as this action is irreversible.'), 'warning');
     $orphaned_objects = islandora_get_orphaned_objects();
     $rows = array();
     foreach ($orphaned_objects as $orphaned_object) {
@@ -81,6 +93,7 @@ function islandora_manage_orphaned_objects_form($form, $form_state) {
   }
   return $form;
 }
+
 /**
  * Validation for the Islandora Orphaned Objects management form.
  *

--- a/includes/orphaned_objects.inc
+++ b/includes/orphaned_objects.inc
@@ -19,12 +19,6 @@
 function islandora_manage_orphaned_objects_form($form, $form_state) {
   if (isset($form_state['show_confirm'])) {
     $pids = $form_state['pids_to_delete'];
-    if (count($form_state['pids_to_delete']) <= 10) {
-      $pid_paths = array();
-      foreach ($pids as $pid) {
-        $pid_paths[] = l($pid, '/islandora/object/' . $pid);
-      }
-    }
     $form['confirm_message'] = array(
       '#type' => 'item',
       '#markup' => format_plural(count($form_state['pids_to_delete']),

--- a/includes/orphaned_objects.inc
+++ b/includes/orphaned_objects.inc
@@ -16,7 +16,7 @@
  * @return array
  *   An array containing the form to be rendered.
  */
-function islandora_orphaned_objects_manage_form($form, $form_state) {
+function islandora_manage_orphaned_objects_form($form, $form_state) {
   if (isset($form_state['show_confirm'])) {
     $pids = $form_state['pids_to_delete'];
     if (count($form_state['pids_to_delete']) == 1) {
@@ -40,7 +40,7 @@ function islandora_orphaned_objects_manage_form($form, $form_state) {
       '#type' => 'submit',
       '#value' => t('Confirm'),
       '#weight' => 2,
-      '#submit' => array('islandora_orphaned_objects_manage_confirm_submit'),
+      '#submit' => array('islandora_manage_orphaned_objects_confirm_submit'),
     );
     $form['cancel_submit'] = array(
       '#type' => 'submit',
@@ -71,14 +71,14 @@ function islandora_orphaned_objects_manage_form($form, $form_state) {
       $form['submit_selected'] = array(
         '#type' => 'submit',
         '#name' => 'islandora-orphaned-objects-submit-selected',
-        '#validate' => array('islandora_orphaned_objects_manage_delete_selected_validate'),
-        '#submit' => array('islandora_orphaned_objects_manage_delete_submit'),
+        '#validate' => array('islandora_delete_selected_orphaned_objects_validate'),
+        '#submit' => array('islandora_delete_orphaned_objects_submit'),
         '#value' => t('Delete Selected'),
       );
       $form['submit_all'] = array(
         '#type' => 'submit',
         '#name' => 'islandora-orphaned-objects-submit-all',
-        '#submit' => array('islandora_orphaned_objects_manage_delete_submit'),
+        '#submit' => array('islandora_delete_orphaned_objects_submit'),
         '#value' => t('Delete All'),
       );
     }
@@ -93,7 +93,7 @@ function islandora_orphaned_objects_manage_form($form, $form_state) {
  * @param array $form_state
  *   An array containing the Drupal form state.
  */
-function islandora_orphaned_objects_manage_delete_selected_validate($form, $form_state) {
+function islandora_delete_selected_orphaned_objects_validate($form, $form_state) {
   $selected = array_filter($form_state['values']['management_table']);
   if (empty($selected)) {
     form_error($form['management_table'], t('At least one object must be selected to delete!'));
@@ -107,7 +107,7 @@ function islandora_orphaned_objects_manage_delete_selected_validate($form, $form
  * @param array $form_state
  *   An array containing the Drupal form state.
  */
-function islandora_orphaned_objects_manage_delete_submit(&$form, &$form_state) {
+function islandora_delete_orphaned_objects_submit(&$form, &$form_state) {
   if ($form_state['triggering_element']['#name'] == 'islandora-orphaned-objects-submit-selected') {
     $selected = array_keys(array_filter($form_state['values']['management_table']));
   }
@@ -127,8 +127,8 @@ function islandora_orphaned_objects_manage_delete_submit(&$form, &$form_state) {
  * @param array $form_state
  *   An array containing the Drupal form state.
  */
-function islandora_orphaned_objects_manage_confirm_submit($form, &$form_state) {
-  $batch = islandora_orphaned_objects_delete_create_batch($form_state['pids_to_delete']);
+function islandora_manage_orphaned_objects_confirm_submit($form, &$form_state) {
+  $batch = islandora_delete_orphaned_objects_create_batch($form_state['pids_to_delete']);
   batch_set($batch);
 }
 
@@ -199,17 +199,17 @@ EOQ;
  * @return array
  *   An array detailing the batch that is about to be run.
  */
-function islandora_orphaned_objects_delete_create_batch($pids) {
+function islandora_delete_orphaned_objects_create_batch($pids) {
   // Set up a batch operation.
   $batch = array(
     'operations' => array(
-      array('islandora_orphaned_objects_delete_batch_operation', array($pids)),
+      array('islandora_delete_orphaned_objects_batch_operation', array($pids)),
     ),
     'title' => t('Deleting the selected objects...'),
     'init_message' => t('Preparing to delete objects.'),
     'progress_message' => t('Time elapsed: @elapsed <br/>Estimated time remaining @estimate.'),
     'error_message' => t('An error has occurred.'),
-    'finished' => 'islandora_orphaned_objects_delete_batch_finished',
+    'finished' => 'islandora_delete_orphaned_objects_batch_finished',
     'file' => drupal_get_path('module', 'islandora') . '/includes/orphaned_objects.inc',
   );
   return $batch;
@@ -222,7 +222,7 @@ function islandora_orphaned_objects_delete_create_batch($pids) {
  * @param array $context
  *   The context of the Drupal batch.
  */
-function islandora_orphaned_objects_delete_batch_operation($pids, &$context) {
+function islandora_delete_orphaned_objects_batch_operation($pids, &$context) {
   if (empty($context['sandbox'])) {
     $context['sandbox'] = array();
     $context['sandbox']['progress'] = 0;
@@ -255,7 +255,7 @@ function islandora_orphaned_objects_delete_batch_operation($pids, &$context) {
  * @param array $operations
  *   The operations array that was used in the batch.
  */
-function islandora_orphaned_objects_delete_batch_finished($success, $results, $operations) {
+function islandora_delete_orphaned_objects_batch_finished($success, $results, $operations) {
   if ($success) {
     $message = format_plural(count($results['success']), 'One object deleted.', '@count objects deleted.');
   }

--- a/islandora.module
+++ b/islandora.module
@@ -39,6 +39,7 @@ define('ISLANDORA_MANAGE_DELETED_OBJECTS', 'manage deleted objects');
 define('ISLANDORA_REVERT_DATASTREAM', 'revert to old datastream');
 define('ISLANDORA_REGENERATE_DERIVATIVES', 'regenerate derivatives for an object');
 define('ISLANDORA_REPLACE_DATASTREAM_CONTENT', 'replace a datastream with new content, preserving version history');
+define('ISLANDORA_MANAGE_ORPHANED_OBJECTS', 'view and delete a list of orphaned objects');
 
 // Hooks.
 define('ISLANDORA_VIEW_HOOK', 'islandora_view_object');
@@ -401,7 +402,7 @@ function islandora_menu() {
     'title' => 'Orphaned Islandora objects',
     'description' => 'List of orphaned Islandora objects.',
     'page callback' => 'drupal_get_form',
-    'page arguments' => array('islandora_orphaned_objects_manage_form'),
+    'page arguments' => array('islandora_manage_orphaned_objects_form'),
     'access arguments' => array('ISLANDORA_MANAGE_ORPHANED_OBJECTS'),
     'file' => 'includes/orphaned_objects.inc',
   );

--- a/islandora.module
+++ b/islandora.module
@@ -398,8 +398,8 @@ function islandora_menu() {
     'access arguments' => array(ISLANDORA_MANAGE_DELETED_OBJECTS),
   );
   $items['admin/reports/orphaned_objects/list'] = array(
-    'title' => 'Orphaned objects',
-    'description' => 'List of orphaned objects.',
+    'title' => 'Orphaned Islandora objects',
+    'description' => 'List of orphaned Islandora objects.',
     'page callback' => 'drupal_get_form',
     'page arguments' => array('islandora_orphaned_objects_manage_form'),
     'access arguments' => array('manage orphaned objects'),

--- a/islandora.module
+++ b/islandora.module
@@ -632,7 +632,7 @@ function islandora_permission() {
       'title' => t('Replace datastreams'),
       'description' => t('Add new datastream content as latest version.'),
     ),
-    'ISLANDORA_MANAGE_ORPHANED_OBJECTS' => array(
+    ISLANDORA_MANAGE_ORPHANED_OBJECTS => array(
       'title' => t('Manage orphaned Islandora objects'),
       'description' => t('View a list of orphaned Islandora objects.'),
     ),

--- a/islandora.module
+++ b/islandora.module
@@ -402,7 +402,7 @@ function islandora_menu() {
     'description' => 'List of orphaned Islandora objects.',
     'page callback' => 'drupal_get_form',
     'page arguments' => array('islandora_orphaned_objects_manage_form'),
-    'access arguments' => array('manage orphaned objects'),
+    'access arguments' => array('ISLANDORA_MANAGE_ORPHANED_OBJECTS'),
     'file' => 'includes/orphaned_objects.inc',
   );
   $items['admin/islandora/restore/manage'] = array(
@@ -631,7 +631,7 @@ function islandora_permission() {
       'title' => t('Replace datastreams'),
       'description' => t('Add new datastream content as latest version.'),
     ),
-    'manage orphaned objects' => array(
+    'ISLANDORA_MANAGE_ORPHANED_OBJECTS' => array(
       'title' => t('Manage orphaned Islandora objects'),
       'description' => t('View a list of orphaned Islandora objects.'),
     ),

--- a/islandora.module
+++ b/islandora.module
@@ -397,7 +397,14 @@ function islandora_menu() {
     'type' => MENU_NORMAL_ITEM,
     'access arguments' => array(ISLANDORA_MANAGE_DELETED_OBJECTS),
   );
-
+  $items['admin/reports/orphaned_objects/list'] = array(
+    'title' => 'Orphaned objects',
+    'description' => 'List of orphaned objects.',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('islandora_orphaned_objects_manage_form'),
+    'access arguments' => array('manage orphaned objects'),
+    'file' => 'includes/orphaned_objects.inc',
+  );
   $items['admin/islandora/restore/manage'] = array(
     'description' => 'Restore or permanantly remove objects with Deleted status',
     'title' => 'Manage Deleted Objects',

--- a/islandora.module
+++ b/islandora.module
@@ -631,6 +631,10 @@ function islandora_permission() {
       'title' => t('Replace datastreams'),
       'description' => t('Add new datastream content as latest version.'),
     ),
+    'manage orphaned objects' => array(
+      'title' => t('Manage orphaned Islandora objects'),
+      'description' => t('View a list of orphaned Islandora objects.'),
+    ),
   );
   if (variable_get('islandora_deny_inactive_and_deleted', FALSE)) {
     $permissions[ISLANDORA_ACCESS_INACTIVE_AND_DELETED_OBJECTS] = array(

--- a/islandora.module
+++ b/islandora.module
@@ -403,7 +403,7 @@ function islandora_menu() {
     'description' => 'List of orphaned Islandora objects.',
     'page callback' => 'drupal_get_form',
     'page arguments' => array('islandora_manage_orphaned_objects_form'),
-    'access arguments' => array('ISLANDORA_MANAGE_ORPHANED_OBJECTS'),
+    'access arguments' => array(ISLANDORA_MANAGE_ORPHANED_OBJECTS),
     'file' => 'includes/orphaned_objects.inc',
   );
   $items['admin/islandora/restore/manage'] = array(


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2130

# What does this Pull Request do?

Adds new functionality to the Reports menu: lists orphaned objects (children with nonexistent parent collections, newspapers, newspaper issues, or books), and allows someone with appropriate permissions to delete them. Includes new permission (Manage orphaned objects).

PR at request of @rosiel, duplicating the functionality of the [Orphaned Objects module
](https://github.com/bondjimbond/islandora_orphaned_objects)

# What's new?
- Generates a list of all orphaned objects
- Creates new permission to manage orphaned objects
- Allows admin to selectively or batch delete via the list

# How should this be tested?

Create some orphaned objects...

- From a Collection Manage screen, delete children that contain children (e.g. newspapers, books, collections that have children of their own)
- Go to Reports -> Orphaned objects
- View the orphans you've created
- Delete some of them
- Delete all of them
- Confirm no bugs

# Interested parties
@Islandora/7-x-1-x-committers
