### PR TITLE
Prevent Warning

### DIFF
--- a/includes/datastream.inc
+++ b/includes/datastream.inc
@@ -161,12 +161,14 @@ function islandora_view_datastream_cache_check(AbstractDatastream $datastream) {
 
   if (isset($_SERVER['HTTP_IF_MODIFIED_SINCE'])) {
     $modified_since = DateTime::createFromFormat('D, d M Y H:i:s e', $_SERVER['HTTP_IF_MODIFIED_SINCE']);
-    if ($datastream->createdDate->getTimestamp() - $modified_since->getTimestamp() > 0) {
-      // Changed!
-      return $return;
-    }
-    else {
-      $return = 304;
+    if ($modified_since !== FALSE) {
+      if ($datastream->createdDate->getTimestamp() - $modified_since->getTimestamp() > 0) {
+        // Changed!
+        return $return;
+      }
+      else {
+        $return = 304;
+      }
     }
   }
   if ($return === 200 && isset($_SERVER['HTTP_IF_UNMODIFIED_SINCE'])) {

--- a/includes/datastream.inc
+++ b/includes/datastream.inc
@@ -161,7 +161,10 @@ function islandora_view_datastream_cache_check(AbstractDatastream $datastream) {
 
   if (isset($_SERVER['HTTP_IF_MODIFIED_SINCE'])) {
     $modified_since = DateTime::createFromFormat('D, d M Y H:i:s e', $_SERVER['HTTP_IF_MODIFIED_SINCE']);
-    if ($modified_since !== FALSE) {
+    if ($modified_since === FALSE) {
+      return $return;
+    }
+    else {
       if ($datastream->createdDate->getTimestamp() - $modified_since->getTimestamp() > 0) {
         // Changed!
         return $return;
@@ -173,12 +176,17 @@ function islandora_view_datastream_cache_check(AbstractDatastream $datastream) {
   }
   if ($return === 200 && isset($_SERVER['HTTP_IF_UNMODIFIED_SINCE'])) {
     $unmodified_since = DateTime::createFromFormat('D, d M Y H:i:s e', $_SERVER['HTTP_IF_UNMODIFIED_SINCE']);
-    if ($datastream->createdDate->getTimestamp() !== $unmodified_since->getTimestamp()) {
-      // Changed!
-      $return = 412;
+    if ($unmodified_since === FALSE) {
+      return $return;
     }
     else {
-      return $return;
+      if ($datastream->createdDate->getTimestamp() !== $unmodified_since->getTimestamp()) {
+        // Changed!
+        $return = 412;
+      }
+      else {
+        return $return;
+      }
     }
   }
 


### PR DESCRIPTION
# What does this Pull Request do?

I'm seeing this in my logs: 
```
Error: Call to a member function getTimestamp() on boolean in islandora_view_datastream_cache_check()
```

This checks that [DateTime::createFromFormat](http://php.net/manual/en/datetime.createfromformat.php) didn't return a boolean.

# What's new?

Should prevent warnings in logs from `islandora_view_datastream_cache_check()`

# How should this be tested?

* Check warnings before
* Check no warnings after

# Interested parties
@DiegoPino 