### PR TITLE
ISLANDORA-2215 Documentation of new permission and add screenshot to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,8 @@ This is one Drupal module in a suite of modules (and stack of related software) 
 Before installing Islandora, the XACML policies located [here](https://github.com/Islandora/islandora-xacml-policies) should be copied into the Fedora global XACML policies folder. This will allow "authenticated users" in Drupal to access Fedora API-M functions (create, edit, and delete objects in Fedora).
 
 Notes:
-* The `permit-upload-to-anonymous-user.xml` and `permit-apim-to-anonymous-user.xml` policies allow anonymous (unauthenticated)
-users to create objects and datastreams. They do not need to be present if this is not required.
-* The policy `deny-purge-datastream-if-active-or-inactive.xml` must be deleted to allow users to purge (permanently remove) datastream versions.
+* Delete the `permit-upload-to-anonymous-user.xml` and `permit-apim-to-anonymous-user.xml` policies unless you want to allow anonymous (unauthenticated) users to create Islandora objects (not recommended).
+* Delete the `deny-purge-datastream-if-active-or-inactive.xml` to allow users to purge (permanently remove) datastream versions.
 
 More detailed information can be found in the 'Set XACML Policies' in the [Installing Fedora](https://wiki.duraspace.org/display/ISLANDORA/milestone+1+-+Installing+Fedora) chapter of the documentation.
 
@@ -60,7 +59,8 @@ By default, objects with the [Fedora state](https://wiki.duraspace.org/display/F
 
 ### Customization
 
-Hooks provided by Islandora are documented in `islandora.api.php`. A [detailed tutorial](https://github.com/Islandora/islandora/wiki/Multi-paged-Ingest-Forms) on extending the multi-page ingest forms is available on the Github (developers') Wiki.
+* Hooks provided by Islandora are documented in `islandora.api.php`. 
+* A [detailed tutorial](https://github.com/Islandora/islandora/wiki/Multi-paged-Ingest-Forms) on extending the multi-page ingest forms is available on the Github (developers') Wiki.
 
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-Islandora Fedora Repository Module
+This module includes the core functionality for interacting with Fedora Repository objects through the Drupal interface.
 
 For installation and customization instructions please see the [documentation and the DuraSpace Wiki](https://wiki.duraspace.org/display/ISLANDORA/Islandora).
 
@@ -24,34 +24,48 @@ More detailed requirements are outlined in the [Installing the Islandora Essenti
 
 ### Optional Requirements
 
-If you want to support languages other than English download and enable [String Translation](https://drupal.org/project/i18n), and follow our [guide](https://github.com/Islandora/islandora/wiki/Multilingual-Support) for setting up additional languges.
+If you want to support languages other than English, download and enable [String Translation](https://drupal.org/project/i18n), and follow our [guide](https://github.com/Islandora/islandora/wiki/Multilingual-Support) for setting up additional languages.
 
 ## Installation
 
-Before installing Islandora the XACML policies located [here](https://github.com/Islandora/islandora-xacml-policies) should be copied into the Fedora global XACML policies folder. This will allow "authenticated users" in Drupal to access Fedora API-M functions. It is to be noted that the `permit-upload-to-anonymous-user.xml` and `permit-apim-to-anonymous-user.xml` files do not need to be present unless requirements for anonymous ingesting are present.
+This is one Drupal module in a suite of modules (and stack of related software) which are required for Islandora to function correctly. For full installation instructions please see the [documentation in the DuraSpace Wiki](https://wiki.duraspace.org/display/ISLANDORA/Islandora).
 
-You will also have to remove some default policies if you want full functionality as well.
+### Global Fedora XACML policies
+Before installing Islandora, the XACML policies located [here](https://github.com/Islandora/islandora-xacml-policies) should be copied into the Fedora global XACML policies folder. This will allow "authenticated users" in Drupal to access Fedora API-M functions (create, edit, and delete objects in Fedora).
 
-Remove `deny-purge-datastream-if-active-or-inactive.xml` to allow for purging of datastream versions.
+Notes:
+* The `permit-upload-to-anonymous-user.xml` and `permit-apim-to-anonymous-user.xml` policies allow anonymous (unauthenticated)
+users to create objects and datastreams. They do not need to be present if this is not required.
+* The policy `deny-purge-datastream-if-active-or-inactive.xml` must be deleted to allow users to purge (permanently remove) datastream versions.
 
 More detailed information can be found in the 'Set XACML Policies' in the [Installing Fedora](https://wiki.duraspace.org/display/ISLANDORA/milestone+1+-+Installing+Fedora) chapter of the documentation.
 
+### Protecting the 'anonymous' username
+The `islandora_drupal_filter` passes the username of 'anonymous' through to Fedora for unauthenticated Drupal Users. A user with the name of 'anonymous' may have XACML policies applied to them that are meant to be applied to Drupal users that are not logged in or vice-versa. This is a potential security issue that can be plugged by creating a user named 'anonymous' and restricting access to the account. If this is done after installing Islandora, Drupal's cron can be run to remove expired authentication tokens.
+
+
 ## Configuration
 
-The `islandora_drupal_filter` passes the username of 'anonymous' through to Fedora for unauthenticated Drupal Users. A user with the name of 'anonymous' may have XACML policies applied to them that are meant to be applied to Drupal users that are not logged in or vice-versa. This is a potential security issue that can be plugged by creating a user named 'anonymous' and restricting access to the account.
+Configuration that applies to all solution packs, including the location of the Fedora Repository, the namespaces accessible by this instance of Islandora, and whether to generate derivatives on ingest, are available at  `admin/islandora/configure`.
 
-Drupal's cron can be run to remove expired authentication tokens.
+![Configuration](https://user-images.githubusercontent.com/1943338/40320855-724afcba-5d03-11e8-9109-0b8413349839.png)
 
-**Breadcrumb Generation** on the configuration page, allows you to choose the default breadcrumb generation
- or a custom method (if implemented).
+### Breadcrumb Generation
+
+Whether Drupal breadcrumbs (showing an object's parent hierarchy) should be displayed, and how they are generated, can be set on the configuration page. Other modules (such as [Islandora Solr](https://github.com/Islandora/islandora_solr_search)) may provide  alternatives that perform better at large scales than the built-in Resource Index query.
+
+### Inactive and Deleted Objects
+
+By default, objects with the [Fedora state](https://wiki.duraspace.org/display/FEDORA38/Fedora+Digital+Object+Model) of "Inactive" or "Deleted" are accessible to all users with the Drupal permission "View repository objects". It is possible to use a separate permission to control access to these non-"Active" objects, but this permission must first be enabled at `admin/islandora/configure`, then the permssion can be granted to desired roles at `admin/people/permissions`.
 
 ### Customization
 
-[Customize ingest forms](https://github.com/Islandora/islandora/wiki/Multi-paged-Ingest-Forms)
+Hooks provided by Islandora are documented in `islandora.api.php`. A [detailed tutorial](https://github.com/Islandora/islandora/wiki/Multi-paged-Ingest-Forms) on extending the multi-page ingest forms is available on the Github (developers') Wiki.
+
 
 ## Documentation
 
-Further documentation for this module is available at [our wiki](https://wiki.duraspace.org/display/ISLANDORA/Islandora+Core+Module).
+Further documentation for this module is available at [our documentation wiki](https://wiki.duraspace.org/display/ISLANDORA/Islandora+Core+Module).
 
 ## Troubleshooting/Issues
 

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -141,7 +141,7 @@ function islandora_repository_admin(array $form, array &$form_state) {
         'islandora_deny_inactive_and_deleted' => array(
           '#type' => 'checkbox',
           '#title' => t('Lock down inactive and deleted objects.'),
-          '#description' => t('Deny access to inactive or deleted objects using a separate permission than for active objects.'),
+          '#description' => t('Require a separate permission to access inactive and deleted objects.'),
           '#default_value' => variable_get('islandora_deny_inactive_and_deleted', FALSE),
         ),
       ),


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2215


# What does this Pull Request do?

Adds a configuration screenshot to the Islandora README, and mentions the new permission relating to inactive/deleted objects. It also improves the wording on the admin form as suggested by @bencomp. 

# What's new?
* Readme differs
* Admin form has new description

# How should this be tested?

View the revised readme at my fork: https://github.com/rosiel/islandora-1/tree/7.x-documentation

# Additional Notes:

* Does this change require documentation to be updated?  * Screenshot on the wiki's also very out of date - will update when this change is accepted. https://wiki.duraspace.org/display/ISLANDORA/Islandora+Core+Module

* Does this change add any new dependencies?  no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# Interested parties
@DiegoPino maintainer, @bencomp. 