### PR TITLE
ISLANDORA-2073 Don't allow datastreams if object is forbidden.

### DIFF
--- a/islandora.module
+++ b/islandora.module
@@ -1737,11 +1737,11 @@ function islandora_datastream_access($op, $datastream, $user = NULL) {
       $user,
     ));
 
-    // The datastream check returned FALSE, and one in the object or datastream
-    // checks returned TRUE.
+    // Nothing returned FALSE at at least one thing returned TRUE
+    // for both the datastream and the object checks.
     $cache[$op][$datastream->parent->id][$datastream->id][$user->uid] = (
-      !in_array(FALSE, $datastream_results, TRUE) &&
-      (in_array(TRUE, $object_results, TRUE) || in_array(TRUE, $datastream_results, TRUE))
+      (!in_array(FALSE, $datastream_results, TRUE) && in_array(TRUE, $datastream_results, TRUE)) &&
+      (!in_array(FALSE, $object_results, TRUE) && in_array(TRUE, $object_results, TRUE))
     );
   }
 


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2073

* Other Relevant Links 
Formerly https://github.com/Islandora/islandora/pull/685 (wherein it was decided to re-work the logic)
Recently bumped in the Google Group: https://groups.google.com/forum/#!topic/islandora/OUVL7Mc7cmM

# What does this Pull Request do?

Makes datastreams inaccessible unless the object their attached to is accessible.

# What's new?

Logic in the datastream access function now:
* requires at least one TRUE in the results of calling hook_islandora_datastream_access() (formerly required one or more TRUE in either hook_islandora_datastream_access() OR hook_islandora_object_access()) 
*  requires no FALSE in the results of calling hook_islandora_object_access(). (formerly allowed FALSEs in the object access results) 

# How should this be tested?

Implement hook_islandora_object_access() to block access to an object. (Implement it in a custom module, or: make an object inactive/deleted, and implement the toggle that allows a permission to control access, and don't give that permission to your user. The problem addressed here only applies when access is blocked in hook_islandora_object_access, not XACML because XACML already knows to block you from a datastream if you can't access its object.) 
* Previously: you can still access that object's datastreams directly.
* With this PR: you are blocked.

# Additional Notes:

* Does this change require documentation to be updated? *Yes. This permission and feature needs to be documented.*
* Does this change add any new dependencies?  *no.*
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)?  *no*
* Could this change impact execution of existing code? *yes. We know that islandora_ip_embargo, which is a Labs module, will be directly affected by this, and will have to figure out another mechanism for showing thumbnails from an otherwise forbidden object.*

# Interested parties
@adam-vessey @DiegoPino 

Thanks for your comments on the last PR, and I'm sorry this one's been so long coming. Thanks Alex Kent for bringing it up again on the Google Group. 