### PR TITLE
made logging messages more accurate

### DIFF
--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -135,6 +135,7 @@ function islandora_derivative_logging(array $logging_results) {
   $result_message = $result_messages['success'];
   foreach ($logging_results as $result) {
     foreach ($result['messages'] as $message) {
+      $message_status = 'status';
       if ($message['type'] === 'dsm') {
         if (isset($message['severity']) && $message['severity'] != 'status') {
           drupal_set_message(filter_xss(format_string($message['message'], isset($message['message_sub']) ? $message['message_sub'] : array())), $message['severity']);
@@ -156,12 +157,13 @@ function islandora_derivative_logging(array $logging_results) {
         // are merged into the standard release for Coder.
         call_user_func('watchdog', 'islandora_derivatives', $message['message'], isset($message['message_sub']) ? $message['message_sub'] : array(), isset($message['severity']) ? $message['severity'] : WATCHDOG_NOTICE);
         $result_message = $result_messages['incomplete'];
+        $message_status = 'warning';
       }
-      drupal_set_message(l($result_message, 'islandora/event-status'), 'status', FALSE);
-
-      // If there is more than one message something has gone wrong.
-      if (isset($_SESSION['messages']['status'][1])) {
-        $_SESSION['messages']['status'] = array(l($result_messages['incomplete'], 'islandora/event-status'));
+      drupal_set_message(l($result_message, 'islandora/event-status'), $message_status, FALSE);
+      if (isset($_SESSION['messages']['warning'])) {
+        if (isset($_SESSION['messages']['status'])) {
+          unset($_SESSION['messages']['status']);
+        }
       }
     }
   }

--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -127,6 +127,12 @@ function islandora_do_derivatives(AbstractObject $object, array $options) {
  *       watchdog if not defined.
  */
 function islandora_derivative_logging(array $logging_results) {
+
+  $result_messages = array(
+    'success' => t('Derivatives successfully created.'),
+    'incomplete' => t('Not all derivatives successfully created.  Please check log messages'),
+  );
+  $result_message = $result_messages['success'];
   foreach ($logging_results as $result) {
     foreach ($result['messages'] as $message) {
       if ($message['type'] === 'dsm') {
@@ -141,7 +147,6 @@ function islandora_derivative_logging(array $logging_results) {
             'message' => filter_xss(format_string($message['message'], isset($message['message_sub']) ? $message['message_sub'] : array())),
             'severity' => 'status',
           );
-          drupal_set_message(l(t('Derivatives successfully created.'), 'islandora/event-status'), 'status', FALSE);
         }
       }
       else {
@@ -150,6 +155,13 @@ function islandora_derivative_logging(array $logging_results) {
         // call_user_func until such time as the @ignore changes
         // are merged into the standard release for Coder.
         call_user_func('watchdog', 'islandora_derivatives', $message['message'], isset($message['message_sub']) ? $message['message_sub'] : array(), isset($message['severity']) ? $message['severity'] : WATCHDOG_NOTICE);
+        $result_message = $result_messages['incomplete'];
+      }
+      drupal_set_message(l($result_message, 'islandora/event-status'), 'status', FALSE);
+
+      // If there is more than one message something has gone wrong.
+      if (isset($_SESSION['messages']['status'][1])) {
+        $_SESSION['messages']['status'] = array(l($result_messages['incomplete'], 'islandora/event-status'));
       }
     }
   }


### PR DESCRIPTION
[Islandora 2284](https://jira.duraspace.org/browse/ISLANDORA-2284)
# What does this Pull Request do?

Lets user know if derivative generation is incomplete.

# What's new?

Users still see
` Derivatives successfully created.` 
if all has gone well, but will see
`Not all derivatives successfully created.  Please check log messages` 
if it didn't.

# How should this be tested?

Ingest as sample object into a misconfigured solution pack - I'd recommend giving the wrong path to Lame in the audio solution pack.  
Make sure a second module (Fits works well) is present and working.
Ingest an audio object.  You should see the warning message.
Fix configuration issue and ingest another audio object.  The message should indicate success.

Repeat with regeneration of derivatives.

# Interested parties
@Islandora/7-x-1-x-committers
