### PR TITLE
Ensure object/ds are accessible before verifying token.

### DIFF
--- a/islandora.module
+++ b/islandora.module
@@ -881,13 +881,17 @@ function islandora_object_access_callback($perm, $object = NULL) {
 function islandora_object_datastream_tokened_access_callback($perm, $object = NULL, $datastream = NULL) {
   module_load_include('inc', 'islandora', 'includes/utilities');
 
+  // Token validation requires a valid object and PID in order to make a
+  // potential match in the db.
   $token_account = NULL;
-  $token = filter_input(INPUT_GET, 'token', FILTER_SANITIZE_STRING);
+  if (is_object($object) && is_object($datastream)) {
+    $token = filter_input(INPUT_GET, 'token', FILTER_SANITIZE_STRING);
 
-  if ($token) {
-    $user = islandora_validate_object_token($object->id, $datastream->id, $token);
-    if ($user) {
-      $token_account = user_load($user->uid);
+    if ($token) {
+      $user = islandora_validate_object_token($object->id, $datastream->id, $token);
+      if ($user) {
+        $token_account = user_load($user->uid);
+      }
     }
   }
 


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2166

# What does this Pull Request do?
Validates that a datastream/object objects are accessible before validating a token present in a datastream view.

# What's new?
Fixes a warning.

# How should this be tested?

- Ingest a large image
- Set a viewing restriction on the object to admin
- Ensure warnings are enabled on the box
- Attempt to view the JP2 directly with a bogus token as the anonymous user, such as:
yoursite/islandora/object/yourpid/datastream/JP2/view?token=garbage
- Warning pops, disappears after the pull.

# Interested parties
@Islandora/7-x-1-x-committers
