### PR TITLE
ISLANDORA-2153: Allow datastreams with no MIME type restrictions to be replaced with any file type 

### DIFF
--- a/includes/datastream.version.inc
+++ b/includes/datastream.version.inc
@@ -283,7 +283,13 @@ function islandora_datastream_version_replace_form($form, &$form_state, Abstract
   $form_state['object'] = $object;
 
   $extensions = islandora_get_extensions_for_datastream($object, $datastream->id);
-  $valid_extensions = implode(' ', $extensions);
+  if (empty($extensions)) {
+    // In case no extensions are returned, don't limit.
+    $valid_extensions = NULL;
+  }
+  else {
+    $valid_extensions = implode(' ', $extensions);
+  }
   $upload_size = min((int) ini_get('post_max_size'), (int) ini_get('upload_max_filesize'));
   return array(
     'dsid_fieldset' => array(

--- a/includes/mimetype.utils.inc
+++ b/includes/mimetype.utils.inc
@@ -76,6 +76,10 @@ function islandora_get_extensions_for_datastream(AbstractObject $object, $dsid) 
   module_load_include('inc', 'islandora', 'includes/utilities');
   $datastream_mime_map = islandora_get_datastreams_requirements_from_models($object->models);
   $mimes = isset($datastream_mime_map[$dsid]) ? $datastream_mime_map[$dsid]['mime'] : array();
+  // If no restriction set via DS-COMPOSITE-MODEL return an empty array.
+  if (empty($mimes)) {
+    return array();
+  }
   if (isset($object[$dsid])) {
     $current_mime = $object[$dsid]->mimetype;
     if (!in_array($current_mime, $mimes)) {


### PR DESCRIPTION

**JIRA Ticket**: [ISLANDORA-2153](https://jira.duraspace.org/browse/ISLANDORA-2153)

* Other Relevant Links
  - https://groups.google.com/forum/#!topic/islandora/MqELsn1p0cU
  - https://github.com/Islandora-Labs/islandora_binary_object/issues/29

# What does this Pull Request do?
Allows unrestricted MIME type datastream replacement for those DSIDs/CMODELs that allow so. It fixes a problem with [```function islandora_get_extensions_for_datastream(AbstractObject $object, $dsid)```](https://github.com/Islandora/islandora/blob/7.x/includes/mimetype.utils.inc#L75) that returns only the already in place datatream's MIME type if no restrictions in the DS-COMPOSITE-MODEL are found for a given datastream, forcing people to stick to its initial ingest choice in SP like Binary Object (Where OBJ is on purpose left unrestricted).
Means you create an Object with a ZIP file, you have to stick to ZIP. Also on Objects that have DSIDs not defined in their CMODELs but ingested by some creative derivative/external code to get the unrestricted replacement option.

# What's new?
The expected behavior is restored. If your CMODEL does not restrict a certain DSDI to be of certain MIME type, you can freely replace existing content with any. This is also consistent with the original ingest, where that is allowed.

# How should this be tested?

Install https://github.com/Islandora-Labs/islandora_binary_object
Ingest an Object using any file type as main Binary (OBJ)
Try to replace the recently ingested DSDI with a different file type
Won't work

Apply this pull, 
Try to replace the recently ingested DSDI with a different file type
Will  work

# Additional Notes:

* Could this change impact execution of existing code?
If you are extending Islandora and using ```function islandora_get_extensions_for_datastream``` as an expensive replacement for $object[$dsid]->mimetype; this won't work anymore for you. On restricted to MIME types DSDI you will still get as bonus the existing $object[$dsid]->mimetype; in the response. If you need $object[$dsid]->mimetype; then please use $object[$dsid]->mimetype;

* It came to my attention that the DSID label is never replaced on DS replacement, maybe it could be beneficial to allow that somewhere.

# Interested parties
@Islandora/7-x-1-x-committers @mjordan @jordandukart @jonathangreen @axfelix (because he found the issue, opened the ticket and tested this fix)