### PR TITLE
Install drush with composer

### DIFF
--- a/includes/add_datastream.form.inc
+++ b/includes/add_datastream.form.inc
@@ -227,7 +227,7 @@ function islandora_add_datastream_form_autocomplete_callback(AbstractObject $obj
   $dsids = array_combine($dsids, $dsids);
   $query = trim($query);
   if (!empty($query)) {
-    $filter = function($id) use($query) {
+    $filter = function ($id) use ($query) {
       return stripos($id, $query) !== FALSE;
     };
     $dsids = array_filter($dsids, $filter);

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -48,7 +48,8 @@ function islandora_repository_admin(array $form, array &$form_state) {
             '#title' => t('Fedora base URL'),
             '#default_value' => variable_get('islandora_base_url', 'http://localhost:8080/fedora'),
             '#description' => t('The URL to use for REST connections <br/> !confirmation_message', array(
-                              '!confirmation_message' => $confirmation_message)),
+              '!confirmation_message' => $confirmation_message,
+            )),
             '#required' => TRUE,
             '#ajax' => array(
               'callback' => 'islandora_update_url_div',
@@ -225,17 +226,21 @@ function islandora_admin_settings_form_repository_access_message($url) {
   if ($info && $dc) {
     $confirmation_message = theme_image(array('path' => 'misc/watchdog-ok.png', 'attributes' => array()));
     $confirmation_message .= t('Successfully connected to Fedora Server (Version !version).', array(
-                               '!version' => $info['repositoryVersion']));
+      '!version' => $info['repositoryVersion'],
+    ));
   }
   elseif ($info) {
     $confirmation_message = theme_image(array('path' => 'misc/watchdog-warning.png', 'attributes' => array()));
     $confirmation_message .= t('Unable to authenticate when connecting to to Fedora Server (Version !version). Please configure the !filter.', array(
-                               '!version' => $info['repositoryVersion'], '!filter' => 'Drupal Filter'));
+      '!version' => $info['repositoryVersion'],
+      '!filter' => 'Drupal Filter',
+    ));
   }
   else {
     $confirmation_message = theme_image(array('path' => 'misc/watchdog-error.png', 'attributes' => array()));
     $confirmation_message .= t('Unable to connect to Fedora server at !islandora_url', array(
-                               '!islandora_url' => $url));
+      '!islandora_url' => $url,
+    ));
   }
   return $confirmation_message;
 }

--- a/includes/authtokens.inc
+++ b/includes/authtokens.inc
@@ -104,11 +104,11 @@ function islandora_validate_object_token($pid, $dsid, $token) {
     // Decrement authentication token uses.
     else {
       db_update("islandora_authtokens")
-      ->fields(array('remaining_uses' => $remaining_uses))
-      ->condition('token', $token, '=')
-      ->condition('pid', $pid, '=')
-      ->condition('dsid', $dsid, '=')
-      ->execute();
+        ->fields(array('remaining_uses' => $remaining_uses))
+        ->condition('token', $token, '=')
+        ->condition('pid', $pid, '=')
+        ->condition('dsid', $dsid, '=')
+        ->execute();
     }
     unset($result[0]->remaining_uses);
     $accounts[$pid][$dsid][$token] = $result[0];

--- a/includes/content_model.autocomplete.inc
+++ b/includes/content_model.autocomplete.inc
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * Autocomplete functionality for content models in Islandora.
@@ -46,7 +47,7 @@ function islandora_get_content_model_names() {
  * @return array
  *   An array of results in a more usable format.
  */
-function islandora_parse_query($content) {
+function islandora_parse_query(array $content) {
   $content_models = array();
   foreach ($content as $model) {
     $content_models[] = $model['object']['value'];

--- a/includes/datastream.inc
+++ b/includes/datastream.inc
@@ -18,16 +18,16 @@ function islandora_download_datastream(AbstractDatastream $datastream) {
 /**
  * Callback function to view or download a datastream.
  *
- * @note
- *  This function calls exit().
- *
  * @param AbstractDatastream $datastream
  *   The datastream to view/download.
  * @param bool $download
  *   If TRUE the file is download to the user computer for viewing otherwise it
  *   will attempt to display in the browser natively.
  * @param int $version
- *   The version of the datastream to display
+ *   The version of the datastream to display.
+ *
+ * @note
+ *  This function calls exit().
  */
 function islandora_view_datastream(AbstractDatastream $datastream, $download = FALSE, $version = NULL) {
   module_load_include('inc', 'islandora', 'includes/mimetype.utils');
@@ -124,14 +124,14 @@ function islandora_view_datastream(AbstractDatastream $datastream, $download = F
  * - fdsa
  * - 2132
  *
- * @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.24
- * @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.26
- *
  * @param string $header_value
  *   The value from the headers.
  *
  * @return array
  *   An array containing all the etags present.
+ *
+ * @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.24
+ * @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.26
  */
 function islandora_parse_http_match_headers($header_value) {
   $matches = array();
@@ -282,7 +282,7 @@ function islandora_datastream_get_human_readable_size(AbstractDatastream $datast
  * @param string $type
  *   One of:
  *   - download
- *   - view
+ *   - view.
  * @param int $version
  *   (Optional) The version of the datastream to get a URL for.
  *
@@ -394,7 +394,7 @@ function islandora_view_datastream_set_chunk_headers(AbstractDatastream $datastr
       $c_start = $size - substr($range, 1);
     }
     else {
-      $range  = explode('-', $range);
+      $range   = explode('-', $range);
       $c_start = $range[0];
       $c_end   = (isset($range[1]) && is_numeric($range[1])) ? $range[1] : $size;
     }
@@ -409,8 +409,8 @@ function islandora_view_datastream_set_chunk_headers(AbstractDatastream $datastr
       header("Content-Range: bytes $start-$end/$size");
       exit;
     }
-    $start  = $c_start;
-    $end    = $c_end;
+    $start = $c_start;
+    $end   = $c_end;
     // Calculate new content length.
     $length = $end - $start + 1;
     header('HTTP/1.1 206 Partial Content');
@@ -432,7 +432,7 @@ function islandora_view_datastream_set_chunk_headers(AbstractDatastream $datastr
  * @param array $params
  *   An associate array containing the start and ending chunk bytes.
  */
-function islandora_view_datastream_deliver_chunks(AbstractDatastream $datastream, $params) {
+function islandora_view_datastream_deliver_chunks(AbstractDatastream $datastream, array $params) {
   $file_uri = islandora_view_datastream_retrieve_file_uri($datastream);
   // The meat of this has been taken from:
   // http://mobiforge.com/design-development/content-delivery-mobile-devices.
@@ -459,14 +459,14 @@ function islandora_view_datastream_deliver_chunks(AbstractDatastream $datastream
  * File locks are used to ensure the datastream is completely downloaded before
  * attempting to serve up chunks from the file.
  *
- * @throws RepositoryException|Exception
- *   Exceptions may be thrown if the file was unable to be reliably acquired.
- *
  * @param AbstractDatastream $datastream
  *   An AbstractDatastream representing a datastream on a Fedora object.
  *
  * @return string
  *   The URI of the file.
+ *
+ * @throws RepositoryException|Exception
+ *   Exceptions may be thrown if the file was unable to be reliably acquired.
  */
 function islandora_view_datastream_retrieve_file_uri(AbstractDatastream $datastream) {
   module_load_include('inc', 'islandora', 'includes/mimetype.utils');

--- a/includes/datastream.version.inc
+++ b/includes/datastream.version.inc
@@ -142,15 +142,17 @@ function islandora_delete_datastream_version_form_submit(array $form, array &$fo
   }
   catch (Exception $e) {
     drupal_set_message(t('Error deleting version %v of %s datastream from object %o %e', array(
-          '%v' => $version,
-          '%s' => $datastream_id,
-          '%o' => $object->label,
-          '%e' => $e->getMessage())), 'error');
+      '%v' => $version,
+      '%s' => $datastream_id,
+      '%o' => $object->label,
+      '%e' => $e->getMessage(),
+    )), 'error');
   }
 
   drupal_set_message(t('%d datastream version successfully deleted from Islandora object %o', array(
-        '%d' => $datastream_id,
-        '%o' => $object->label)));
+    '%d' => $datastream_id,
+    '%o' => $object->label,
+  )));
 
   $form_state['redirect'] = "islandora/object/{$object->id}/datastream/{$datastream->id}/version";
 }
@@ -224,9 +226,10 @@ function islandora_revert_datastream_version_form_submit(array $form, array &$fo
   }
 
   drupal_set_message(t('%d datastream successfully reverted to version %v for Islandora object %o', array(
-        '%d' => $datastream_to_revert->id,
-        '%v' => $version,
-        '%o' => $islandora_object->label)));
+    '%d' => $datastream_to_revert->id,
+    '%v' => $version,
+    '%o' => $islandora_object->label,
+  )));
 
   $form_state['redirect'] = "islandora/object/{$islandora_object->id}/datastream/{$datastream_to_revert->id}/version";
 }
@@ -235,9 +238,9 @@ function islandora_revert_datastream_version_form_submit(array $form, array &$fo
  * Process available dsids, mime and extensions for a given object.
  *
  * @param AbstractObject $object
- *   The FedoraObject to process available extensions
+ *   The FedoraObject to process available extensions.
  *
- * @return array()
+ * @return array
  *   An associative array, merged from calls to
  *   islandora_get_datastreams_requirements_from_content_models()
  *   and an objects dsid's.
@@ -272,7 +275,7 @@ function islandora_get_object_extensions(AbstractObject $object) {
  * @return array
  *   The drupal form definition.
  */
-function islandora_datastream_version_replace_form($form, &$form_state, AbstractDatastream $datastream) {
+function islandora_datastream_version_replace_form(array $form, array &$form_state, AbstractDatastream $datastream) {
   module_load_include('inc', 'islandora', 'includes/content_model');
   module_load_include('inc', 'islandora', 'includes/utilities');
   module_load_include('inc', 'islandora', 'includes/mimetype.utils');
@@ -337,7 +340,7 @@ function islandora_datastream_version_replace_form($form, &$form_state, Abstract
  * @param array $form_state
  *   The Drupal form state.
  */
-function islandora_datastream_version_replace_form_submit($form, &$form_state) {
+function islandora_datastream_version_replace_form_submit(array $form, array &$form_state) {
   $object = islandora_object_load($form_state['object_id']);
   $form_state['redirect'] = "islandora/object/{$object->id}";
   $file = file_load($form_state['values']['file']);
@@ -370,7 +373,7 @@ function islandora_datastream_version_replace_form_submit($form, &$form_state) {
  * Gets Audit datastream values from foxml.
  *
  * @param string $pid
- *   PID of parent object
+ *   PID of parent object.
  *
  * @return array
  *   Array of audit values

--- a/includes/delete_datastream.form.inc
+++ b/includes/delete_datastream.form.inc
@@ -127,19 +127,22 @@ function islandora_delete_datastream_form_submit(array $form, array &$form_state
   }
   catch (Exception $e) {
     drupal_set_message(t('Error deleting %s datastream from object %o %e', array(
-          '%s' => $datastream_id,
-          '%o' => $object->label,
-          '%e' => $e->getMessage())), 'error');
+      '%s' => $datastream_id,
+      '%o' => $object->label,
+      '%e' => $e->getMessage(),
+    )), 'error');
   }
   if ($deleted) {
     drupal_set_message(t('%d datastream sucessfully deleted from Islandora object %o', array(
-          '%d' => $datastream_id,
-          '%o' => $object->label)));
+      '%d' => $datastream_id,
+      '%o' => $object->label,
+    )));
   }
   else {
     drupal_set_message(t('Error deleting %s datastream from object %o', array(
-          '%s' => $datastream_id,
-          '%o' => $object->label)), 'error');
+      '%s' => $datastream_id,
+      '%o' => $object->label,
+    )), 'error');
   }
   $form_state['redirect'] = "islandora/object/{$object->id}";
 }

--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * Defines functions used when constructing derivatives.
@@ -221,7 +222,7 @@ function islandora_do_batch_derivatives(AbstractObject $object, array $options) 
  * @return array
  *   Returns the filtered array of hooks to be ran.
  */
-function islandora_filter_derivatives($hooks, $options, AbstractObject $object) {
+function islandora_filter_derivatives(array $hooks, array $options, AbstractObject $object) {
   if (array_key_exists('source_dsid', $options)) {
     $hooks = array_filter($hooks, function ($filter_hook) use ($options) {
       return array_key_exists('source_dsid', $filter_hook) &&
@@ -296,10 +297,10 @@ function islandora_remove_defer_derivatives_flag(AbstractObject $object) {
  *
  * @param AbstractObject $object
  *   The object to find derivatives for.
- * @param &array $options
+ * @param array $options
  *   Options for derivatives, will be updated to default force to FALSE.
  */
-function islandora_get_derivative_list(AbstractObject $object, &$options) {
+function islandora_get_derivative_list(AbstractObject $object, array &$options) {
   module_load_include('inc', 'islandora', 'includes/utilities');
 
   $ds_modified_params = isset($options['ds_modified_params']) ? $options['ds_modified_params'] : array();

--- a/includes/dublin_core.inc
+++ b/includes/dublin_core.inc
@@ -9,7 +9,7 @@
  */
 
 /**
- * Dublin Core Class
+ * Dublin Core Class.
  */
 class DublinCore {
 
@@ -40,7 +40,7 @@ class DublinCore {
    */
   public function __construct($dc_xml = NULL) {
     if (!empty($dc_xml)) {
-      $this->dc = self::importFromXMLString($dc_xml);
+      $this->dc = self::importFromXmlString($dc_xml);
     }
   }
 
@@ -81,7 +81,7 @@ class DublinCore {
    * @return string
    *   The serialized XML.
    */
-  public function asXML() {
+  public function asXml() {
     $dc_xml = new DomDocument();
     $oai_dc = $dc_xml->createElementNS('http://www.openarchives.org/OAI/2.0/oai_dc/', 'oai_dc:dc');
     $oai_dc->setAttribute('xmlns:dc', 'http://purl.org/dc/elements/1.1/');
@@ -152,7 +152,7 @@ class DublinCore {
    * @return DublinCore
    *   The instantiated object.
    */
-  public static function importFromXMLString($dc_xml) {
+  public static function importFromXmlString($dc_xml) {
     $dc_doc = new DomDocument();
     if (!empty($dc_xml) && $dc_doc->loadXML($dc_xml)) {
       $oai_dc = $dc_doc->getElementsByTagNameNS('http://purl.org/dc/elements/1.1/', '*');

--- a/includes/ingest.form.inc
+++ b/includes/ingest.form.inc
@@ -64,8 +64,11 @@ function islandora_ingest_form(array $form, array &$form_state, array $configura
       WATCHDOG_ERROR
     );
     drupal_set_message($e->getMessage(), 'error');
-    return array(array(
-        '#markup' => l(t('Back'), 'javascript:window.history.back();', array('external' => TRUE))));
+    return array(
+      array(
+        '#markup' => l(t('Back'), 'javascript:window.history.back();', array('external' => TRUE)),
+      ),
+    );
   }
 }
 
@@ -285,7 +288,7 @@ function islandora_ingest_form_increment_step(array &$form_state) {
  *   The Drupal form state.
  */
 function islandora_ingest_form_decrement_step(array &$form_state) {
-  $previous_step_id  = islandora_ingest_form_get_previous_step_id($form_state);
+  $previous_step_id = islandora_ingest_form_get_previous_step_id($form_state);
   // Don't decrement passed the first step.
   if (isset($previous_step_id)) {
     islandora_ingest_form_stash_info($form_state);
@@ -496,7 +499,7 @@ function islandora_ingest_form_stepify(array $form, array &$form_state, array $s
  */
 function islandora_ingest_form_add_step_context(array &$form, array $form_state) {
   $items = array();
-  $get_label = function(AbstractObject $collection = NULL, AbstractObject $fedora_cmodel) {
+  $get_label = function (AbstractObject $collection = NULL, AbstractObject $fedora_cmodel) {
     if (isset($collection['COLLECTION_POLICY'])) {
       $policy = new CollectionPolicy($collection['COLLECTION_POLICY']->content);
       $policy_content_models = $policy->getContentModels();
@@ -876,18 +879,18 @@ function &islandora_ingest_form_get_objects(array &$form_state) {
 /**
  * Gets a single object from the stored NewFedoraObject's.
  *
- * @note In our current use case we are only dealing with a single object
- *   ingest, this makes it convenient to access it. Ideally the steps
- *   implementations will be abstracted to be indifferent to what object it's
- *   currently working on. This will act as a placeholder for such
- *   functionality.
- *
  * @param array $form_state
  *   The Drupal form state.
  *
  * @return NewFedoraObject
  *   Returns the 'current' object in the array of NewFedoraObjects, generally
  *   this is only used when there is one object in the list of objects.
+ *
+ * @note In our current use case we are only dealing with a single object
+ *   ingest, this makes it convenient to access it. Ideally the steps
+ *   implementations will be abstracted to be indifferent to what object it's
+ *   currently working on. This will act as a placeholder for such
+ *   functionality.
  */
 function islandora_ingest_form_get_object(array &$form_state) {
   $objects = &islandora_ingest_form_get_objects($form_state);
@@ -899,7 +902,7 @@ function islandora_ingest_form_get_object(array &$form_state) {
  *
  * @param array $form_state
  *   The Drupal form state.
- * @param array $step_id
+ * @param string $step_id
  *   The ID of the step.
  *
  * @return array
@@ -1004,7 +1007,7 @@ function islandora_ingest_form_get_steps(array &$form_state) {
  */
 function islandora_ingest_form_get_form_steps(array &$form_state) {
   $steps = islandora_ingest_form_get_steps($form_state);
-  $form_step_filter = function($o) {
+  $form_step_filter = function ($o) {
     return $o['type'] == 'form';
   };
   return array_filter($steps, $form_step_filter);
@@ -1022,7 +1025,7 @@ function islandora_ingest_form_get_form_steps(array &$form_state) {
  */
 function islandora_ingest_form_get_callback_steps(array &$form_state) {
   $steps = islandora_ingest_form_get_steps($form_state);
-  $callback_step_filter = function($o) {
+  $callback_step_filter = function ($o) {
     return $o['type'] == 'callback';
   };
   return array_filter($steps, $callback_step_filter);

--- a/includes/metadata.inc
+++ b/includes/metadata.inc
@@ -107,7 +107,7 @@ function islandora_metadata_display_form(array $form, array $form_state) {
       );
       $form['viewers']['configuration'][$name] = array(
         '#type' => 'item',
-        '#markup' => (isset($profile['configuration']) and $profile['configuration'] != '') ? l(t('configure'), $profile['configuration']) : '',
+        '#markup' => (isset($profile['configuration']) && $profile['configuration'] != '') ? l(t('configure'), $profile['configuration']) : '',
       );
     }
     $form['viewers']['default'] = array(

--- a/includes/metadata.inc
+++ b/includes/metadata.inc
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * Defines functions used when viewing metadata displays on Islandora objects.
@@ -70,7 +71,7 @@ function islandora_retrieve_description_markup(AbstractObject $object) {
  * @return array
  *   An array representing the metadata display viewer form.
  */
-function islandora_metadata_display_form($form, $form_state) {
+function islandora_metadata_display_form(array $form, array $form_state) {
   module_load_include('inc', 'islandora', 'includes/solution_packs.inc');
   $form = array();
   $defined_displays = module_invoke_all('islandora_metadata_display_info');
@@ -106,7 +107,7 @@ function islandora_metadata_display_form($form, $form_state) {
       );
       $form['viewers']['configuration'][$name] = array(
         '#type' => 'item',
-        '#markup' => (isset($profile['configuration']) AND $profile['configuration'] != '') ? l(t('configure'), $profile['configuration']) : '',
+        '#markup' => (isset($profile['configuration']) and $profile['configuration'] != '') ? l(t('configure'), $profile['configuration']) : '',
       );
     }
     $form['viewers']['default'] = array(
@@ -135,7 +136,7 @@ function islandora_metadata_display_form($form, $form_state) {
  * @param array $form_state
  *   An array containing the Drupal form state.
  */
-function islandora_metadata_display_form_submit($form, $form_state) {
+function islandora_metadata_display_form_submit(array $form, array $form_state) {
   variable_set('islandora_metadata_display', $form_state['values']['viewers']['default']);
   drupal_set_message(t('The configuration options have been saved.'));
 }

--- a/includes/mime_detect.inc
+++ b/includes/mime_detect.inc
@@ -21,54 +21,71 @@
  * http://api.drupal.org/api/function/file_default_mimetype_mapping/7
  */
 
+/**
+ * Class for mime-type detection.
+ */
 class MimeDetect {
 
-  protected $protectedMimeTypes = array(
-    /*
-     * This is a shortlist of mimetypes which should catch most
-     * mimetype<-->extension lookups in the context of Islandora collections.
-     *
-     * It has been cut from a much longer list.
-     *
-     * Two types of mimetypes should be put in this list:
-     *  1) Special emerging formats which may not yet be expressed in the system
-     *     mime.types file.
-     *  2) Heavily used mimetypes of particular importance to the Islandora
-     *     project, as lookups against this list will be quicker and less
-     *     resource intensive than other methods.
-     *
-     * Lookups are first checked against this short list.  If no results are
-     * found, then the lookup function may move on to check other sources,
-     * namely the system's mime.types file.
-     *
-     * In most cases though, this short list should suffice.
-     *
-     * If modifying this list, please note that for promiscuous mimetypes
-     * (those which map to multiple extensions, such as text/plain)
-     * The function get_extension will always return the *LAST* extension in
-     * this list, so you should put your preferred extension *LAST*.
-     *
-     * e.g...
-     * "jpeg"    => "image/jpeg",
-     * "jpe"     => "image/jpeg",
-     * "jpg"     => "image/jpeg",
-     *
-     * $this->get_extension('image/jpeg') will always return 'jpg'.
-     *
-     */
-  );
+  /**
+   * Shortlist of mimetypes which catch most mimetype to extension lookups.
+   *
+   * @var array
+   *
+   * It has been cut from a much longer list.
+   *
+   * Two types of mimetypes should be put in this list:
+   * 1) Special emerging formats which may not yet be expressed in the system
+   * mime.types file.
+   * 2) Heavily used mimetypes of particular importance to the Islandora
+   * project, as lookups against this list will be quicker and less
+   * resource intensive than other methods.
+   *
+   * Lookups are first checked against this short list.  If no results are
+   * found, then the lookup function may move on to check other sources,
+   * namely the system's mime.types file.
+   *
+   * In most cases though, this short list should suffice.
+   *
+   * If modifying this list, please note that for promiscuous mimetypes
+   * (those which map to multiple extensions, such as text/plain)
+   * The function get_extension will always return the *LAST* extension in
+   * this list, so you should put your preferred extension *LAST*.
+   *
+   * e.g...
+   * "jpeg"    => "image/jpeg",
+   * "jpe"     => "image/jpeg",
+   * "jpg"     => "image/jpeg",
+   *
+   * $this->get_extension('image/jpeg') will always return 'jpg'.
+   */
+  protected $protectedMimeTypes = array();
   protected $protectedFileExtensions;
   protected $extensionExceptions = array(
     // XXX: Deprecated... Only here due to old 'tif' => 'image/tif' mapping...
     // The correct MIMEtype is 'image/tiff'.
     'image/tif' => 'tif',
   );
+  /**
+   * Array of mimetypes from the system.
+   *
+   * @var array
+   */
   protected $systemTypes;
+  /**
+   * Array of extensions from the system.
+   *
+   * @var array
+   */
   protected $systemExts;
+  /**
+   * Location of the system mime.types file.
+   *
+   * @var string
+   */
   protected $etcMimeTypes = '/etc/mime.types';
 
   /**
-   * Construtor.
+   * Constructor.
    */
   public function __construct() {
     module_load_include('inc', 'islandora', 'includes/mimetype.utils');
@@ -87,7 +104,7 @@ class MimeDetect {
    * Gets MIME type associated with the give file's extension.
    *
    * @param string $filename
-   *   The filename
+   *   The filename.
    * @param bool $debug
    *   Returns a debug array.
    *
@@ -171,7 +188,8 @@ class MimeDetect {
   /**
    * Gets an associative array of MIME type and extension associations.
    *
-   * Users the system mime.types file, or a local mime.types if one is found
+   * Users the system mime.types file, or a local mime.types if one is found.
+   *
    * @see MIMEDetect::__constuctor()
    *
    * @return array
@@ -206,7 +224,8 @@ class MimeDetect {
   /**
    * Gets a associative array of extensions and MIME types.
    *
-   * Users the system mime.types file, or a local mime.types if one is found
+   * Users the system mime.types file, or a local mime.types if one is found.
+   *
    * @see MIMEDetect::__constuctor()
    *
    * @return array
@@ -262,4 +281,5 @@ class MimeDetect {
     };
     return array_keys(array_filter($this->protectedMimeTypes, $filter));
   }
+
 }

--- a/includes/mime_type.autocomplete.inc
+++ b/includes/mime_type.autocomplete.inc
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * Autocomplete functionality for MIME types in Islandora.

--- a/includes/mimetype.utils.inc
+++ b/includes/mimetype.utils.inc
@@ -272,7 +272,7 @@ function islandora_mime_mapping() {
     // Web Archives:
     "warc" => "application/warc",
     "json" => "application/json",
-    // JSON-LD
+    // JSON-LD.
     "jsonld" => "application/ld+json",
   );
 }

--- a/includes/object.entity_controller.inc
+++ b/includes/object.entity_controller.inc
@@ -5,6 +5,9 @@
  * Very basic entity controller.
  */
 
+/**
+ * Special loader for Islandora objects.
+ */
 class IslandoraObjectEntityController implements DrupalEntityControllerInterface {
 
   /**
@@ -20,13 +23,16 @@ class IslandoraObjectEntityController implements DrupalEntityControllerInterface
   /**
    * Load all the entities.
    *
-   * @param array $ids
+   * @param mixed $ids
    *   The ID's of the entities.
-   * @param array $conditions
+   * @param mixed $conditions
    *   The conditions to apply.
    *
    * @return array
    *   An array of loaded objects.
+   *
+   * @throws \Exception
+   *   If no conditions are provided.
    */
   public function load($ids = array(), $conditions = array()) {
     if (!empty($conditions)) {
@@ -54,4 +60,5 @@ class IslandoraObjectEntityController implements DrupalEntityControllerInterface
   public function resetCache(array $ids = NULL) {
     // no-op.
   }
+
 }

--- a/includes/object_properties.form.inc
+++ b/includes/object_properties.form.inc
@@ -90,7 +90,8 @@ function islandora_object_properties_form(array $form, array &$form_state, Abstr
       '#type' => 'submit',
       '#access' => islandora_object_access(ISLANDORA_PURGE, $object),
       '#value' => t("Permanently remove '@label' from repository", array(
-        '@label' => truncate_utf8($object->label, 32, TRUE, TRUE))
+        '@label' => truncate_utf8($object->label, 32, TRUE, TRUE),
+      )
       ),
       '#submit' => array('islandora_object_properties_form_delete'),
       '#limit_validation_errors' => array(array('pid')),
@@ -200,15 +201,15 @@ function islandora_object_properties_form_delete(array $form, array &$form_state
  * Updates object state.
  *
  * @param string $pid
- *   PID of object to be updated
+ *   PID of object to be updated.
  * @param bool $update_states
- *   If TRUE, update object state
+ *   If TRUE, update object state.
  * @param string $state
- *   Desired object state
+ *   Desired object state.
  * @param bool $update_owners
- *   If TRUE, update Owner
+ *   If TRUE, update Owner.
  * @param string $owner
- *   New Owner
+ *   New Owner.
  */
 function islandora_update_object_properties($pid, $update_states, $state, $update_owners, $owner) {
   $fedora_object = islandora_object_load($pid);

--- a/includes/orphaned_objects.inc
+++ b/includes/orphaned_objects.inc
@@ -16,7 +16,7 @@
  * @return array
  *   An array containing the form to be rendered.
  */
-function islandora_manage_orphaned_objects_form($form, $form_state) {
+function islandora_manage_orphaned_objects_form(array $form, array $form_state) {
   if (isset($form_state['show_confirm'])) {
     $pids = $form_state['pids_to_delete'];
     $form['confirm_message'] = array(
@@ -96,12 +96,13 @@ function islandora_manage_orphaned_objects_form($form, $form_state) {
  * @param array $form_state
  *   An array containing the Drupal form state.
  */
-function islandora_delete_selected_orphaned_objects_validate($form, $form_state) {
+function islandora_delete_selected_orphaned_objects_validate(array $form, array $form_state) {
   $selected = array_filter($form_state['values']['management_table']);
   if (empty($selected)) {
     form_error($form['management_table'], t('At least one object must be selected to delete!'));
   }
 }
+
 /**
  * Submit handler for the delete buttons in the workflow management form.
  *
@@ -110,7 +111,7 @@ function islandora_delete_selected_orphaned_objects_validate($form, $form_state)
  * @param array $form_state
  *   An array containing the Drupal form state.
  */
-function islandora_delete_orphaned_objects_submit(&$form, &$form_state) {
+function islandora_delete_orphaned_objects_submit(array &$form, array &$form_state) {
   if ($form_state['triggering_element']['#name'] == 'islandora-orphaned-objects-submit-selected') {
     $selected = array_keys(array_filter($form_state['values']['management_table']));
   }
@@ -122,6 +123,7 @@ function islandora_delete_orphaned_objects_submit(&$form, &$form_state) {
   $form_state['rebuild'] = TRUE;
   $form_state['show_confirm'] = TRUE;
 }
+
 /**
  * Submit handler for the workflow management confirm form.
  *
@@ -130,7 +132,7 @@ function islandora_delete_orphaned_objects_submit(&$form, &$form_state) {
  * @param array $form_state
  *   An array containing the Drupal form state.
  */
-function islandora_manage_orphaned_objects_confirm_submit($form, &$form_state) {
+function islandora_manage_orphaned_objects_confirm_submit(array $form, array &$form_state) {
   $batch = islandora_delete_orphaned_objects_create_batch($form_state['pids_to_delete']);
   batch_set($batch);
 }
@@ -212,7 +214,7 @@ EOQ;
  * @return array
  *   An array detailing the batch that is about to be run.
  */
-function islandora_delete_orphaned_objects_create_batch($pids) {
+function islandora_delete_orphaned_objects_create_batch(array $pids) {
   // Set up a batch operation.
   $batch = array(
     'operations' => array(
@@ -227,6 +229,7 @@ function islandora_delete_orphaned_objects_create_batch($pids) {
   );
   return $batch;
 }
+
 /**
  * Constructs and performs the deleting batch operation.
  *
@@ -235,7 +238,7 @@ function islandora_delete_orphaned_objects_create_batch($pids) {
  * @param array $context
  *   The context of the Drupal batch.
  */
-function islandora_delete_orphaned_objects_batch_operation($pids, &$context) {
+function islandora_delete_orphaned_objects_batch_operation(array $pids, array &$context) {
   if (empty($context['sandbox'])) {
     $context['sandbox'] = array();
     $context['sandbox']['progress'] = 0;
@@ -247,10 +250,10 @@ function islandora_delete_orphaned_objects_batch_operation($pids, &$context) {
     $target_pid = array_pop($context['sandbox']['pids']);
     $target_object = islandora_object_load($target_pid);
     $context['message'] = t('Deleting @label (@pid) (@current of @total)...', array(
-        '@label' => $target_object->label,
-        '@pid' => $target_pid,
-        '@current' => $context['sandbox']['progress'],
-        '@total' => $context['sandbox']['total'],
+      '@label' => $target_object->label,
+      '@pid' => $target_pid,
+      '@current' => $context['sandbox']['progress'],
+      '@total' => $context['sandbox']['total'],
     ));
     islandora_delete_object($target_object);
     $object_check = islandora_object_load($target_pid);
@@ -267,6 +270,7 @@ function islandora_delete_orphaned_objects_batch_operation($pids, &$context) {
   }
   $context['finished'] = ($context['sandbox']['total'] == 0) ? 1 : ($context['sandbox']['progress'] / $context['sandbox']['total']);
 }
+
 /**
  * Finished function for the orphaned objects delete batch.
  *
@@ -277,7 +281,7 @@ function islandora_delete_orphaned_objects_batch_operation($pids, &$context) {
  * @param array $operations
  *   The operations array that was used in the batch.
  */
-function islandora_delete_orphaned_objects_batch_finished($success, $results, $operations) {
+function islandora_delete_orphaned_objects_batch_finished($success, array $results, array $operations) {
   if ($success) {
     $message = format_plural(count($results['success']), 'One object deleted.', '@count objects deleted.');
   }

--- a/includes/regenerate_derivatives.form.inc
+++ b/includes/regenerate_derivatives.form.inc
@@ -122,8 +122,8 @@ function islandora_regenerate_datastream_derivative_batch(AbstractDatastream $da
   return array(
     'title' => t('Regenerating derivatives for the @dsid datastream', array('@dsid' => $datastream->id)),
     'operations' => islandora_do_batch_derivatives($datastream->parent, array(
-        'force' => TRUE,
-        'destination_dsid' => $datastream->id,
+      'force' => TRUE,
+      'destination_dsid' => $datastream->id,
     )),
     'init_message' => t('Preparing to regenerate derivatives...'),
     'progress_message' => t('Time elapsed: @elapsed <br/>Estimated time remaining @estimate.'),
@@ -139,7 +139,7 @@ function islandora_regenerate_datastream_derivative_batch(AbstractDatastream $da
  * @param string $function
  *   The name of the function we are calling for derivatives.
  * @param bool|string $file
- *   FALSE if there is no file to load, the path to require otherwise
+ *   FALSE if there is no file to load, the path to require otherwise.
  * @param string $pid
  *   The pid of the object we are performing.
  * @param bool $force
@@ -149,7 +149,7 @@ function islandora_regenerate_datastream_derivative_batch(AbstractDatastream $da
  * @param array $context
  *   The context of the current batch operation.
  */
-function islandora_derivative_perform_batch_operation($function, $file, $pid, $force, $hook, &$context) {
+function islandora_derivative_perform_batch_operation($function, $file, $pid, $force, array $hook, array &$context) {
   if ($file) {
     require_once $file;
   }
@@ -174,7 +174,7 @@ function islandora_derivative_perform_batch_operation($function, $file, $pid, $f
  * @param array $operations
  *   An array of operations passed from the batch.
  */
-function islandora_regenerate_derivative_batch_finished($success, $results, $operations) {
+function islandora_regenerate_derivative_batch_finished(array $success, array $results, array $operations) {
   module_load_include('inc', 'islandora', 'includes/derivatives');
   if (!empty($results['logging'])) {
     islandora_derivative_logging($results['logging']);

--- a/includes/solution_packs.inc
+++ b/includes/solution_packs.inc
@@ -105,7 +105,7 @@ function islandora_solution_packs_admin() {
  * @return array
  *   The Drupal form definition.
  */
-function islandora_solution_pack_form(array $form, array &$form_state, $solution_pack_module, $solution_pack_name, $objects = array()) {
+function islandora_solution_pack_form(array $form, array &$form_state, $solution_pack_module, $solution_pack_name, array $objects = array()) {
   // The order is important in terms of severity of the status, where higher
   // index indicates the status is more serious, this will be used to determine
   // what messages get displayed to the user.
@@ -145,7 +145,8 @@ function islandora_solution_pack_form(array $form, array &$form_state, $solution
   $header = array(
     'label' => t('Label'),
     'pid' => t('PID'),
-    'status' => t('Status'));
+    'status' => t('Status'),
+  );
 
   $object_info = array();
   foreach ($objects as $object) {
@@ -161,7 +162,8 @@ function islandora_solution_pack_form(array $form, array &$form_state, $solution
     $object_info[] = array(
       'label' => $label,
       'pid' => $object->id,
-      'status' => $status_msg);
+      'status' => $status_msg,
+    );
   }
   $solution_pack_status = $status_severities[$solution_pack_status_severity];
   $solution_pack_status_info = $status_info[$solution_pack_status];
@@ -260,7 +262,7 @@ function islandora_solution_pack_form_submit(array $form, array &$form_state) {
  * @return array
  *   An array defining a batch which can be passed on to batch_set().
  */
-function islandora_solution_pack_get_batch($module, $not_checked = array()) {
+function islandora_solution_pack_get_batch($module, array $not_checked = array()) {
   $batch = array(
     'title' => t('Installing / Updating solution pack objects'),
     'file' => drupal_get_path('module', 'islandora') . '/includes/solution_packs.inc',
@@ -299,8 +301,8 @@ function islandora_solution_pack_batch_operation_reingest_object(AbstractObject 
     if (!$deleted) {
       $object_link = l($existing_object->label, "islandora/object/{$existing_object->id}");
       drupal_set_message(filter_xss(t('Failed to purge existing object !object_link.', array(
-            '!object_link' => $object_link,
-          ))), 'error');
+        '!object_link' => $object_link,
+      ))), 'error');
       // Failed to purge don't attempt to ingest.
       return;
     }
@@ -405,8 +407,8 @@ function islandora_install_solution_pack($module, $op = 'install', $force = FALS
         $object_status = islandora_check_object_status($object);
         $here_params = array(
           '!summary' => $t("@module: Did not install !object_link.", array(
-              '!object_link' => $object_link,
-            ) + $t_params),
+            '!object_link' => $object_link,
+          ) + $t_params),
           '!description' => $status_messages[$object_status['status']],
         );
         drupal_set_message(filter_xss(format_string('!summary !description', $here_params)), 'warning');
@@ -422,25 +424,25 @@ function islandora_install_solution_pack($module, $op = 'install', $force = FALS
       if ($object) {
         if ($deleted) {
           drupal_set_message(filter_xss($t('@module: Successfully reinstalled. !object_link.', array(
-              '!object_link' => $object_link,
-            ) + $t_params)), 'status');
+            '!object_link' => $object_link,
+          ) + $t_params)), 'status');
         }
         else {
           drupal_set_message(filter_xss($t('@module: Successfully installed. !object_link.', array(
-              '!object_link' => $object_link,
-            ) + $t_params)), 'status');
+            '!object_link' => $object_link,
+          ) + $t_params)), 'status');
         }
       }
       else {
         drupal_set_message($t('@module: Failed to install. @label.', array(
-              '@label' => $label,
-            ) + $t_params), 'warning');
+          '@label' => $label,
+        ) + $t_params), 'warning');
       }
     }
     else {
       drupal_set_message($t('@module: "@label" already exists and failed to be deleted.', array(
-              '@label' => $label,
-            ) + $t_params), 'warning');
+        '@label' => $label,
+      ) + $t_params), 'warning');
     }
   }
 }
@@ -535,7 +537,7 @@ function islandora_check_object_status(AbstractObject $object_definition) {
     );
   }
 
-  $is_xml_datastream = function($ds) {
+  $is_xml_datastream = function ($ds) {
     return $ds->mimetype == 'text/xml';
   };
   $xml_datastreams = array_filter(iterator_to_array($object_definition), $is_xml_datastream);
@@ -627,11 +629,11 @@ function islandora_check_object_status(AbstractObject $object_definition) {
  * that supports either the give $mimetype or $model will be listed.
  *
  * @param string $variable_id
- *   The ID of the Drupal variable to save the viewer settings in
+ *   The ID of the Drupal variable to save the viewer settings in.
  * @param string $mimetype
- *   The table will be populated with viewers supporting this mimetype
+ *   The table will be populated with viewers supporting this mimetype.
  * @param string $model
- *   The table will be populated with viewers supporting this content model
+ *   The table will be populated with viewers supporting this content model.
  *
  * @return array
  *   A form api array which defines a themed table to select a viewer.
@@ -680,7 +682,7 @@ function islandora_viewers_form($variable_id = NULL, $mimetype = NULL, $model = 
       );
       $form['viewers'][$variable_id]['configuration'][$name] = array(
         '#type' => 'item',
-        '#markup' => (isset($profile['configuration']) AND $profile['configuration'] != '') ? l(t('configure'), $profile['configuration']) : '',
+        '#markup' => (isset($profile['configuration']) and $profile['configuration'] != '') ? l(t('configure'), $profile['configuration']) : '',
       );
     }
     $form['viewers'][$variable_id]['default'] = array(
@@ -717,7 +719,7 @@ function islandora_viewers_form($variable_id = NULL, $mimetype = NULL, $model = 
  * @return array
  *   Viewer definitions, or FALSE if none are found.
  */
-function islandora_get_viewers($mimetype = array(), $content_model = NULL) {
+function islandora_get_viewers(array $mimetype = array(), $content_model = NULL) {
   $viewers = array();
   $defined_viewers = module_invoke_all('islandora_viewer_info');
 
@@ -729,7 +731,7 @@ function islandora_get_viewers($mimetype = array(), $content_model = NULL) {
   foreach ($defined_viewers as $key => $value) {
     $value['mimetype'] = isset($value['mimetype']) ? $value['mimetype'] : array();
     $value['model'] = isset($value['model']) ? $value['model'] : array();
-    if (array_intersect($mimetype, $value['mimetype']) OR in_array($content_model, $value['model'])) {
+    if (array_intersect($mimetype, $value['mimetype']) or in_array($content_model, $value['model'])) {
       $viewers[$key] = $value;
     }
   }
@@ -763,10 +765,10 @@ function theme_islandora_viewers_table($variables) {
 
   $output = '';
   $output .= theme('table', array(
-               'header' => $header,
-               'rows' => $rows,
-               'attributes' => array('id' => 'islandora-viewers-table'),
-    ));
+    'header' => $header,
+    'rows' => $rows,
+    'attributes' => array('id' => 'islandora-viewers-table'),
+  ));
   $output .= drupal_render_children($form);
   return $output;
 }
@@ -774,22 +776,22 @@ function theme_islandora_viewers_table($variables) {
 /**
  * Gather information and return a rendered viewer.
  *
- * @param array/string $params
- *   Array or string with data the module needs in order to render a full viewer
+ * @param array|string $params
+ *   Array or string of data the module needs in order to render a full viewer.
  * @param string $variable_id
- *   The id of the Drupal variable the viewer settings are saved in
+ *   The id of the Drupal variable the viewer settings are saved in.
  * @param AbstractObject $fedora_object
- *   The tuque object representing the fedora object being displayed
+ *   The tuque object representing the fedora object being displayed.
  *
  * @return string
  *   The callback to the viewer module. Returns a rendered viewer. Returns FALSE
  *   if no viewer is set.
  */
-function islandora_get_viewer($params = NULL, $variable_id = NULL, $fedora_object = NULL) {
+function islandora_get_viewer($params = NULL, $variable_id = NULL, AbstractObject $fedora_object = NULL) {
   $settings = variable_get($variable_id, array());
-  if (!empty($settings) AND $settings['default'] !== 'none') {
+  if (!empty($settings) and $settings['default'] !== 'none') {
     $viewer_id = islandora_get_viewer_id($variable_id);
-    if ($viewer_id AND $params !== NULL) {
+    if ($viewer_id and $params !== NULL) {
       $callback = islandora_get_viewer_callback($viewer_id);
       if (function_exists($callback)) {
         return $callback($params, $fedora_object);
@@ -803,7 +805,7 @@ function islandora_get_viewer($params = NULL, $variable_id = NULL, $fedora_objec
  * Get id of the enabled viewer.
  *
  * @param string $variable_id
- *   The ID of the Drupal variable the viewer settings are saved in
+ *   The ID of the Drupal variable the viewer settings are saved in.
  *
  * @return string
  *   The enabled viewer id. Returns FALSE if no viewer config is set.
@@ -834,6 +836,7 @@ function islandora_get_viewer_callback($viewer_id = NULL) {
   }
   return FALSE;
 }
+
 /**
  * @} End of "defgroup viewer-functions".
  */

--- a/includes/solution_packs.inc
+++ b/includes/solution_packs.inc
@@ -789,9 +789,9 @@ function theme_islandora_viewers_table($variables) {
  */
 function islandora_get_viewer($params = NULL, $variable_id = NULL, AbstractObject $fedora_object = NULL) {
   $settings = variable_get($variable_id, array());
-  if (!empty($settings) and $settings['default'] !== 'none') {
+  if (!empty($settings) && $settings['default'] !== 'none') {
     $viewer_id = islandora_get_viewer_id($variable_id);
-    if ($viewer_id and $params !== NULL) {
+    if ($viewer_id && $params !== NULL) {
       $callback = islandora_get_viewer_callback($viewer_id);
       if (function_exists($callback)) {
         return $callback($params, $fedora_object);

--- a/includes/tuque.inc
+++ b/includes/tuque.inc
@@ -27,18 +27,20 @@ $islandora_module_path = drupal_get_path('module', 'islandora');
 @include_once "$islandora_module_path/libraries/tuque/RepositoryException.php";
 @include_once "$islandora_module_path/libraries/tuque/Repository.php";
 @include_once "$islandora_module_path/libraries/tuque/FedoraRelationships.php";
-
+/**
+ * The Tuque class built from various supporting classes.
+ */
 class IslandoraTuque {
 
   /**
-   * Connection to the repository
+   * Connection to the repository.
    *
    * @var RepositoryConnection
    */
   public $connection = NULL;
 
   /**
-   * The Fedora API we are using
+   * The Fedora API we are using.
    *
    * @var FedoraAPI
    */
@@ -61,7 +63,7 @@ class IslandoraTuque {
   /**
    * Constructor.
    *
-   * @param array $user
+   * @param object $user
    *   A Drupal user.
    * @param string $url
    *   The url to the fedora instance.
@@ -113,4 +115,5 @@ class IslandoraTuque {
     $message = t('Islandora requires the !tuque_url. Please install in /sites/all/libraries/tuque before continuing. See the !islandora_url.', array('!tuque_url' => $tuque_link, '!islandora_url' => $islandora_doc_link));
     drupal_set_message(filter_xss($message), 'error', FALSE);
   }
+
 }

--- a/includes/tuque_wrapper.inc
+++ b/includes/tuque_wrapper.inc
@@ -2,8 +2,9 @@
 
 /**
  * @file
- * Wrapper around the tuque library, allows for autoloading of Islandora Tuque
- * Objects.
+ * Wrapper around the tuque library.
+ *
+ * Allows for autoloading of Islandora Tuque Objects.
  *
  * @todo Overload functions and apply pre/post hooks.
  */
@@ -75,6 +76,9 @@ function islandora_invoke_datastream_hooks($hook, array $models, $dsid) {
   return islandora_invoke_hook_list($hook, $refinements, array_slice(func_get_args(), 3));
 }
 
+/**
+ * Implementation of the FedoraRepository class.
+ */
 class IslandoraFedoraRepository extends FedoraRepository {
   protected $queryClass = 'IslandoraRepositoryQuery';
   protected $newObjectClass = 'IslandoraNewFedoraObject';
@@ -119,9 +123,10 @@ class IslandoraFedoraRepository extends FedoraRepository {
     }
     catch (Exception $e) {
       watchdog('islandora', 'Failed to ingest object: @pid</br>code: @code<br/>message: @msg', array(
-          '@pid' => $object->id,
-          '@code' => $e->getCode(),
-          '@msg' => $e->getMessage()), WATCHDOG_ERROR);
+        '@pid' => $object->id,
+        '@code' => $e->getCode(),
+        '@msg' => $e->getMessage(),
+      ), WATCHDOG_ERROR);
       throw $e;
     }
   }
@@ -134,7 +139,7 @@ class IslandoraFedoraRepository extends FedoraRepository {
   public function constructObject($id = NULL, $create_uuid = NULL) {
     // Enforces UUID when set, but allows to override if called
     // with $create_uuid set to bool.
-    return parent::constructObject($id, static::useUUIDs($create_uuid));
+    return parent::constructObject($id, static::useUuids($create_uuid));
   }
 
   /**
@@ -145,13 +150,13 @@ class IslandoraFedoraRepository extends FedoraRepository {
   public function getNextIdentifier($namespace = NULL, $create_uuid = NULL, $count = 1) {
     // Enforces UUID when set, but allows to override if called
     // with $create_uuid set to bool.
-    return parent::getNextIdentifier($namespace, static::useUUIDs($create_uuid), $count);
+    return parent::getNextIdentifier($namespace, static::useUuids($create_uuid), $count);
   }
 
   /**
    * Helper for three-valued logic with UUIDs.
    *
-   * @param bool|NULL $to_create
+   * @param bool|null $to_create
    *   The variable to test.
    *
    * @return bool
@@ -159,21 +164,29 @@ class IslandoraFedoraRepository extends FedoraRepository {
    *   'islandora_basic_collection_generate_uuid' Drupal variable; otherwise,
    *   the value of $to_create itself.
    */
-  protected static function useUUIDs($to_create) {
+  protected static function useUuids($to_create) {
     return is_null($to_create) ?
       variable_get('islandora_basic_collection_generate_uuid', FALSE) :
       $to_create;
   }
+
 }
-
+/**
+ * Implementation of RepositoryQuery class.
+ */
 class IslandoraRepositoryQuery extends RepositoryQuery {}
-
+/**
+ * Implementation of NewFedoraObject class.
+ */
 class IslandoraNewFedoraObject extends NewFedoraObject {
   protected $newFedoraDatastreamClass = 'IslandoraNewFedoraDatastream';
   protected $fedoraDatastreamClass = 'IslandoraFedoraDatastream';
   protected $fedoraRelsExtClass = 'IslandoraFedoraRelsExt';
-}
 
+}
+/**
+ * Implementation, magic functions for a FedoraObject class.
+ */
 class IslandoraFedoraObject extends FedoraObject {
   protected $newFedoraDatastreamClass = 'IslandoraNewFedoraDatastream';
   protected $fedoraDatastreamClass = 'IslandoraFedoraDatastream';
@@ -275,9 +288,10 @@ class IslandoraFedoraObject extends FedoraObject {
     }
     catch (Exception $e) {
       watchdog('islandora', 'Failed to modify object: @pid</br>code: @code<br/>message: @msg', array(
-          '@pid' => $this->id,
-          '@code' => $e->getCode(),
-          '@msg' => $e->getMessage()), WATCHDOG_ERROR);
+        '@pid' => $this->id,
+        '@code' => $e->getCode(),
+        '@msg' => $e->getMessage(),
+      ), WATCHDOG_ERROR);
       throw $e;
     }
   }
@@ -322,16 +336,21 @@ class IslandoraFedoraObject extends FedoraObject {
     }
     catch (Exception $e) {
       watchdog('islandora', 'Failed to purge datastream @dsid from @pid</br>code: @code<br/>message: @msg', array(
-          '@pid' => $this->id,
-          '@dsid' => $id,
-          '@code' => $e->getCode(),
-          '@msg' => $e->getMessage()), WATCHDOG_ERROR);
+        '@pid' => $this->id,
+        '@dsid' => $id,
+        '@code' => $e->getCode(),
+        '@msg' => $e->getMessage(),
+      ), WATCHDOG_ERROR);
       throw $e;
     }
   }
-}
 
+}
+/**
+ * Implementation of a RepositoryConnection class.
+ */
 class IslandoraRepositoryConnection extends RepositoryConnection {
+
   /**
    * Constructor.
    *
@@ -345,8 +364,11 @@ class IslandoraRepositoryConnection extends RepositoryConnection {
     parent::__construct($url, $username, $password);
     drupal_alter('islandora_repository_connection_construction', $this);
   }
-}
 
+}
+/**
+ * Implementation of a FedoraApi class.
+ */
 class IslandoraFedoraApi extends FedoraApi {
 
   /**
@@ -362,8 +384,11 @@ class IslandoraFedoraApi extends FedoraApi {
     $this->m = new IslandoraFedoraApiM($connection, $serializer);
     $this->connection = $connection;
   }
-}
 
+}
+/**
+ * Implementation of FedoraApiM class.
+ */
 class IslandoraFedoraApiM extends FedoraApiM {
 
   /**
@@ -452,9 +477,10 @@ class IslandoraFedoraApiM extends FedoraApiM {
     }
     catch (Exception $e) {
       watchdog('islandora', 'Failed to purge object @pid</br>code: @code<br/>message: @msg', array(
-          '@pid' => $pid,
-          '@code' => $e->getCode(),
-          '@msg' => $e->getMessage()), WATCHDOG_ERROR);
+        '@pid' => $pid,
+        '@code' => $e->getCode(),
+        '@msg' => $e->getMessage(),
+      ), WATCHDOG_ERROR);
       throw $e;
     }
   }
@@ -505,7 +531,7 @@ class IslandoraFedoraApiM extends FedoraApiM {
    *
    * All extra arguments are passed along to the callback.
    *
-   * @param callable $callback
+   * @param string $callback
    *   The method we are wrapping.
    * @param string $pid
    *   The PID to create a semaphore for.
@@ -540,15 +566,23 @@ class IslandoraFedoraApiM extends FedoraApiM {
       return call_user_func_array(array($this, "parent::$callback"), $args);
     }
   }
+
 }
-
+/**
+ * Implementation of SimpleCache class.
+ */
 class IslandoraSimpleCache extends SimpleCache {}
-
+/**
+ * Implementation of NewFedoraDatastream class.
+ */
 class IslandoraNewFedoraDatastream extends NewFedoraDatastream {
   protected $fedoraRelsIntClass = 'IslandoraFedoraRelsInt';
   protected $fedoraDatastreamVersionClass = 'IslandoraFedoraDatastreamVersion';
-}
 
+}
+/**
+ * Implementation and magic functions for FedoraDatastream class.
+ */
 class IslandoraFedoraDatastream extends FedoraDatastream {
   protected $fedoraRelsIntClass = 'IslandoraFedoraRelsInt';
   protected $fedoraDatastreamVersionClass = 'IslandoraFedoraDatastreamVersion';
@@ -610,20 +644,29 @@ class IslandoraFedoraDatastream extends FedoraDatastream {
     }
     catch (Exception $e) {
       watchdog('islandora', 'Failed to modify datastream @dsid from @pid</br>code: @code<br/>message: @msg', array(
-          '@pid' => $this->parent->id,
-          '@dsid' => $this->id,
-          '@code' => $e->getCode(),
-          '@msg' => $e->getMessage()), WATCHDOG_ERROR);
+        '@pid' => $this->parent->id,
+        '@dsid' => $this->id,
+        '@code' => $e->getCode(),
+        '@msg' => $e->getMessage(),
+      ), WATCHDOG_ERROR);
       throw $e;
     }
   }
-}
 
+}
+/**
+ * Implementation of FedoraDatastreamVersion class.
+ */
 class IslandoraFedoraDatastreamVersion extends FedoraDatastreamVersion {
   protected $fedoraRelsIntClass = 'IslandoraFedoraRelsInt';
   protected $fedoraDatastreamVersionClass = 'IslandoraFedoraDatastreamVersion';
+
 }
-
+/**
+ * Implementation of FedoraRelsExt class.
+ */
 class IslandoraFedoraRelsExt extends FedoraRelsExt {}
-
+/**
+ * Implementation of FedoraRelsInt class.
+ */
 class IslandoraFedoraRelsInt extends FedoraRelsInt {}

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -13,7 +13,7 @@
  * XXX: Shouldn't Drupal's format_size() be preferred?
  *
  * @param int $bytes
- *   Size in bytes to convert
+ *   Size in bytes to convert.
  * @param int $precision
  *   The amount of decimal precision to show.
  *
@@ -175,8 +175,6 @@ function islandora_describe_repository($url = NULL) {
  * as MODULE_REFINEMENT_HOOK. Any additional arguments passed to this function
  * will be passed as arguments to module_invoke_all().
  *
- * @see islandora_build_hook_list()
- *
  * @param string $hook
  *   A hook to call.
  * @param array $refinements
@@ -188,6 +186,8 @@ function islandora_describe_repository($url = NULL) {
  *
  * @return array
  *   The merged results from all the hooks.
+ *
+ * @see islandora_build_hook_list()
  */
 function islandora_invoke_hook_list($hook, array $refinements, array $args) {
   $return = array();
@@ -229,7 +229,7 @@ function islandora_invoke_hook_list($hook, array $refinements, array $args) {
  *   An array with each refinement escaped and concatenated with the base hook
  *   name, in addition to the base hook name.
  */
-function islandora_build_hook_list($hook, $refinements = array()) {
+function islandora_build_hook_list($hook, array $refinements = array()) {
   $refinements = array_unique($refinements);
   $hooks = array($hook);
   foreach ($refinements as $refinement) {
@@ -333,7 +333,7 @@ function islandora_get_parents_from_rels_ext(AbstractObject $object) {
     // @todo some logging would be nice, not sure what this throws.
     return array();
   }
-  $map = function($o) {
+  $map = function ($o) {
     return islandora_object_load($o['object']['value']);
   };
   $collections = array_map($map, $collections);
@@ -484,7 +484,11 @@ function islandora_get_datastreams_requirements_from_content_model(AbstractObjec
  * @return NewFedoraObject
  *   An ingestable NewFedoraObject.
  */
-function islandora_prepare_new_object($name_source = NULL, $label = NULL, $datastreams = array(), $content_models = array(), $relationships = array()) {
+function islandora_prepare_new_object($name_source = NULL,
+                                      $label = NULL,
+                                      array $datastreams = array(),
+                                      array $content_models = array(),
+                                      array $relationships = array()) {
   global $user;
   $tuque = islandora_get_tuque_connection();
   $object = isset($name_source) ? $tuque->repository->constructObject($name_source) : new IslandoraNewFedoraObject(NULL, $tuque->repository);
@@ -500,7 +504,7 @@ function islandora_prepare_new_object($name_source = NULL, $label = NULL, $datas
     $dsid = $ds['dsid'];
     $label = isset($ds['label']) ? $ds['label'] : '';
     $mimetype = isset($ds['mimetype']) ? $ds['mimetype'] : 'text/xml';
-    // Default 'Managed'
+    // Default 'Managed'.
     $control_group = 'M';
     $groups = array('X', 'M', 'R', 'E');
     if (isset($ds['control_group']) && in_array($ds['control_group'], $groups)) {
@@ -733,16 +737,16 @@ function islandora_get_content_models($ignore_system_namespace = TRUE) {
  * Returns Drupal tableselect element allowing selection of Content Models.
  *
  * @param string $drupal_variable
- *   the name of the Drupal variable holding selected content models
+ *   The name of the Drupal variable holding selected content models
  *   Content models held in this variable will appear at the top of
- *   the displayed list
+ *   the displayed list.
  * @param array $default_values_array
- *   default values to display if $drupal_variable is unset
+ *   Default values to display if $drupal_variable is unset.
  *
  * @return array
  *   Drupal form element allowing content model selection
  */
-function islandora_content_model_select_table_form_element($drupal_variable, $default_values_array = array('')) {
+function islandora_content_model_select_table_form_element($drupal_variable, array $default_values_array = array('')) {
   $defaults = array();
   $rows = array();
   $content_models = array();
@@ -835,7 +839,7 @@ function islandora_deprecated($release, $solution = NULL) {
  *   of strings, which we transform to renderable markup elements (by
  *   reference).
  */
-function islandora_as_renderable_array(&$markup_array) {
+function islandora_as_renderable_array(array &$markup_array) {
   foreach ($markup_array as &$value) {
     if (!is_array($value)) {
       // Not a renderable array, just a string. Let's convert it to a

--- a/islandora.api.php
+++ b/islandora.api.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * This file documents all available hook functions to manipulate data.
@@ -8,7 +9,7 @@
  * Generate a repository objects view.
  *
  * @param AbstractObject $object
- *   The object to display
+ *   The object to display.
  * @param object $user
  *   The user accessing the object.
  * @param string $page_number
@@ -19,7 +20,7 @@
  * @return array
  *   An array whose values are markup.
  */
-function hook_islandora_view_object($object, $user, $page_number, $page_size) {
+function hook_islandora_view_object(AbstractObject $object, $user, $page_number, $page_size) {
   $output = array();
   if (in_array('islandora:sp_basic_image', $object->models)) {
     $resource_url = url("islandora/object/{$object->id}/datastream/OBJ/view");
@@ -30,7 +31,8 @@ function hook_islandora_view_object($object, $user, $page_number, $page_size) {
     // Theme the image seperatly.
     $variables['islandora_img'] = theme('image', $params);
     $output = theme('islandora_default_print', array(
-    'islandora_content' => $variables['islandora_img']));
+      'islandora_content' => $variables['islandora_img'],
+    ));
   }
   return $output;
 }
@@ -52,13 +54,15 @@ function hook_islandora_view_print_object($object) {
  * create the hook name.
  *
  * @param AbstractObject $object
- *   A Tuque FedoraObject
+ *   A Tuque FedoraObject.
  *
  * @return array
  *   An array whose values are markup.
  */
-function hook_cmodel_pid_islandora_view_object($object) {
-
+function hook_cmodel_pid_islandora_view_object(AbstractObject $object) {
+  $output = array();
+  // See hook_islandora_view_object().
+  return $output;
 }
 
 /**
@@ -69,21 +73,21 @@ function hook_cmodel_pid_islandora_view_object($object) {
  * @param array $rendered
  *   The array of rendered views.
  */
-function hook_islandora_view_object_alter(&$object, &$rendered) {
+function hook_islandora_view_object_alter(AbstractObject &$object, array &$rendered) {
 
 }
 
 /**
  * Alter display output if the object has the given model.
  *
- * @see hook_islandora_view_object_alter()
- *
  * @param AbstractObject $object
  *   A Tuque AbstractObject being operated on.
  * @param array $rendered
  *   The array of rendered views.
+ *
+ * @see hook_islandora_view_object_alter()
  */
-function hook_cmodel_pid_islandora_view_object_alter(&$object, &$rendered) {
+function hook_cmodel_pid_islandora_view_object_alter(AbstractObject &$object, array &$rendered) {
 
 }
 
@@ -91,13 +95,15 @@ function hook_cmodel_pid_islandora_view_object_alter(&$object, &$rendered) {
  * Generate an object's datastreams management display.
  *
  * @param AbstractObject $object
- *   A Tuque FedoraObject
+ *   A Tuque FedoraObject.
  *
  * @return array
  *   An array whose values are markup.
  */
-function hook_islandora_edit_object($object) {
-
+function hook_islandora_edit_object(AbstractObject $object) {
+  $output = array();
+  // Not sure if there is an implementation of this hook.
+  return $output;
 }
 
 /**
@@ -107,24 +113,27 @@ function hook_islandora_edit_object($object) {
  * create the hook name.
  *
  * @param AbstractObject $object
- *   A Tuque FedoraObject
+ *   A Tuque FedoraObject.
  *
  * @return array
  *   An array whose values are markup.
+ *
+ * @see hook_islandora_edit_object()
  */
-function hook_cmodel_pid_islandora_edit_object($object) {
-
+function hook_cmodel_pid_islandora_edit_object(AbstractObject $object) {
+  $output = array();
+  return $output;
 }
 
 /**
  * Allow datastreams management display output to be altered.
  *
  * @param AbstractObject $object
- *   A Tuque FedoraObject
+ *   A Tuque FedoraObject.
  * @param array $rendered
- *   an arr of rendered views
+ *   An array of rendered views.
  */
-function hook_islandora_edit_object_alter(&$object, &$rendered) {
+function hook_islandora_edit_object_alter(AbstractObject &$object, array &$rendered) {
 
 }
 
@@ -227,12 +236,12 @@ function hook_cmodel_pid_dsid_islandora_datastream_alter(AbstractObject $object,
  * This hook is called after an object has been successfully ingested via a
  * FedoraRepository object.
  *
+ * @param AbstractObject $object
+ *   The object that was ingested.
+ *
  * @note
  * If ingested directly via the FedoraApiM object this will not be called as we
  * don't have access to the ingested object at that time.
- *
- * @param AbstractObject $object
- *   The object that was ingested.
  */
 function hook_islandora_object_ingested(AbstractObject $object) {
 
@@ -301,14 +310,14 @@ function hook_cmodel_pid_islandora_object_purged($pid) {
  *
  * This hook is called after the datastream has been successfully ingested.
  *
- * @note
- * If ingested directly via the FedoraApiM object this will not be called as we
- * don't have access to the ingested datastream at that time.
- *
  * @param AbstractObject $object
  *   The object the datastream belongs to.
  * @param AbstractDatastream $datastream
  *   The ingested datastream.
+ *
+ * @note
+ * If ingested directly via the FedoraApiM object this will not be called as we
+ * don't have access to the ingested datastream at that time.
  */
 function hook_islandora_datastream_ingested(AbstractObject $object, AbstractDatastream $datastream) {
 
@@ -394,7 +403,7 @@ function hook_cmodel_pid_dsid_islandora_datastream_purged(AbstractObject $object
  *   - name: A string containg a human-readable name for the entry.
  *   - url: A string containing the URL to which to the user will be routed.
  */
-function hook_islandora_edit_datastream_registry($object, $dsid) {
+function hook_islandora_edit_datastream_registry(AbstractObject $object, $dsid) {
   $routes = array();
   $routes[] = array(
     'name' => t('My Awesome Edit Route'),
@@ -451,7 +460,7 @@ function hook_islandora_undeletable_datastreams(array $models) {
  *
  * @param array $form_state
  *   An array containing the form_state, on which infomation from step storage
- *   might be extracted.  Note that the
+ *   might be extracted.
  *
  * @return array
  *   An associative array of associative arrays which define each step in the
@@ -511,7 +520,6 @@ function hook_islandora_ingest_steps(array $form_state) {
  *
  * @param array $steps
  *   An array of steps as generated by hook_islandora_ingest_steps().
- *
  * @param array $form_state
  *   An array containing the Drupal form_state.
  */
@@ -538,7 +546,6 @@ function hook_cmodel_pid_islandora_ingest_steps(array $form_state) {
  *
  * @param array $steps
  *   An array of steps as generated by hook_islandora_ingest_steps().
- *
  * @param array $form_state
  *   An array containing the Drupal form_state.
  */
@@ -557,13 +564,13 @@ function hook_cmodel_pid_islandora_ingest_steps_alter(array &$steps, array &$for
  * @param object $user
  *   A loaded user object, as the global $user variable might contain.
  *
- * @return bool|NULL|array
+ * @return bool|null|array
  *   Either boolean TRUE or FALSE to explicitly allow or deny the operation on
  *   the given object, or NULL to indicate that we are making no assertion
  *   about the outcome. Can also be an array containing multiple
  *   TRUE/FALSE/NULLs, due to how hooks work.
  */
-function hook_islandora_object_access($op, $object, $user) {
+function hook_islandora_object_access($op, AbstractObject $object, $user) {
   switch ($op) {
     case 'create stuff':
       return TRUE;
@@ -596,13 +603,13 @@ function hook_cmodel_pid_islandora_object_access($op, $object, $user) {
  * @param object $user
  *   A loaded user object, as the global $user variable might contain.
  *
- * @return bool|NULL|array
+ * @return bool|null|array
  *   Either boolean TRUE or FALSE to explicitly allow or deny the operation on
  *   the given object, or NULL to indicate that we are making no assertion
  *   about the outcome. Can also be an array containing multiple
  *   TRUE/FALSE/NULLs, due to how hooks work.
  */
-function hook_islandora_datastream_access($op, $object, $user) {
+function hook_islandora_datastream_access($op, AbstractDatastream $object, $user) {
   switch ($op) {
     case 'create stuff':
       return TRUE;
@@ -664,7 +671,7 @@ function hook_cmodel_pid_islandora_overview_object_alter(AbstractObject &$object
  * hierarchy.
  *
  * @param AbstractObject $object
- *   Optional object to which derivatives will be added
+ *   Optional object to which derivatives will be added.
  * @param array $ds_modified_params
  *   An array that will contain the properties changed on the datastream if
  *   derivatives were triggered from a datastream_modified hook, as well as a
@@ -703,7 +710,7 @@ function hook_cmodel_pid_islandora_overview_object_alter(AbstractObject &$object
  *   - file: A string denoting the path to the file where the function
  *     is being called from.
  */
-function hook_islandora_derivative(AbstractObject $object = NULL, $ds_modified_params = array()) {
+function hook_islandora_derivative(AbstractObject $object = NULL, array $ds_modified_params = array()) {
   $derivatives[] = array(
     'source_dsid' => 'OBJ',
     'destination_dsid' => 'DERIV',
@@ -777,7 +784,7 @@ function hook_cmodel_pid_islandora_derivative_alter() {
  * Retrieves PIDS of related objects for property updating.
  *
  * @param AbstractObject $object
- *   AbstractObject representing deleted object
+ *   AbstractObject representing deleted object.
  */
 function hook_islandora_update_related_objects_properties(AbstractObject $object) {
   $related_objects = get_all_children_siblings_and_friends($object);
@@ -796,9 +803,9 @@ function hook_islandora_update_related_objects_properties(AbstractObject $object
  * @param string $context
  *   Where the alter is originating from for distinguishing.
  * @param AbstractObject $object
- *   (Optional) AbstractObject representing object providing breadcrumb path
+ *   (Optional) AbstractObject representing object providing breadcrumb path.
  */
-function hook_islandora_breadcrumbs_alter(&$breadcrumbs, $context, $object = NULL) {
+function hook_islandora_breadcrumbs_alter(array &$breadcrumbs, $context, AbstractObject $object = NULL) {
 
 }
 
@@ -883,7 +890,7 @@ function hook_islandora_get_breadcrumb_query_predicates() {
  *   - original_edit_registry: The original edit_registry prior to any
  *     modifications.
  */
-function hook_islandora_edit_datastream_registry_alter(&$edit_registry, $context) {
+function hook_islandora_edit_datastream_registry_alter(array &$edit_registry, array $context) {
   // Example: Remove xml form builder edit registry.
   if (isset($edit_registry['xml_form_builder_edit_form_registry'])) {
     unset($edit_registry['xml_form_builder_edit_form_registry']);
@@ -951,7 +958,6 @@ function callback_islandora_breadcrumbs_backends(AbstractObject $object) {
  *
  * @param string $filename
  *   The filename being created.
- *
  * @param AbstractDatastream $datastream
  *   The datastream object being downloaded.
  */

--- a/islandora.module
+++ b/islandora.module
@@ -4,7 +4,7 @@
  * @file
  * Defines all the hooks this module implements.
  *
- * islandora.module: defines paths (drupal menu items) as entry points and acts
+ * Islandora.module: defines paths (drupal menu items) as entry points and acts
  *  as a hub for dispatching tasks to other modules.
  *
  * This file is part of Islandora.
@@ -76,7 +76,7 @@ const ISLANDORA_BREADCRUMB_LEGACY_BACKEND = 'islandora_breadcrumbs_legacy_sparql
  * Implements hook_menu().
  *
  * We need some standard entry points so we can have consistent urls for
- * different Object actions
+ * different Object actions.
  */
 function islandora_menu() {
   $items = array();
@@ -190,7 +190,8 @@ function islandora_menu() {
         ISLANDORA_ADD_DS,
         ISLANDORA_PURGE,
         ISLANDORA_INGEST,
-      ), 2),
+      ), 2,
+    ),
   );
   $items['islandora/object/%islandora_object/manage/overview'] = array(
     'title' => 'Overview',
@@ -208,7 +209,8 @@ function islandora_menu() {
         ISLANDORA_METADATA_EDIT,
         ISLANDORA_ADD_DS,
         ISLANDORA_PURGE,
-      ), 2),
+      ), 2,
+    ),
     'weight' => -10,
   );
   $items['islandora/object/%islandora_object/manage/properties'] = array(
@@ -437,7 +439,7 @@ function islandora_admin_paths() {
  * The theme entries 'islandora_objects' and 'islandora_objects_subset'
  * utilize the same template file. When theming, be sure to utilize the theme
  * name, and not the template file names. Similar situation found here:
- * @link https://jira.duraspace.org/browse/ISLANDORA-934. @endlink
+ * @link https://jira.duraspace.org/browse/ISLANDORA-934. @endlink.
  */
 function islandora_theme() {
   return array(
@@ -722,7 +724,7 @@ function islandora_print_object(AbstractObject $object) {
  *   FALSE if 'islandora_show_print_option' is not selected in islandora
  *   configuraton.
  */
-function islandora_print_object_access($op, $object) {
+function islandora_print_object_access($op, AbstractObject $object) {
   if (!variable_get('islandora_show_print_option', FALSE)) {
     return FALSE;
   }
@@ -750,8 +752,6 @@ function islandora_forms($form_id) {
  * Will check the given user or the user repersented by the GET token parameter,
  * failing that it will use the global user.
  *
- * @global $user
- *
  * @param mixed $object_or_datastream
  *   The AbstractObject or AbstractDatastream to test for accessibility, if NULL
  *   is given the object is assumed to not exist or be inaccessible.
@@ -768,11 +768,13 @@ function islandora_forms($form_id) {
  *   a token to restore the user. If no GET parameter is present use currently
  *   logged in user.
  *
+ * @global $user
+ *
  * @return bool
  *   TRUE if the user is allowed to access this object/datastream, FALSE
  *   otherwise.
  */
-function islandora_user_access($object_or_datastream, array $permissions, $content_models = array(), $access_any = TRUE, $user = NULL) {
+function islandora_user_access($object_or_datastream, array $permissions, array $content_models = array(), $access_any = TRUE, $user = NULL) {
 
   module_load_include('inc', 'islandora', 'includes/utilities');
   $is_repository_accessible = &drupal_static(__FUNCTION__);
@@ -860,7 +862,7 @@ function islandora_user_access($object_or_datastream, array $permissions, $conte
  * Checks whether the user can access the given object.
  *
  * Checks for object existance, accessiblitly, namespace permissions,
- * and user permissions
+ * and user permissions.
  *
  * @param string $perm
  *   User permission to test for.
@@ -871,7 +873,7 @@ function islandora_user_access($object_or_datastream, array $permissions, $conte
  * @return bool
  *   TRUE if the user is allowed to access this object, FALSE otherwise.
  */
-function islandora_object_access_callback($perm, $object = NULL) {
+function islandora_object_access_callback($perm, AbstractObject $object = NULL) {
   module_load_include('inc', 'islandora', 'includes/utilities');
 
   if (!$object && !islandora_describe_repository()) {
@@ -914,7 +916,7 @@ function islandora_object_datastream_tokened_access_callback($perm, $object = NU
  * Checks whether the user can access the given object's manage tab.
  *
  * Checks for object existance, accessiblitly, namespace permissions,
- * and user permissions
+ * and user permissions.
  *
  * @param array $perms
  *   Array of user permission to test for.
@@ -925,7 +927,7 @@ function islandora_object_datastream_tokened_access_callback($perm, $object = NU
  * @return bool
  *   TRUE if the user is allowed to access this object, FALSE otherwise.
  */
-function islandora_object_manage_access_callback($perms, $object = NULL) {
+function islandora_object_manage_access_callback(array $perms, AbstractObject $object = NULL) {
   module_load_include('inc', 'islandora', 'includes/utilities');
 
   if (!$object && !islandora_describe_repository()) {
@@ -1140,7 +1142,7 @@ function islandora_drupal_title(AbstractObject $object) {
  * @return array
  *   The default rendering of the object view page, indexed at 'Default output'.
  */
-function islandora_default_islandora_view_object($object) {
+function islandora_default_islandora_view_object(AbstractObject $object) {
   $output = theme('islandora_default', array('islandora_object' => $object));
   return array('Default output' => array('#markup' => $output));
 }
@@ -1156,7 +1158,7 @@ function islandora_default_islandora_view_object($object) {
  * @return array
  *   A renderable array
  */
-function islandora_default_islandora_printer_object($object, $alter) {
+function islandora_default_islandora_printer_object(AbstractObject $object, $alter) {
   module_load_include('inc', 'islandora', 'includes/utilities');
   module_load_include('inc', 'islandora', 'includes/datastream');
   module_load_include('inc', 'islandora', 'includes/metadata');
@@ -1165,11 +1167,10 @@ function islandora_default_islandora_printer_object($object, $alter) {
   drupal_add_css($path . '/css/islandora.print.css');
 
   $islandora_object = islandora_object_load($object->id);
-  $repository = $islandora_object->repository;
 
   try {
     $dc = $islandora_object['DC']->content;
-    $dc_object = DublinCore::importFromXMLString($dc);
+    $dc_object = DublinCore::importFromXmlString($dc);
   }
   catch (Exception $e) {
     drupal_set_message(t('Error retrieving object %s %t', array('%s' => $islandora_object->id, '%t' => $e->getMessage())), 'error', FALSE);
@@ -1180,7 +1181,8 @@ function islandora_default_islandora_printer_object($object, $alter) {
     'object' => $object,
     'dc_array' => $variables,
     'metadata' => $metadata,
-    'islandora_content' => $alter));
+    'islandora_content' => $alter,
+  ));
 
   return array('Default output' => array('#markup' => $output));
 }
@@ -1277,7 +1279,7 @@ function islandora_object_load($object_id) {
  * @return FedoraObject
  *   A token authenticated object. @see islandora_object_load
  */
-function islandora_tokened_object_load($object_id, $map) {
+function islandora_tokened_object_load($object_id, array $map) {
   if (array_key_exists('token', $_GET)) {
     $token = filter_input(INPUT_GET, 'token', FILTER_SANITIZE_STRING);
     if ($token) {
@@ -1304,7 +1306,7 @@ function islandora_tokened_object_load($object_id, $map) {
  * islandora_tokened_datastream_load(DSID, DSID, PID)
  *
  * @param mixed $datastream_id
- *   %islandora_tokened_datastream @see islandora_datastream_load
+ *   Load datastream from %islandora_tokened_datastream.
  * @param array $map
  *   Used to extract the Fedora object's PID at $map[2].
  *
@@ -1313,7 +1315,7 @@ function islandora_tokened_object_load($object_id, $map) {
  *
  * @see islandora_datastream_load
  */
-function islandora_tokened_datastream_load($datastream_id, $map) {
+function islandora_tokened_datastream_load($datastream_id, array $map) {
   return islandora_datastream_load($datastream_id, $map[2]);
 }
 
@@ -1329,7 +1331,6 @@ function islandora_tokened_datastream_load($datastream_id, $map) {
  * @param string $datastream_id
  *   The DSID of the datastream specified as '%islandora_datastream' to fetch
  *   from the given object in the menu path identified by '%islandora_object'.
- *
  * @param mixed $object_id
  *   The object to load the datastream from.  This can be a Fedora PID or
  *   an instantiated IslandoraAbstractObject as it implements __toString()
@@ -1365,7 +1366,7 @@ function islandora_datastream_load($datastream_id, $object_id) {
  * @return int
  *   The datastreams version if found, NULL otherwise.
  */
-function islandora_get_islandora_datastream_version($object = NULL, $dsid = NULL, $datastream_file = NULL) {
+function islandora_get_islandora_datastream_version(AbstractObject $object = NULL, $dsid = NULL, $datastream_file = NULL) {
   $return = NULL;
   // @TODO, need better check for $object
   if ($object && $object[$dsid]) {
@@ -1500,15 +1501,15 @@ function islandora_delete_object(AbstractObject &$object) {
 /**
  * Delete's or purges the given datastream.
  *
- * @throws Exception
- *  Which types are undefined, but more than likely because of the hooks
- *  there will be several kinds.
- *
  * @param AbstractDatastream $datastream
  *   The datastream to delete.
  *
  * @return bool
  *   TRUE if successful, FALSE otherwise.
+ *
+ * @throws Exception
+ *   Which types are undefined, but more than likely because of the hooks
+ *   there will be several kinds.
  */
 function islandora_delete_datastream(AbstractDatastream &$datastream) {
   $object = $datastream->parent;
@@ -1641,7 +1642,7 @@ function islandora_entity_property_info() {
  * Implements hook_file_mimetype_mapping_alter().
  *
  * Grab custom Islandora mime type list
- * and add any missing ext/mimes to the Drupal mapping
+ * and add any missing ext/mimes to the Drupal mapping.
  */
 function islandora_file_mimetype_mapping_alter(&$mapping) {
   module_load_include('inc', 'islandora', 'includes/mimetype.utils');
@@ -1677,7 +1678,7 @@ function islandora_file_mimetype_mapping_alter(&$mapping) {
  *   TRUE if at least one implementation of hook_islandora_object_access()
  *   returned TRUE, and no implementation return FALSE; FALSE otherwise.
  */
-function islandora_object_access($op, $object, $user = NULL) {
+function islandora_object_access($op, AbstractObject $object, $user = NULL) {
   $cache = &drupal_static(__FUNCTION__);
 
   if (!is_object($object)) {
@@ -1712,7 +1713,7 @@ function islandora_object_access($op, $object, $user = NULL) {
  * Denies according to PID namespace restrictions, then passes or denies
  * according to core Drupal permissions according to user_access().
  */
-function islandora_islandora_object_access($op, $object, $user) {
+function islandora_islandora_object_access($op, AbstractObject $object, $user) {
   module_load_include('inc', 'islandora', 'includes/utilities');
   $access = (islandora_namespace_accessible($object->id) && user_access($op, $user));
   if (($object->state != 'A') && variable_get('islandora_deny_inactive_and_deleted', FALSE)) {
@@ -1726,7 +1727,7 @@ function islandora_islandora_object_access($op, $object, $user) {
  *
  * Positive permissions on object access suggests on the datastream.
  */
-function islandora_datastream_access($op, $datastream, $user = NULL) {
+function islandora_datastream_access($op, AbstractDatastream $datastream, $user = NULL) {
   $cache = &drupal_static(__FUNCTION__);
 
   if (!is_object($datastream)) {
@@ -2003,7 +2004,7 @@ function islandora_islandora_datastream_access($op, AbstractDatastream $datastre
  * Access for submenu items.
  *
  * @param string $package_name
- *   Name of the package
+ *   Name of the package.
  *
  * @return bool
  *   Access granted
@@ -2217,7 +2218,7 @@ function islandora_islandora_breadcrumbs_backends() {
 }
 
 /**
- * Implements hook_islandora_solution_pack_child_relationships
+ * Implements hook_islandora_solution_pack_child_relationships().
  */
 function islandora_islandora_solution_pack_child_relationships($cmodels) {
   // Return empty arrays from core implementation so that these keys always

--- a/islandora.module
+++ b/islandora.module
@@ -1666,19 +1666,11 @@ function islandora_file_mimetype_mapping_alter(&$mapping) {
 /**
  * Hookable object access callback.
  *
- * @param string $op
- *   String identifying an operation to check. Should correspond to a
- *   permission declared via hook_permission().
- * @param AbstractObject $object
- *   An object to check for permissions.
- * @param object $user
- *   An optional loaded user object. Defaults to the global $user.
- *
  * @return bool
  *   TRUE if at least one implementation of hook_islandora_object_access()
  *   returned TRUE, and no implementation return FALSE; FALSE otherwise.
  */
-function islandora_object_access($op, AbstractObject $object, $user = NULL) {
+function islandora_object_access($op, $object, $user = NULL) {
   $cache = &drupal_static(__FUNCTION__);
 
   if (!is_object($object)) {
@@ -1727,7 +1719,7 @@ function islandora_islandora_object_access($op, AbstractObject $object, $user) {
  *
  * Positive permissions on object access suggests on the datastream.
  */
-function islandora_datastream_access($op, AbstractDatastream $datastream, $user = NULL) {
+function islandora_datastream_access($op, $datastream, $user = NULL) {
   $cache = &drupal_static(__FUNCTION__);
 
   if (!is_object($datastream)) {

--- a/islandora.module
+++ b/islandora.module
@@ -866,14 +866,14 @@ function islandora_user_access($object_or_datastream, array $permissions, array 
  *
  * @param string $perm
  *   User permission to test for.
- * @param AbstractObject $object
+ * @param AbstractObject|string $object
  *   The object to test, if NULL given the object doesn't exist or is
  *   inaccessible.
  *
  * @return bool
  *   TRUE if the user is allowed to access this object, FALSE otherwise.
  */
-function islandora_object_access_callback($perm, AbstractObject $object = NULL) {
+function islandora_object_access_callback($perm, $object = NULL) {
   module_load_include('inc', 'islandora', 'includes/utilities');
 
   if (!$object && !islandora_describe_repository()) {
@@ -1331,7 +1331,7 @@ function islandora_tokened_datastream_load($datastream_id, array $map) {
  * @param string $datastream_id
  *   The DSID of the datastream specified as '%islandora_datastream' to fetch
  *   from the given object in the menu path identified by '%islandora_object'.
- * @param mixed $object_id
+ * @param AbstractObject|string $object_id
  *   The object to load the datastream from.  This can be a Fedora PID or
  *   an instantiated IslandoraAbstractObject as it implements __toString()
  *   returning the PID.
@@ -1665,6 +1665,14 @@ function islandora_file_mimetype_mapping_alter(&$mapping) {
 
 /**
  * Hookable object access callback.
+ *
+ * @param string $op
+ *   String identifying an operation to check. Should correspond to a
+ *   permission declared via hook_permission().
+ * @param AbstractObject|string $object
+ *   An object to check for permissions.
+ * @param object $user
+ *   An optional loaded user object. Defaults to the global $user.
  *
  * @return bool
  *   TRUE if at least one implementation of hook_islandora_object_access()

--- a/islandora.rules.inc
+++ b/islandora.rules.inc
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Does rule type stuff,
+ * Does rule type stuff,.
  */
 
 /**
@@ -157,7 +157,6 @@ function islandora_rules_base_xpath_parameters() {
     ),
   );
 }
-
 
 /**
  * Implements hook_rules_condition_info().
@@ -397,7 +396,7 @@ function islandora_rules_datastream_load_domxpath($string) {
  *   A loaded Drupal taxonomy vocabulary object, in which terms are understood
  *   to be namespace prefixes and descriptions are the namespace URIs.
  */
-function islandora_rules_datastream_load_namespace_vocab($xpath, $xpath_vocab) {
+function islandora_rules_datastream_load_namespace_vocab(DOMXPath $xpath, $xpath_vocab) {
   foreach (taxonomy_get_tree($xpath_vocab->vid, 0, 1, FALSE) as $term) {
     $xpath->registerNamespace($term->name, $term->description);
   }
@@ -499,7 +498,7 @@ function islandora_rules_data_info() {
  *   The object on which to set the property, described by $info['property'].
  * @param array $options
  *   An array of options... Not sure how it's used? Not touched by us, in any
- *   case. :P
+ *   case. :P.
  * @param string $name
  *   The name of the property to set, as used by Rules.
  * @param string $type
@@ -510,7 +509,7 @@ function islandora_rules_data_info() {
  *   - property: A string indicate the actual property on the $data we wish to
  *     set.
  */
-function islandora_rules_property_get($data, array $options, $name, $type, $info) {
+function islandora_rules_property_get($data, array $options, $name, $type, array $info) {
   return $data->$info['property'];
 }
 
@@ -536,7 +535,7 @@ function islandora_rules_property_get($data, array $options, $name, $type, $info
  *   - property: A string indicate the actual property on the $data we wish to
  *     set.
  */
-function islandora_rules_property_set(&$data, $name, $value, $langcode, $type, $info) {
+function islandora_rules_property_set(&$data, $name, $value, $langcode, $type, array $info) {
   $data->$info['property'] = $value;
 }
 

--- a/tests/authtokens.test
+++ b/tests/authtokens.test
@@ -5,6 +5,9 @@
  * Test Authentication Tokens.
  */
 
+/**
+ *
+ */
 class IslandoraAuthtokensTestCase extends IslandoraWebTestCase {
 
   /**
@@ -107,4 +110,5 @@ class IslandoraAuthtokensTestCase extends IslandoraWebTestCase {
   public function testTokenedViewDatastreamWithXacml() {
     // We need to add this test.
   }
+
 }

--- a/tests/authtokens.test
+++ b/tests/authtokens.test
@@ -6,7 +6,7 @@
  */
 
 /**
- *
+ * Auth token tests.
  */
 class IslandoraAuthtokensTestCase extends IslandoraWebTestCase {
 
@@ -19,13 +19,6 @@ class IslandoraAuthtokensTestCase extends IslandoraWebTestCase {
       'description' => 'Ensure the correct functionality of the tokens to pass authorization to Djatoka in Islandora.',
       'group' => 'Islandora',
     );
-  }
-
-  /**
-   * Set up data for the tests.
-   */
-  public function setUp() {
-    parent::setUp();
   }
 
   /**

--- a/tests/datastream_cache.test
+++ b/tests/datastream_cache.test
@@ -5,6 +5,9 @@
  * Tests to verify the cache headers we provide.
  */
 
+/**
+ * Datastream caching tests.
+ */
 class IslandoraDatastreamCacheTestCase extends IslandoraWebTestCase {
 
   /**
@@ -134,7 +137,7 @@ class IslandoraDatastreamCacheTestCase extends IslandoraWebTestCase {
     ));
     $this->assertResponse(200);
 
-    // Test combination of If-None-Match and If-Modified-Since
+    // Test combination of If-None-Match and If-Modified-Since.
     $result = $this->drupalGet("islandora/object/{$object->id}/datastream/{$datastream->id}/view", array(), array(
       'If-Modified-Since: ' . $datastream->createdDate->format('D, d M Y H:i:s \G\M\T'),
       format_string('If-None-Match: "!checksum"', array(
@@ -157,4 +160,5 @@ class IslandoraDatastreamCacheTestCase extends IslandoraWebTestCase {
     ));
     $this->assertResponse(200);
   }
+
 }

--- a/tests/datastream_validator_tests.test
+++ b/tests/datastream_validator_tests.test
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * Tests for things that test tests. Madness.
@@ -22,6 +23,7 @@ class TestDatastreamValidator extends DatastreamValidator {
   protected function assertSomethingFailed() {
     $this->addResult(FALSE, 'boo you failed', $this->getAssertionCall());
   }
+
 }
 
 /**
@@ -109,8 +111,8 @@ class DatastreamValidatorResultTestCase extends IslandoraWebTestCase {
       $this->assertTrue(substr($first_caller['file'], -48) === substr($second_caller['file'], -48), "Fail caller file matches the pass caller file.", 'Islandora');
       $this->assertTrue($first_caller['function'] === 'TestDatastreamValidator->assertSomethingSuccessfully()', "Correct pass caller function returned (actual: {$first_caller['function']}; expected: TestDatastreamValidator->assertSomethingSuccessfully()).", 'Islandora');
       $this->assertTrue($second_caller['function'] === 'TestDatastreamValidator->assertSomethingFailed()', "Correct fail caller function returned (actual: {$second_caller['function']}; expected: TestDatastreamValidator->assertSomethingFailed()).", 'Islandora');
-      $this->assertTrue($first_caller['line'] === 16, "Correct pass line number returned (actual: {$first_caller['line']}; expected: 16).", 'Islandora');
-      $this->assertTrue($second_caller['line'] === 23, "Correct fail line number returned (actual: {$second_caller['line']}; expected: 23).", 'Islandora');
+      $this->assertTrue($first_caller['line'] === 17, "Correct pass line number returned (actual: {$first_caller['line']}; expected: 17).", 'Islandora');
+      $this->assertTrue($second_caller['line'] === 24, "Correct fail line number returned (actual: {$second_caller['line']}; expected: 24).", 'Islandora');
     }
   }
 
@@ -222,7 +224,7 @@ class PrefixDatastreamValidatorTestCase extends IslandoraWebTestCase {
       'dsid' => $prefix,
       'path' => $this->path . $filename,
       'control_group' => 'M',
-      ),
+    ),
     );
     $object = $this->ingestConstructedObject(array(), $datastreams);
     return $object;
@@ -273,4 +275,5 @@ class PrefixDatastreamValidatorTestCase extends IslandoraWebTestCase {
       }
     }
   }
+
 }

--- a/tests/datastream_versions.test
+++ b/tests/datastream_versions.test
@@ -2,9 +2,12 @@
 
 /**
  * @file
- * Tests that datastream versions code works as intended
+ * Tests that datastream versions code works as intended.
  */
 
+/**
+ * Datastream version tests.
+ */
 class IslandoraDatastreamVersionTestCase extends IslandoraWebTestCase {
 
   /**
@@ -195,4 +198,5 @@ class IslandoraDatastreamVersionTestCase extends IslandoraWebTestCase {
     $this->drupalGet("islandora/object/{$this->pid}/datastream/DC/version/0/delete");
     $this->assertResponse(404);
   }
+
 }

--- a/tests/derivatives.test
+++ b/tests/derivatives.test
@@ -11,6 +11,9 @@
  * To make sense of these tests reference islandora_derivatives_test.module.
  */
 
+/**
+ * Derivative hook tests.
+ */
 class IslandoraDerivativesTestCase extends IslandoraWebTestCase {
 
   /**
@@ -334,4 +337,5 @@ class IslandoraDerivativesTestCase extends IslandoraWebTestCase {
     $object->ingestDatastream($ds);
     return $object;
   }
+
 }

--- a/tests/derivatives.test
+++ b/tests/derivatives.test
@@ -208,7 +208,7 @@ class IslandoraDerivativesTestCase extends IslandoraWebTestCase {
   /**
    * Tests that when no source_dsid all derivative functions are called.
    */
-  public function testNoSourceDSIDNoForce() {
+  public function testNoSourceDsidNoForce() {
     global $_islandora_derivative_test_derivative_functions;
     $_islandora_derivative_test_derivative_functions = array();
     $object = $this->constructBaseObject();

--- a/tests/derivatives.test
+++ b/tests/derivatives.test
@@ -96,8 +96,8 @@ class IslandoraDerivativesTestCase extends IslandoraWebTestCase {
     global $_islandora_derivative_test_ingest_method;
     $_islandora_derivative_test_ingest_method = 'ingestDatastream';
     $object = $this->constructBaseObject();
-    $object = $this->constructDERIVDatastream($object);
-    $this->constructNOSOURCEDatastream($object);
+    $object = $this->constructDerivDatastream($object);
+    $this->constructNoSourceDatastream($object);
     $islandora_object = islandora_object_load($this->pid);
     islandora_do_derivatives($islandora_object, array(
       'force' => TRUE,
@@ -128,7 +128,7 @@ class IslandoraDerivativesTestCase extends IslandoraWebTestCase {
     global $_islandora_derivative_test_ingest_method;
     $_islandora_derivative_test_ingest_method = 'ingestDatastream';
     $object = $this->constructBaseObject();
-    $this->constructDERIVDatastream($object);
+    $this->constructDerivDatastream($object);
     // Need to do this as Tuque caches.
     $connection = islandora_get_tuque_connection();
     $connection->cache->resetCache();
@@ -159,11 +159,11 @@ class IslandoraDerivativesTestCase extends IslandoraWebTestCase {
   /**
    * Tests derivative hook filtering based upon source_dsid.
    */
-  public function testDerivativeFilteringOnSourceDSID() {
+  public function testDerivativeFilteringOnSourceDsid() {
     global $_islandora_derivative_test_derivative_functions;
     $_islandora_derivative_test_derivative_functions = array();
     $object = $this->constructBaseObject();
-    $this->constructSOMEWEIRDDATASTREAMDatastream($object);
+    $this->constructSomeWeirdDatastream($object);
     $object = islandora_object_load($this->pid);
     islandora_do_derivatives($object, array(
       'source_dsid' => 'OBJ',
@@ -185,7 +185,7 @@ class IslandoraDerivativesTestCase extends IslandoraWebTestCase {
   /**
    * Tests that only functions were the source_dsid is NULL are fired.
    */
-  public function testNULLSourceDSID() {
+  public function testNullSourceDsid() {
     global $_islandora_derivative_test_derivative_functions;
     $_islandora_derivative_test_derivative_functions = array();
     $this->constructBaseObject();
@@ -212,7 +212,7 @@ class IslandoraDerivativesTestCase extends IslandoraWebTestCase {
     global $_islandora_derivative_test_derivative_functions;
     $_islandora_derivative_test_derivative_functions = array();
     $object = $this->constructBaseObject();
-    $object = $this->constructSOMEWEIRDDATASTREAMDatastream($object);
+    $object = $this->constructSomeWeirdDatastream($object);
     $object = islandora_object_load($this->pid);
     islandora_do_derivatives($object, array());
     $this->assertDatastreams($object, array(
@@ -230,11 +230,11 @@ class IslandoraDerivativesTestCase extends IslandoraWebTestCase {
   /**
    * Tests that when no source_dsid all derivative functions are called.
    */
-  public function testNoSourceDSIDForce() {
+  public function testNoSourceDsidForce() {
     global $_islandora_derivative_test_derivative_functions;
     $_islandora_derivative_test_derivative_functions = array();
     $object = $this->constructBaseObject();
-    $this->constructSOMEWEIRDDATASTREAMDatastream($object);
+    $this->constructSomeWeirdDatastream($object);
     $object = islandora_object_load($this->pid);
     islandora_do_derivatives($object, array(
       'force' => TRUE,
@@ -293,7 +293,7 @@ class IslandoraDerivativesTestCase extends IslandoraWebTestCase {
    * @return AbstractObject
    *   The modified AbstractObject.
    */
-  public function constructDERIVDatastream(AbstractObject $object) {
+  public function constructDerivDatastream(AbstractObject $object) {
     $dsid = 'DERIV';
     $ds = $object->constructDatastream($dsid);
     $ds->label = 'Test';
@@ -311,7 +311,7 @@ class IslandoraDerivativesTestCase extends IslandoraWebTestCase {
    * @return AbstractObject
    *   The modified AbstractObject.
    */
-  public function constructNOSOURCEDatastream(AbstractObject $object) {
+  public function constructNoSourceDatastream(AbstractObject $object) {
     $dsid = 'NOSOURCE';
     $ds = $object->constructDatastream($dsid);
     $ds->label = 'Test';
@@ -329,7 +329,7 @@ class IslandoraDerivativesTestCase extends IslandoraWebTestCase {
    * @return AbstractObject
    *   The modified AbstractObject.
    */
-  public function constructSOMEWEIRDDATASTREAMDatastream(AbstractObject $object) {
+  public function constructSomeWeirdDatastream(AbstractObject $object) {
     $dsid = 'SOMEWEIRDDATASTREAM';
     $ds = $object->constructDatastream($dsid);
     $ds->label = 'Test';

--- a/tests/hooked_access.test
+++ b/tests/hooked_access.test
@@ -11,6 +11,9 @@
  * To make sense of these tests reference islandora_hooked_access_test.module.
  */
 
+/**
+ * Access hook tests.
+ */
 class IslandoraHookedAccessTestCase extends IslandoraWebTestCase {
 
   /**
@@ -92,20 +95,6 @@ class IslandoraHookedAccessTestCase extends IslandoraWebTestCase {
   }
 
   /**
-   * Deny an object permission check without an object.
-   */
-  public function testDenyBadObject() {
-    $this->assertFalse(islandora_object_access($this->op, 'this is not an object'), 'Deny bad objects.');
-  }
-
-  /**
-   * Deny a datastream permission check without a datastream.
-   */
-  public function testDenyBadDatastream() {
-    $this->assertFalse(islandora_datastream_access($this->op, 'this is not a datastream'), 'Deny bad datastreams.');
-  }
-
-  /**
    * Allow operation on object.
    */
   public function testAllowObject() {
@@ -146,4 +135,5 @@ class IslandoraHookedAccessTestCase extends IslandoraWebTestCase {
   public function testDenyDatastreamExplicit() {
     $this->assertFalse(islandora_datastream_access($this->denied_op, $this->object['asdf']), 'Explicit denial of datastream access.');
   }
+
 }

--- a/tests/hooks.test
+++ b/tests/hooks.test
@@ -11,6 +11,9 @@
  * To make sense of these tests reference islandora_hooks_test.module.
  */
 
+/**
+ * Islandora hooks tests.
+ */
 class IslandoraHooksTestCase extends IslandoraWebTestCase {
 
   /**
@@ -256,4 +259,5 @@ class IslandoraHooksTestCase extends IslandoraWebTestCase {
     $this->assert($_SESSION['islandora_hooks']['hook'][ISLANDORA_DATASTREAM_INGESTED_HOOK], 'Called ISLANDORA_DATASTREAM_INGESTED_HOOK when ingesting via FedoraObject::ingestDatastream.');
     $this->repository->purgeObject($object->id);
   }
+
 }

--- a/tests/includes/datastream_validators.inc
+++ b/tests/includes/datastream_validators.inc
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * Classes and functions for datastream validation.
@@ -16,7 +17,7 @@
  *   The hexidecimal string.
  *
  * @throws Exception
- *   if something horrible happens during the actual conversion.
+ *   If something horrible happens during the actual conversion.
  *
  * @return bool|int
  *   FALSE on failure, or the integer on success.
@@ -221,14 +222,14 @@ class TIFFDatastreamValidator extends DatastreamValidator {
   /**
    * Asserts that the TIFF contains an appropriate header.
    */
-  public function assertTIFFHeaderHex() {
-    $datastream_header_hex = self::getTIFFHeaderHex();
+  public function assertTiffHeaderHex() {
+    $datastream_header_hex = self::getTiffHeaderHex();
     if ($datastream_header_hex == "49492a00") {
       // In this case, the ingested TIFF is designated as using the "Intel
       // byte-order" (i.e. little-endian) by starting with the characters "II"
       // (repeated so that byte order does not yet need to be significant).
       // The number that follows is '42' in little-endian hex, a number of
-      // 'deep philosophical significance' to the TIFF format creators.'
+      // 'deep philosophical significance' to the TIFF format creators.'.
       $this->addResult(TRUE, "{$this->datastream} datastream asserts that it is a valid Intel-byte-orderded TIF/TIFF file.");
     }
     elseif ($datastream_header_hex == "4d4d002a") {
@@ -248,7 +249,7 @@ class TIFFDatastreamValidator extends DatastreamValidator {
    * @return string
    *   The ... thing I just wrote up there.
    */
-  protected function getTIFFHeaderHex() {
+  protected function getTiffHeaderHex() {
     return substr(bin2hex($this->datastreamContent), 0, 8);
   }
 
@@ -265,7 +266,7 @@ class JP2DatastreamValidator extends DatastreamValidator {
    * JP2 files begin with an offset header at the second 32-bit integer,
    * 0x6A502020. This header is in all .jp2s, and we check for it here.
    */
-  protected function assertJP2Header() {
+  protected function assertJp2Header() {
     $assertion = substr(bin2hex($this->datastreamContent), 8, 8) == '6a502020';
     $pass = "Datastream {$this->datastream} contains the appropriate JP2 header.";
     $fail = "Datastream {$this->datastream} does not contain the appropriate JP2 header.";
@@ -279,13 +280,14 @@ class JP2DatastreamValidator extends DatastreamValidator {
    * JP2 files have their codestream capped with a marker, 0xFFD9. We're just
    * checking for it here to see if the .jp2 encoder finished okay.
    */
-  protected function assertJP2Marker() {
+  protected function assertJp2Marker() {
     $assertion = substr(bin2hex($this->datastreamContent), strlen(bin2hex($this->datastreamContent)) - 4, 4) == 'ffd9';
     $pass = "Datastream {$this->datastream} contains the appropriate JP2 ending marker.";
     $fail = "Datastream {$this->datastream} does not contain the appropriate JP2 ending marker. If this is the only JP2 validator that failed, it is likely that derivative generation was interrupted.";
     $message = $assertion ? $pass : $fail;
     $this->addResult($assertion, $message);
   }
+
 }
 
 /**
@@ -296,7 +298,7 @@ class PDFDatastreamValidator extends DatastreamValidator {
   /**
    * Validates the PDF signature.
    */
-  protected function assertPDFSignature() {
+  protected function assertPdfSignature() {
     $assertion = substr($this->datastreamContent, 0, 5) == '%PDF-';
     $pdf_version = substr($this->datastreamContent, 5, 3);
     $pass = "{$this->datastream} datastream asserts that it is a valid PDF file using PDF version {$pdf_version}";
@@ -308,7 +310,7 @@ class PDFDatastreamValidator extends DatastreamValidator {
   /**
    * Counts the number of signatures in this PDF file and asserts there are any.
    */
-  protected function assertPDFStreamCount() {
+  protected function assertPdfStreamCount() {
     $pdf_stream_count = substr_count(bin2hex($this->datastreamContent), '0a73747265616d0a');
     $assertion = $pdf_stream_count !== 0;
     $pass = "{$this->datastream} datastream reports the existence of {$pdf_stream_count} PDF streams. Note that an extremely low number could still indicate corruption.";
@@ -319,17 +321,15 @@ class PDFDatastreamValidator extends DatastreamValidator {
 
   /**
    * Validates the PDF closing tag.
-   *
-   * @return bool
-   *   TRUE if it was present; FALSE otherwise.
    */
-  protected function assertPDFClosingTag() {
+  protected function assertPdfClosingTag() {
     $assertion = strpos(bin2hex($this->datastreamContent), '0a2525454f460a') == TRUE;
     $pass = "{$this->datastream} datastream reports the existence of the closing 'EOF' tag required at the end of PDFs";
     $fail = "{$this->datastream} datastream does not contain the closing 'EOF' tag. If this is the only PDF validation that failed, it is likely that derivative generation was interrupted.";
     $message = $assertion ? $pass : $fail;
     $this->addResult($assertion, $message);
   }
+
 }
 
 /**
@@ -340,6 +340,7 @@ class PDFDatastreamValidator extends DatastreamValidator {
  * integer representing the number of times it should appear in the datastream.
  */
 class TextDatastreamValidator extends DatastreamValidator {
+
   /**
    * Constructor override; blow up if we don't have our two values.
    */
@@ -369,6 +370,7 @@ class TextDatastreamValidator extends DatastreamValidator {
   protected function getTextStringCount() {
     return substr_count($this->datastreamContent, $this->params[0]);
   }
+
 }
 
 /**
@@ -401,7 +403,7 @@ class WAVDatastreamValidator extends DatastreamValidator {
   /**
    * Asserts that the datastream contains a valid WAV signature.
    */
-  protected function assertWAVSignature() {
+  protected function assertWavSignature() {
     $signatures = str_split(substr($this->datastreamContent, 0, 24), 8);
     $assertion = $signatures[0] == '52494646' && $signatures[2] == '57415645';
     $pass = "Header of the {$this->datastream} datastream contains a valid file signature.";
@@ -413,7 +415,7 @@ class WAVDatastreamValidator extends DatastreamValidator {
   /**
    * Asserts that the chunksize in the header is correct.
    */
-  protected function assertWAVChunkSize() {
+  protected function assertWavChunkSize() {
     $assertion = islandora_hex2int(substr($this->datastreamContent, 8, 8)) === 36 + self::getDataSubChunkSize();
     $pass = "{$this->datastream} datastream chunksize in WAV header is correct";
     $fail = "{$this->datastream} datastream chunksize in WAV header does not match actual chunksize.";
@@ -424,7 +426,7 @@ class WAVDatastreamValidator extends DatastreamValidator {
   /**
    * Asserts that the datastream contains a 'fmt' subchunk.
    */
-  protected function assertWAVFmtSubChunk() {
+  protected function assertWavFmtSubChunk() {
     $assertion = substr($this->datastreamContent, 24, 8) === '666d7420';
     $pass = "{$this->datastream} datastream contains a 'fmt' subchunk.";
     $fail = "{$this->datastream} datastream is missing the required 'fmt' subchunk.";
@@ -435,7 +437,7 @@ class WAVDatastreamValidator extends DatastreamValidator {
   /**
    * Asserts that the byterate reported by the WAV header is valid.
    */
-  protected function assertWAVByteRate() {
+  protected function assertWavByteRate() {
     $wav_samplerate = islandora_hex2int(substr($this->datastreamContent, 48, 8));
     $assertion = islandora_hex2int(substr($this->datastreamContent, 56, 8)) === $wav_samplerate * self::getNumChannels() * self::getBytesPerSample();
     $pass = "{$this->datastream} datastream byterate in the WAV header is correct.";
@@ -447,7 +449,7 @@ class WAVDatastreamValidator extends DatastreamValidator {
   /**
    * Asserts that the block alignment is correct.
    */
-  protected function assertWAVBlockAlignment() {
+  protected function assertWavBlockAlignment() {
     $assertion = islandora_hex2int(substr($this->datastreamContent, 64, 4)) === self::getNumChannels() * self::getBytesPerSample();
     $pass = "{$this->datastream} datastream block alignment is set correctly.";
     $fail = "{$this->datastream} datastream block alignment is off.";
@@ -460,7 +462,7 @@ class WAVDatastreamValidator extends DatastreamValidator {
    *
    * Also asserts that the subchunk size is correct.
    */
-  protected function assertWAVDataSubChunk() {
+  protected function assertWavDataSubChunk() {
     if (substr($this->datastreamContent, 72, 8) !== '64617461') {
       $this->addResult(FALSE, "{$this->datastream} datastream is missing the 'data' subchunk.");
       return;
@@ -505,6 +507,7 @@ class WAVDatastreamValidator extends DatastreamValidator {
   protected function getDataSubChunkSize() {
     return islandora_hex2int(substr($this->datastreamContent, 80, 8));
   }
+
 }
 
 /**
@@ -526,7 +529,7 @@ class MP3DatastreamValidator extends DatastreamValidator {
    * breaking my own rules here and using a single assert function so that I
    * can handle the weird logic.
    */
-  protected function assertValidMP3() {
+  protected function assertValidMp3() {
     $this->datastreamContent = bin2hex($this->datastreamContent);
 
     // If it's not a VBR MP3, we don't have to check much, so let's get that
@@ -612,7 +615,7 @@ class MP4DatastreamValidator extends DatastreamValidator {
   /**
    * Asserts that the datastream is ISO-formatted video.
    */
-  protected function assertISOVideo() {
+  protected function assertIsoVideo() {
     $mp4_ftyp = substr(strpos($this->datastreamContent, 'ftyp'), 4, 4);
     $assertion = strpos($this->datastreamContent, 'ftyp') !== 0;
     $pass = "{$this->datastream} datastream asserts that it is a valid ISO-formatted video file using ftyp {$mp4_ftyp}";
@@ -620,6 +623,7 @@ class MP4DatastreamValidator extends DatastreamValidator {
     $message = $assertion ? $pass : $fail;
     $this->addResult($assertion, $message);
   }
+
 }
 
 /**
@@ -636,7 +640,7 @@ class OGGDatastreamValidator extends DatastreamValidator {
   /**
    * Asserts that the datastream contains ogg pages.
    */
-  protected function assertOGGPages() {
+  protected function assertOggPages() {
     $ogg_pages = substr_count($this->datastreamContent, 'OggS');
     $assertion = $ogg_pages !== 0;
     $pass = "{$this->datastream} datastream asserts that it contains {$ogg_pages} Ogg pages (even a very small file should contain several).";
@@ -666,6 +670,7 @@ class OGGDatastreamValidator extends DatastreamValidator {
     $message = $assertion ? $pass : $fail;
     $this->addResult($assertion, $message);
   }
+
 }
 
 /**
@@ -683,7 +688,7 @@ class MKVDatastreamValidator extends DatastreamValidator {
   /**
    * Asserts that the datastream is an EBML-format file.
    */
-  protected function assertEBMLFormat() {
+  protected function assertEbmlFormat() {
     $assertion = substr(bin2hex($this->datastreamContent), 0, 8) == '1a45dfa3';
     $pass = "{$this->datastream} datastream asserts that it is an EBML-formatted file";
     $fail = "{$this->datastream} datastream is not an EBML-formatted file.";
@@ -701,4 +706,5 @@ class MKVDatastreamValidator extends DatastreamValidator {
     $message = $assertion ? $pass : $fail;
     $this->addResult($assertion, $message);
   }
+
 }

--- a/tests/includes/islandora_unit_test_case.inc
+++ b/tests/includes/islandora_unit_test_case.inc
@@ -1,9 +1,13 @@
 <?php
+
 /**
  * @file
  * Islandora extensions for DrupalUnitTestCase.
  */
 
+/**
+ * Islandora specific setup for UnitTestCase.
+ */
 class IslandoraUnitTestCase extends DrupalUnitTestCase {
 
   /**
@@ -21,7 +25,7 @@ class IslandoraUnitTestCase extends DrupalUnitTestCase {
    * @param array $args
    *   The arguments for that method.
    */
-  public function __call($method, $args) {
+  public function __call($method, array $args) {
     module_load_include('inc', 'islandora', 'tests/includes/utilities');
     $params = array('db_access' => FALSE);
     $utilities = new IslandoraTestUtilities($this->configuration, $params);
@@ -40,7 +44,7 @@ class IslandoraUnitTestCase extends DrupalUnitTestCase {
    * @param IslandoraTestUtilities $utility
    *   An instance of IslandoraTestUtilities with populated results.
    */
-  public function parseUtilityResults($utility) {
+  public function parseUtilityResults(IslandoraTestUtilities $utility) {
     foreach ($utility->getResults() as $result) {
       $this->assert($result->getType(), $result->getMessage(), 'Islandora', $result->getCaller());
     }

--- a/tests/includes/islandora_web_test_case.inc
+++ b/tests/includes/islandora_web_test_case.inc
@@ -5,6 +5,9 @@
  * Defines the class IslandoraWebTestCase, which allows tests to access Fedora.
  */
 
+/**
+ * Islandora specific state for WebTestCase.
+ */
 class IslandoraWebTestCase extends DrupalWebTestCase {
 
   /**
@@ -43,7 +46,7 @@ class IslandoraWebTestCase extends DrupalWebTestCase {
    * @return bool
    *   TRUE if the result was a pass, or FALSE otherwise.
    */
-  public function __call($method, $args) {
+  public function __call($method, array $args) {
     module_load_include('inc', 'islandora', 'tests/includes/utilities');
     $params = array(
       'logged_in_user' => $this->loggedInUser,
@@ -65,7 +68,7 @@ class IslandoraWebTestCase extends DrupalWebTestCase {
    * @param IslandoraTestUtilities $utility
    *   An instance of IslandoraTestUtilities with populated results.
    */
-  public function parseUtilityResults($utility) {
+  public function parseUtilityResults(IslandoraTestUtilities $utility) {
     foreach ($utility->getResults() as $result) {
       $this->assert($result->getType(), $result->getMessage(), 'Islandora', $result->getCaller());
     }
@@ -253,9 +256,9 @@ class IslandoraWebTestCase extends DrupalWebTestCase {
    * Deletes an object using the PID. This does the deletion using the UI.
    *
    * @param string $pid
-   *   The PID of the collection to be deleted
+   *   The PID of the collection to be deleted.
    * @param string $button
-   *   The label of the first 'Delete' button
+   *   The label of the first 'Delete' button.
    * @param bool $safety
    *   If TRUE, this will only delete objects owned by users in $this->users.
    *
@@ -284,7 +287,7 @@ class IslandoraWebTestCase extends DrupalWebTestCase {
     }
   }
 
-  /**
+  /*
    * These are a few quick helper functions to fill in a gap in the standard
    * DrupalWebTestCase where no function exists to test for the simple existence
    * or non-existence of an error.
@@ -373,8 +376,6 @@ class IslandoraWebTestCase extends DrupalWebTestCase {
    * button labels that don't have the ID we want, so that the only one left
    * with the correct label is the one with the right ID.
    *
-   * @see DrupalWebTestCase::drupalPost()
-   *
    * @param string $path
    *   Location of the post form.
    * @param array $edit
@@ -388,15 +389,17 @@ class IslandoraWebTestCase extends DrupalWebTestCase {
    * @param array $headers
    *   An array containing additional HTTP request headers, each formatted as
    *   "name: value".
-   * @param null $form_html_id
+   * @param string $form_html_id
    *   (optional) HTML ID of the form to be submitted.
-   * @param null $extra_post
+   * @param string $extra_post
    *   (optional) A string of additional data to append to the POST submission.
    *
    * @return bool|string
    *   The content from the POST request's curlExec, or FALSE on fail.
+   *
+   * @see DrupalWebTestCase::drupalPost()
    */
-  public function drupalPostByID($path, $edit, $submit, $id, array $options = array(), array $headers = array(), $form_html_id = NULL, $extra_post = NULL) {
+  public function drupalPostById($path, array $edit, $submit, $id, array $options = array(), array $headers = array(), $form_html_id = NULL, $extra_post = NULL) {
     $buttons = $this->xpath("//input[@type=\"submit\" and @value=\"{$submit}\"]");
     if (empty($buttons)) {
       $this->fail("No buttons found on the page with value '$submit'");

--- a/tests/includes/test_utility_abstraction.inc
+++ b/tests/includes/test_utility_abstraction.inc
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * Abstraction n' stuff for the test utilities and results.
@@ -75,6 +76,7 @@ class IslandoraTestUtilityResult {
   public function getType() {
     return $this->type;
   }
+
 }
 
 /**

--- a/tests/includes/utilities.inc
+++ b/tests/includes/utilities.inc
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * Utilities classes for simpletest.
@@ -13,6 +14,9 @@
  * breaking existing implementations.
  */
 
+/**
+ * An implementation of the IslandoraTestUtilityClass.
+ */
 class IslandoraTestUtilities extends IslandoraTestUtilityClass {
 
   protected $configuration;
@@ -31,7 +35,7 @@ class IslandoraTestUtilities extends IslandoraTestUtilityClass {
    * @param array $params
    *   Any additional parameters the method called may need to function.
    */
-  public function __construct($configuration, array $params = array()) {
+  public function __construct(array $configuration, array $params = array()) {
     $this->configuration = $configuration;
     $this->params = $params;
     $connection = new RepositoryConnection($this->configuration['fedora_url'], $this->configuration['admin_user'], $this->configuration['admin_pass']);
@@ -111,7 +115,7 @@ class IslandoraTestUtilities extends IslandoraTestUtilityClass {
    * @return bool
    *   TRUE on success, FALSE on fail.
    */
-  public function assertDatastreams($object, array $datastreams) {
+  public function assertDatastreams(AbstractObject $object, array $datastreams) {
     if (!self::assertFedoraObject($object)) {
       $this->addResult(FALSE, "Failed. Object passed in is invalid.", 'Islandora');
     }
@@ -136,7 +140,7 @@ class IslandoraTestUtilities extends IslandoraTestUtilityClass {
    * @param array $datastreams
    *   An array of datastreams to confirm not present.
    */
-  public function assertNoDatastreams($object, array $datastreams) {
+  public function assertNoDatastreams(AbstractObject $object, array $datastreams) {
     if (!self::assertFedoraObject($object)) {
       $this->addResult(FALSE, "Failed. Object passed in is invalid.", 'Islandora');
       return;

--- a/tests/ingest.test
+++ b/tests/ingest.test
@@ -11,6 +11,9 @@
  * To make sense of these tests reference islandora_hooks_test.module.
  */
 
+/**
+ * Ingest tests.
+ */
 class IslandoraIngestsTestCase extends IslandoraWebTestCase {
 
   /**

--- a/tests/islandora_derivatives_test.module
+++ b/tests/islandora_derivatives_test.module
@@ -71,6 +71,7 @@ function islandora_derivatives_test_some_cmodel_islandora_derivative_alter(&$der
  *   An AbstractObject representing a Fedora object.
  * @param bool $force
  *   Whether or not derivative generation is to be forced.
+ *
  * @return array
  *   An array detailing the success of the operation.
  *
@@ -131,6 +132,7 @@ function islandora_derivatives_test_create_stanley_datastream(AbstractObject $ob
  *   An AbstractObject representing a Fedora object.
  * @param bool $force
  *   Whether or not derivative generation is to be forced.
+ *
  * @return array
  *   An array detailing the success of the operation.
  *
@@ -226,13 +228,13 @@ function islandora_derivatives_test_add_datastream(AbstractObject $object, $dsid
 /**
  * Returns a message if we failed to add a derivative.
  *
- * @see hook_islandora_derivative()
- *
  * @param string $message
  *   The error message to be returned back.
  *
  * @return array
  *   An array describing the outcome of our failure.
+ *
+ * @see hook_islandora_derivative()
  */
 function islandora_derivatives_test_failed_adding($message) {
   return array(

--- a/tests/islandora_hooked_access_test.module
+++ b/tests/islandora_hooked_access_test.module
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Hook implementations tested in hooked_access.test
+ * Hook implementations tested in hooked_access.test.
  */
 
 /**

--- a/tests/islandora_hooks_test.module
+++ b/tests/islandora_hooks_test.module
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Implements hooks that get tested by islandora_hooks.test
+ * Implements hooks that get tested by islandora_hooks.test.
  */
 
 /**
@@ -112,7 +112,8 @@ function islandora_hooks_test_islandora_object_ingested(AbstractObject $object) 
 function islandora_hooks_test_islandora_object_modified(AbstractObject $object) {
   if ($object->id == 'test:testModifiedObjectHook') {
     $_SESSION['islandora_hooks']['hook'][ISLANDORA_OBJECT_MODIFIED_HOOK] = TRUE;
-    if ($_SESSION['islandora_hooks']['iteration'][ISLANDORA_OBJECT_MODIFIED_HOOK]++ < 3) {
+    while ($_SESSION['islandora_hooks']['iteration'][ISLANDORA_OBJECT_MODIFIED_HOOK] < 3) {
+      $_SESSION['islandora_hooks']['iteration'][ISLANDORA_OBJECT_MODIFIED_HOOK] += 1;
       $new_label = 'New Label! + ' . $_SESSION['islandora_hooks']['iteration'][ISLANDORA_OBJECT_MODIFIED_HOOK];
       $object->label = $new_label;
     }
@@ -143,7 +144,8 @@ function islandora_hooks_test_islandora_datastream_ingested(AbstractObject $obje
 function islandora_hooks_test_islandora_datastream_modified(AbstractObject $object, AbstractDatastream $datastream, array $params) {
   if ($object->id == 'test:testModifiedDatastreamHook' && $datastream->id == "TEST") {
     $_SESSION['islandora_hooks']['hook'][ISLANDORA_DATASTREAM_MODIFIED_HOOK] = TRUE;
-    if ($_SESSION['islandora_hooks']['iteration'][ISLANDORA_DATASTREAM_MODIFIED_HOOK]++ < 3) {
+    while ($_SESSION['islandora_hooks']['iteration'][ISLANDORA_DATASTREAM_MODIFIED_HOOK] < 3) {
+      $_SESSION['islandora_hooks']['iteration'][ISLANDORA_DATASTREAM_MODIFIED_HOOK] += 1;
       $new_label = 'New Label! + ' . $_SESSION['islandora_hooks']['iteration'][ISLANDORA_DATASTREAM_MODIFIED_HOOK];
       $datastream->label = $new_label;
     }

--- a/tests/islandora_ingest_test.module
+++ b/tests/islandora_ingest_test.module
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Implements hooks that get tested by islandora_hooks.test
+ * Implements hooks that get tested by islandora_hooks.test.
  */
 
 /**

--- a/tests/islandora_manage_permissions.test
+++ b/tests/islandora_manage_permissions.test
@@ -5,6 +5,9 @@
  * Tests islandora permissions, and permission related funcitons.
  */
 
+/**
+ * Permission management tests.
+ */
 class IslandoraPermissionsTestCase extends IslandoraWebTestCase {
 
   /**
@@ -133,4 +136,5 @@ class IslandoraPermissionsTestCase extends IslandoraWebTestCase {
     $ret = islandora_user_access($object['DC'], array(ISLANDORA_VIEW_OBJECTS), array(), TRUE, $user);
     $this->assertTrue($ret, 'User access granted for matching permissions, with a datastream given instead of an object.');
   }
+
 }

--- a/tests/islandora_manage_temp_file.test
+++ b/tests/islandora_manage_temp_file.test
@@ -5,6 +5,9 @@
  * Tests for our islandora_temp_file_entry() function.
  */
 
+/**
+ * Temporary file management tests.
+ */
 class IslandoraManageTempfileTestCase extends IslandoraWebTestCase {
 
   /**
@@ -80,4 +83,5 @@ class IslandoraManageTempfileTestCase extends IslandoraWebTestCase {
     $this->baseFileHelper($this->tempUri);
     $this->baseFileHelper($this->publicUri);
   }
+
 }

--- a/tests/scripts/travis_scripts.sh
+++ b/tests/scripts/travis_scripts.sh
@@ -1,15 +1,40 @@
 #!/bin/bash
 
 # Common checks to get run during the 'script' section in Travis.
+OUTPUT=0
+
+# Make OUTPUT equal return code if return code is not 0
+function checkReturn {
+  if [ $1 -ne 0 ]; then
+    OUTPUT=$1
+  fi
+}  
 
 # Lint
 find $TRAVIS_BUILD_DIR -type f \( -name '*.php' -o -name '*.inc' -o -name '*.module' -o -name '*.install' -o -name '*.test' \) -exec php -l {} \;
+checkReturn $?
 
 # Check line endings
 $ISLANDORA_DIR/tests/scripts/line_endings.sh $TRAVIS_BUILD_DIR
+checkReturn $?
 
 # Coding standards
-drush coder-review --reviews=production,security,style,i18n,potx,sniffer $TRAVIS_BUILD_DIR
+drush coder-review --reviews=production,security,style,i18n,potx $TRAVIS_BUILD_DIR
+checkReturn $?
+
+# Code sniffer
+if [ -d "$HOME/.composer/vendor/drupal/coder/coder_sniffer/Drupal" ]; then
+  DRUPAL_SNIFFS=$HOME/.composer/vendor/drupal/coder/coder_sniffer/Drupal
+elif [ -d "$HOME/.config/composer/vendor/drupal/coder/coder_sniffer/Drupal" ]; then
+  DRUPAL_SNIFFS=$HOME/.config/composer/vendor/drupal/coder/coder_sniffer/Drupal
+else
+  DRUPAL_SNIFFS="Drupal"
+fi
+/usr/bin/phpcs --standard=$DRUPAL_SNIFFS --extensions="php,module,inc" --ignore="*.md" $TRAVIS_BUILD_DIR
+checkReturn $?
 
 # Copy/paste detection
 phpcpd --names *.module,*.inc,*.test $TRAVIS_BUILD_DIR
+checkReturn $?
+
+exit $OUTPUT

--- a/tests/scripts/travis_scripts.sh
+++ b/tests/scripts/travis_scripts.sh
@@ -11,7 +11,7 @@ function checkReturn {
 }  
 
 # Lint
-find $TRAVIS_BUILD_DIR -type f \( -name '*.php' -o -name '*.inc' -o -name '*.module' -o -name '*.install' -o -name '*.test' \) -exec php -l {} \;
+find $TRAVIS_BUILD_DIR -type f \( -name '*.php' -o -name '*.inc' -o -name '*.module' -o -name '*.install' -o -name '*.test' \) -print0 | xargs -0 -n1 php -l
 checkReturn $?
 
 # Check line endings
@@ -22,16 +22,19 @@ checkReturn $?
 drush coder-review --reviews=production,security,style,i18n,potx $TRAVIS_BUILD_DIR
 checkReturn $?
 
-# Code sniffer
-if [ -d "$HOME/.composer/vendor/drupal/coder/coder_sniffer/Drupal" ]; then
-  DRUPAL_SNIFFS=$HOME/.composer/vendor/drupal/coder/coder_sniffer/Drupal
-elif [ -d "$HOME/.config/composer/vendor/drupal/coder/coder_sniffer/Drupal" ]; then
-  DRUPAL_SNIFFS=$HOME/.config/composer/vendor/drupal/coder/coder_sniffer/Drupal
-else
-  DRUPAL_SNIFFS="Drupal"
+# Skip code sniffer for PHP 5.3.3
+if [ "$(phpenv version-name)" != "5.3.3" ]; then
+  # Code sniffer
+  if [ -d "$HOME/.composer/vendor/drupal/coder/coder_sniffer/Drupal" ]; then
+    DRUPAL_SNIFFS=$HOME/.composer/vendor/drupal/coder/coder_sniffer/Drupal
+  elif [ -d "$HOME/.config/composer/vendor/drupal/coder/coder_sniffer/Drupal" ]; then
+    DRUPAL_SNIFFS=$HOME/.config/composer/vendor/drupal/coder/coder_sniffer/Drupal
+  else
+    DRUPAL_SNIFFS="Drupal"
+  fi
+  /usr/bin/phpcs --standard=$DRUPAL_SNIFFS --extensions="php,module,inc,install,test" --ignore="*.md" $TRAVIS_BUILD_DIR
+  checkReturn $?
 fi
-/usr/bin/phpcs --standard=$DRUPAL_SNIFFS --extensions="php,module,inc" --ignore="*.md" $TRAVIS_BUILD_DIR
-checkReturn $?
 
 # Copy/paste detection
 phpcpd --names *.module,*.inc,*.test $TRAVIS_BUILD_DIR

--- a/tests/scripts/travis_scripts.sh
+++ b/tests/scripts/travis_scripts.sh
@@ -8,7 +8,7 @@ function checkReturn {
   if [ $1 -ne 0 ]; then
     OUTPUT=$1
   fi
-}  
+}
 
 # Lint
 find $TRAVIS_BUILD_DIR -type f \( -name '*.php' -o -name '*.inc' -o -name '*.module' -o -name '*.install' -o -name '*.test' \) -print0 | xargs -0 -n1 php -l
@@ -32,7 +32,7 @@ if [ "$(phpenv version-name)" != "5.3.3" ]; then
   else
     DRUPAL_SNIFFS="Drupal"
   fi
-  /usr/bin/phpcs --standard=$DRUPAL_SNIFFS --extensions="php,module,inc,install,test" --ignore="*.md" $TRAVIS_BUILD_DIR
+  /usr/bin/phpcs --standard=$DRUPAL_SNIFFS --extensions="php,module,inc,install,test" --ignore="vendor,*.info,*.txt,*.md" $TRAVIS_BUILD_DIR
   checkReturn $?
 fi
 

--- a/tests/scripts/travis_setup.sh
+++ b/tests/scripts/travis_setup.sh
@@ -64,7 +64,7 @@ else
 fi
 
 # PHP Copy-Paste Detection installation.
-composer global --dev sebastian/phpcpd
+composer global require --dev sebastian/phpcpd
 if [ -f "$HOME/.config/composer/vendor/bin/phpcpd" ]; then
   sudo ln -s $HOME/.config/composer/vendor/bin/phpcpd /usr/local/bin/phpcpd
 elif [ -f "$HOME/.composer/vendor/bin/phpcpd" ]; then

--- a/tests/scripts/travis_setup.sh
+++ b/tests/scripts/travis_setup.sh
@@ -64,9 +64,14 @@ else
 fi
 
 # PHP Copy-Paste Detection installation.
-wget http://alpha.library.yorku.ca/phpcpd.phar
-sudo mv phpcpd.phar /usr/local/bin/phpcpd
-sudo chmod +x /usr/local/bin/phpcpd
+composer global --dev sebastian/phpcpd
+if [ -f "$HOME/.config/composer/vendor/bin/phpcpd" ]; then
+  sudo ln -s $HOME/.config/composer/vendor/bin/phpcpd /usr/local/bin/phpcpd
+elif [ -f "$HOME/.composer/vendor/bin/phpcpd" ]; then
+  sudo ln -s $HOME/.composer/vendor/bin/phpcpd /usr/local/bin/phpcpd
+else
+  echo "Did not find phpcpd"
+fi
 
 # Drupal installation.
 phpenv rehash

--- a/tests/scripts/travis_setup.sh
+++ b/tests/scripts/travis_setup.sh
@@ -25,25 +25,43 @@ export CATALINA_HOME='.'
 export JAVA_OPTS="-Xms1024m -Xmx1024m -XX:MaxPermSize=512m -XX:+CMSClassUnloadingEnabled -Djavax.net.ssl.trustStore=$CATALINA_HOME/fedora/server/truststore -Djavax.net.ssl.trustStorePassword=tomcat"
 # TODO: roll a Fedora 3.8.1 islandora_tomcat that doesn't require a rebuild.
 if [ $FEDORA_VERSION = "3.8.1" ]; then
-  export FEDORA_HOME=fedora
+  export FEDORA_HOME=$HOME/islandora_tomcat/fedora
   ./fedora/server/bin/fedora-rebuild.sh -r org.fcrepo.server.utilities.rebuild.SQLRebuilder
 fi
 ./bin/startup.sh
 
-# Drush installation.
 cd $HOME
-pear channel-discover pear.drush.org
-pear upgrade --force Console_Getopt
-pear upgrade --force pear
-pear channel-discover pear.drush.org
-wget http://alpha.library.yorku.ca/drush-6.3.tar.gz
-tar xf drush-6.3.tar.gz
-sudo mv drush-6.3 /opt/
-sudo ln -s /opt/drush-6.3/drush /usr/bin/drush
 
-# PHPCS installation.
-wget http://alpha.library.yorku.ca/PHP_CodeSniffer-1.5.6.tgz
-pear install PHP_CodeSniffer-1.5.6.tgz
+# Drush and PHPCS installation.
+if [ "$(phpenv version-name)" == "5.3.3" ]; then
+  # No mod_openssl in Travis 5.3.3 boxes
+  composer config -g disable-tls true
+  composer config -g secure-http false
+  composer self-update
+  composer global require drush/drush:6.*
+  composer global require drupal/coder:7.*
+else
+  composer global require drush/drush:7.*
+  composer global require drupal/coder
+fi
+
+# Symlink the things
+if [ -f "$HOME/.config/composer/vendor/bin/drush" ]; then
+  sudo ln -s $HOME/.config/composer/vendor/bin/drush /usr/bin/drush
+elif [ -f "$HOME/.composer/vendor/bin/drush" ]; then
+  sudo ln -s $HOME/.composer/vendor/bin/drush /usr/bin/drush
+else
+  echo "Could not find drush"
+  exit 1
+fi
+
+if [ -f "$HOME/.config/composer/vendor/bin/phpcs" ]; then
+  sudo ln -s $HOME/.config/composer/vendor/bin/phpcs /usr/bin/phpcs
+elif [ -f "$HOME/.composer/vendor/bin/phpcs" ]; then
+  sudo ln -s $HOME/.composer/vendor/bin/phpcs /usr/bin/phpcs
+else
+  echo "Did not find phpcs"
+fi
 
 # PHP Copy-Paste Detection installation.
 wget http://alpha.library.yorku.ca/phpcpd.phar
@@ -55,7 +73,11 @@ phpenv rehash
 drush dl --yes drupal
 cd drupal-*
 drush si minimal --db-url=mysql://drupal:drupal@localhost/drupal --yes
-drush runserver --php-cgi=$HOME/.phpenv/shims/php-cgi localhost:8081 &>/tmp/drush_webserver.log &
+if [ "$(phpenv version-name)" == "5.3.3" ]; then
+  drush runserver --php-cgi=$HOME/.phpenv/shims/php-cgi localhost:8081 &>/tmp/drush_webserver.log &
+else
+  drush runserver localhost:8081 &>/tmp/drush_webserver.log &
+fi
 # Add Islandora to the list of symlinked modules.
 ln -s $ISLANDORA_DIR sites/all/modules/islandora
 # Use our custom Travis test config for Simpletest.

--- a/tests/scripts/travis_setup.sh
+++ b/tests/scripts/travis_setup.sh
@@ -61,6 +61,7 @@ elif [ -f "$HOME/.composer/vendor/bin/phpcs" ]; then
   sudo ln -s $HOME/.composer/vendor/bin/phpcs /usr/bin/phpcs
 else
   echo "Did not find phpcs"
+  exit 1
 fi
 
 # PHP Copy-Paste Detection installation.
@@ -71,6 +72,7 @@ elif [ -f "$HOME/.composer/vendor/bin/phpcpd" ]; then
   sudo ln -s $HOME/.composer/vendor/bin/phpcpd /usr/local/bin/phpcpd
 else
   echo "Did not find phpcpd"
+  exit 1
 fi
 
 # Drupal installation.

--- a/tests/scripts/travis_setup.sh
+++ b/tests/scripts/travis_setup.sh
@@ -76,7 +76,7 @@ else
   echo "Did not find phpcpd"
   exit 1
 fi
-/usr/bin/phpcpd --version
+/usr/local/bin/phpcpd --version
 
 # Drupal installation.
 phpenv rehash

--- a/tests/scripts/travis_setup.sh
+++ b/tests/scripts/travis_setup.sh
@@ -54,6 +54,7 @@ else
   echo "Could not find drush"
   exit 1
 fi
+/usr/bin/drush version
 
 if [ -f "$HOME/.config/composer/vendor/bin/phpcs" ]; then
   sudo ln -s $HOME/.config/composer/vendor/bin/phpcs /usr/bin/phpcs
@@ -63,6 +64,7 @@ else
   echo "Did not find phpcs"
   exit 1
 fi
+/usr/bin/phpcs --version
 
 # PHP Copy-Paste Detection installation.
 composer global require --dev sebastian/phpcpd
@@ -74,6 +76,7 @@ else
   echo "Did not find phpcpd"
   exit 1
 fi
+/usr/bin/phpcpd --version
 
 # Drupal installation.
 phpenv rehash

--- a/theme/islandora-dublin-core-description.tpl.php
+++ b/theme/islandora-dublin-core-description.tpl.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * This is the template file for the Dublin Core metadata description.

--- a/theme/islandora-dublin-core-display.tpl.php
+++ b/theme/islandora-dublin-core-display.tpl.php
@@ -1,20 +1,21 @@
 <?php
+
 /**
-* @file
-* This is the template file for the object page for large image
-*
-* Available variables:
-* - $islandora_object: The Islandora object rendered in this template file
-* - $islandora_dublin_core: The DC datastream object
-* - $dc_array: The DC datastream object values as a sanitized array. This
-* includes label, value and class name.
-* - $islandora_object_label: The sanitized object label.
-*
-* @see template_preprocess_islandora_dublin_core_display()
-* @see theme_islandora_dublin_core_display()
-*/
+ * @file
+ * This is the template file for the object page for large image.
+ *
+ * Available variables:
+ * - $islandora_object: The Islandora object rendered in this template file
+ * - $islandora_dublin_core: The DC datastream object
+ * - $dc_array: The DC datastream object values as a sanitized array. This
+ * includes label, value and class name.
+ * - $islandora_object_label: The sanitized object label.
+ *
+ * @see template_preprocess_islandora_dublin_core_display()
+ * @see theme_islandora_dublin_core_display()
+ */
 ?>
-<fieldset <?php $print ? print('class="islandora islandora-metadata"') : print('class="islandora islandora-metadata collapsible collapsed"');?>>
+<fieldset <?php $print ? print ('class="islandora islandora-metadata"') : print ('class="islandora islandora-metadata collapsible collapsed"');?>>
   <legend><span class="fieldset-legend"><?php print t('Details'); ?></span></legend>
   <div class="fieldset-wrapper">
     <dl xmlns:dcterms="http://purl.org/dc/terms/" class="islandora-inline-metadata islandora-metadata-fields islandora-object-fields">

--- a/theme/islandora-object-edit.tpl.php
+++ b/theme/islandora-object-edit.tpl.php
@@ -4,11 +4,11 @@
  * @file
  * The default manage datastreams view for objects.
  *
- * islandora_object is a fedora tuque Object
+ * Islandora_object is a fedora tuque Object
  *    $object->label
  *    $object->id
  * to get the contents of a datastream
- *    $object['dsid']->content
+ *    $object['dsid']->content.
  *
  * $dublin_core is a DublinCore object
  * which is an array of elements, such as dc.title

--- a/theme/islandora-object-print.tpl.php
+++ b/theme/islandora-object-print.tpl.php
@@ -3,7 +3,6 @@
 /**
  * @file
  * The default view to print objects.
- *
  */
 ?>
 <div>

--- a/theme/islandora-object.tpl.php
+++ b/theme/islandora-object.tpl.php
@@ -86,11 +86,16 @@
   </tr>
   <?php foreach($datastreams as $key => $value): ?>
   <tr>
-      <td><?php if(isset($value['id'])): ?><?php print $value['id']; ?><?php endif; ?></td>
-      <td><?php if(isset($value['label_link'])): ?><?php print $value['label_link']; ?><?php endif; ?></td>
-      <td><?php if(isset($value['size'])): ?><?php print $value['size']; ?><?php endif; ?></td>
-      <td><?php if(isset($value['mimetype'])): ?><?php print $value['mimetype']; ?><?php endif; ?></td>
-      <td><?php if(isset($value['created_date'])): ?><?php print $value['created_date']; ?><?php endif; ?></td>
+      <td><?php if(isset($value['id'])): ?><?php print $value['id']; ?><?php
+     endif; ?></td>
+      <td><?php if(isset($value['label_link'])): ?><?php print $value['label_link']; ?><?php
+     endif; ?></td>
+      <td><?php if(isset($value['size'])): ?><?php print $value['size']; ?><?php
+     endif; ?></td>
+      <td><?php if(isset($value['mimetype'])): ?><?php print $value['mimetype']; ?><?php
+     endif; ?></td>
+      <td><?php if(isset($value['created_date'])): ?><?php print $value['created_date']; ?><?php
+     endif; ?></td>
   </tr>
   <?php endforeach; ?>
 </table>

--- a/theme/islandora-objects.tpl.php
+++ b/theme/islandora-objects.tpl.php
@@ -7,11 +7,11 @@
 ?>
 <div class="islandora-objects clearfix">
   <span class="islandora-objects-display-switch">
-    <?php 
+    <?php
     print theme('links', array(
-                           'links' => $display_links,
-                           'attributes' => array('class' => array('links', 'inline')),
-                         )
+      'links' => $display_links,
+      'attributes' => array('class' => array('links', 'inline')),
+    )
     );
     ?>
   </span>

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -147,7 +147,7 @@ function template_preprocess_islandora_default(&$variables) {
   $variables['datastreams'] = $datastreams;
   // Objects in fcrepo4 don't always contain a DC datastream.
   if (isset($islandora_object['DC']) && islandora_datastream_access(ISLANDORA_VIEW_OBJECTS, $islandora_object['DC'])) {
-    $dc_object = DublinCore::importFromXMLString($islandora_object['DC']->content);
+    $dc_object = DublinCore::importFromXmlString($islandora_object['DC']->content);
     $dc_array = $dc_object->asArray();
   }
   // We should eventually remove the DC object and dc_array code as it only
@@ -168,7 +168,7 @@ function template_preprocess_islandora_default(&$variables) {
  */
 function template_preprocess_islandora_object_print(array &$variables) {
   // Apply the print CSS in non print context.
-  $only_print_media = function($o) {
+  $only_print_media = function ($o) {
     return $o['media'] == 'print';
   };
   $css = array_filter(drupal_add_css(), $only_print_media);
@@ -280,7 +280,7 @@ function islandora_objects_object_mapper($object_id) {
     $link_options = array('html' => TRUE, 'attributes' => array('title' => $o->label));
     $description = NULL;
     if (isset($o['DC']) && islandora_datastream_access(ISLANDORA_VIEW_OBJECTS, $o['DC'])) {
-      $dc = DublinCore::importFromXMLString($o['DC']->content);
+      $dc = DublinCore::importFromXmlString($o['DC']->content);
       if ($dc) {
         $dc = $dc->asArray();
         $description = $dc['dc:description']['value'];
@@ -313,8 +313,6 @@ function islandora_objects_object_mapper($object_id) {
  *
  * A variant of "islandora_objects" which accepts a subset of object to theme.
  *
- * @see template_preprocess_islandora_objects()
- *
  * @param array $variables
  *   An associative array containing:
  *   - objects: An array of PIDs to render for the given page.
@@ -333,8 +331,10 @@ function islandora_objects_object_mapper($object_id) {
  *     be toggled between a "grid" and "list" view.
  *   - pager: A renderable array for the pager.
  *   - content: A renderable array for the main content of the page.
+ *
+ * @see template_preprocess_islandora_objects()
  */
-function template_preprocess_islandora_objects_subset(&$variables) {
+function template_preprocess_islandora_objects_subset(array &$variables) {
   $display = (empty($_GET['display'])) ? $variables['display'] : $_GET['display'];
   $grid_display = $display == 'grid';
   $list_display = !$grid_display;
@@ -624,7 +624,7 @@ function template_preprocess_islandora_dublin_core_display(array &$variables) {
   if (islandora_datastream_access(ISLANDORA_VIEW_OBJECTS, $islandora_object['DC'])) {
     try {
       $dc = $islandora_object['DC']->content;
-      $dc_object = DublinCore::importFromXMLString($dc);
+      $dc_object = DublinCore::importFromXmlString($dc);
     }
     catch (Exception $e) {
       drupal_set_message(t('Error retrieving object %s %t', array('%s' => $islandora_object->id, '%t' => $e->getMessage())), 'error', FALSE);
@@ -641,7 +641,7 @@ function template_preprocess_islandora_dublin_core_description(array &$variables
   if (islandora_datastream_access(ISLANDORA_VIEW_OBJECTS, $islandora_object['DC'])) {
     try {
       $dc = $islandora_object['DC']->content;
-      $dc_object = DublinCore::importFromXMLString($dc);
+      $dc_object = DublinCore::importFromXmlString($dc);
     }
     catch (Exception $e) {
       drupal_set_message(t('Error retrieving object %s %t', array('%s' => $islandora_object->id, '%t' => $e->getMessage())), 'error', FALSE);


### PR DESCRIPTION
**JIRA Ticket**: n/a

Discussed at the January 24, 2019 committer's call.

# What does this Pull Request do?

Due to PEAR issues, this PR installs drush using composer. It also installs coder and PHP Codesniffer this way.

For PHP 5.3.3 it installs:
1. Drush 6.*
1. Coder 7.*

For all newer PHP version it installs:
1. Drush 7.*
1. Latest Coder version

Finally it updates the `travis_scripts.sh` to ensure appropriate response in the case that the final test (`phpcpd`) passes but previous have failed.

# What's new?

There are 2 commits here.

The first commit contains the setup changes.

The second commit contains all the code updates to account for the new coder sniffs.

# How should this be tested?

Travis should pass.

# Additional Notes:

There are two things of concern in the DublinCore class.

https://github.com/Islandora/islandora/commit/d0d9d16981bf86c395af15074d191b14e0c81c83#diff-e8e5de937161791c32db421e1faec58c

These were required by the sniffer, but I am wondering if they will cause failure to others using these functions? 

I'm not sure if PHP is case sensitive for function names, but my IDE warned my about adding in the old function names to pass along with deprecation notices. 

If they are case-sensitive, perhaps nothing needs to be done. If they aren't case-sensitive we could ignore these functions for the code sniffer. 🤷‍♂️ 

* Does this change the interface, add a new feature, or otherwise change behaviours that would require updating documentation? no
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? possibly (see DublinCore discussion)

# Interested parties
@Islandora/7-x-1-x-committers specifically @dannylamb, @jonathangreen and @adam-vessey 
