### PR TITLE
ISLANDORA-1748 -- add hook_islandora_datastream_filename_alter().

### DIFF
--- a/includes/datastream.inc
+++ b/includes/datastream.inc
@@ -63,6 +63,11 @@ function islandora_view_datastream(AbstractDatastream $datastream, $download = F
     if ($duplicate_extension_position === FALSE) {
       $filename .= $extension;
     }
+
+    // Allow other modules to modify or replace the filename.
+    drupal_alter('datastream_filename', $filename, $datastream);
+
+
     header("Content-Disposition: attachment; filename=\"$filename\"");
   }
 

--- a/includes/datastream.inc
+++ b/includes/datastream.inc
@@ -65,7 +65,7 @@ function islandora_view_datastream(AbstractDatastream $datastream, $download = F
     }
 
     // Allow other modules to modify or replace the filename.
-    drupal_alter('datastream_filename', $filename, $datastream);
+    drupal_alter('islandora_datastream_filename', $filename, $datastream);
 
     header("Content-Disposition: attachment; filename=\"$filename\"");
   }

--- a/includes/datastream.inc
+++ b/includes/datastream.inc
@@ -67,7 +67,6 @@ function islandora_view_datastream(AbstractDatastream $datastream, $download = F
     // Allow other modules to modify or replace the filename.
     drupal_alter('datastream_filename', $filename, $datastream);
 
-
     header("Content-Disposition: attachment; filename=\"$filename\"");
   }
 

--- a/islandora.api.php
+++ b/islandora.api.php
@@ -945,3 +945,21 @@ function callback_islandora_breadcrumbs_backends(AbstractObject $object) {
   // Do something to get an array of breadcrumb links for $object, root first.
   return array($root_link, $collection_link, $object_link);
 }
+
+/**
+ * Permit modules to alter the filename of a downloaded datastream.
+ *
+ * @param string $filename
+ * @param AbstractDatastream $datastream
+ */
+function hook_datastream_filename_alter(&$filename, AbstractDatastream $datastream) {
+
+  // Example taken from islandora_datastream_filenamer.
+  $pattern = variable_get('islandora_ds_download_filename_pattern', FALSE);
+  if($pattern) {
+    $filename = token_replace($pattern,
+      array('datastream' => $datastream),
+      array('clear' => TRUE)
+    );
+  }
+}

--- a/islandora.api.php
+++ b/islandora.api.php
@@ -955,7 +955,7 @@ function callback_islandora_breadcrumbs_backends(AbstractObject $object) {
  * @param AbstractDatastream $datastream
  *   The datastream object being downloaded.
  */
-function hook_datastream_filename_alter(&$filename, AbstractDatastream $datastream) {
+function hook_islandora_datastream_filename_alter(&$filename, AbstractDatastream $datastream) {
 
   // Example taken from islandora_datastream_filenamer.
   $pattern = variable_get('islandora_ds_download_filename_pattern', FALSE);

--- a/islandora.api.php
+++ b/islandora.api.php
@@ -950,13 +950,16 @@ function callback_islandora_breadcrumbs_backends(AbstractObject $object) {
  * Permit modules to alter the filename of a downloaded datastream.
  *
  * @param string $filename
+ *   The filename being created.
+ *
  * @param AbstractDatastream $datastream
+ *   The datastream object being downloaded.
  */
 function hook_datastream_filename_alter(&$filename, AbstractDatastream $datastream) {
 
   // Example taken from islandora_datastream_filenamer.
   $pattern = variable_get('islandora_ds_download_filename_pattern', FALSE);
-  if($pattern) {
+  if ($pattern) {
     $filename = token_replace($pattern,
       array('datastream' => $datastream),
       array('clear' => TRUE)


### PR DESCRIPTION

**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1748

# What does this Pull Request do?

Adds an alter hook that permits modules to change the file names of downloaded datastreams.

# What's new?
Background:
* The islandora_datastream_filenamer module allows the file names of downloadable datastreams to be modified, using tokens such as the object pid, datastream id, etc.
* But in order to work, it requires a patch be applied to islandora core.

This change addresses the need by:
* Creates a new drupal_alter hook in islandora/includes/datastream.inc: hook_islandora_datastream_filename_alter().
* Documents the hook in islandora.api.php

# How should this be tested?
* Implement hook_islandora_datastream_filename_alter in a module. This could do anything to modify the filename, e.g. add "test-" to the beginning.
* Test to see if, when downloading any datastream, the file has the altered name as expected.

# Additional Notes:
I will be creating a separate PR on https://github.com/ulsdevteam/islandora_datastream_filenamer which will depend upon acceptance of this pull request.

* Does this change require documentation to be updated? 
The new hook is documented in islandora.api.php

* Does this change add any new dependencies? 
No

* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? 
No

* Could this change impact execution of existing code?
No

# Interested parties
@rosiel @DiegoPino @Islandora/7-x-1-x-committers
