### PR TITLE
Allow custom codesniffer ignore arguments

### DIFF
--- a/tests/scripts/travis_scripts.sh
+++ b/tests/scripts/travis_scripts.sh
@@ -35,8 +35,11 @@ if [ "$(phpenv version-name)" != "5.3.3" ]; then
   else
     DRUPAL_SNIFFS="Drupal"
   fi
+  if [ -z "$CODESNIFFER_IGNORE" ]; then
+    CODESNIFFER_IGNORE="vendor,*.info,*.txt,*.md"
+  fi
   echo "PHP Codesniffer"
-  /usr/bin/phpcs --standard=$DRUPAL_SNIFFS --extensions="php,module,inc,install,test" --ignore="vendor,*.info,*.txt,*.md" $TRAVIS_BUILD_DIR
+  /usr/bin/phpcs --standard=$DRUPAL_SNIFFS --extensions="php,module,inc,install,test" --ignore="$CODESNIFFER_IGNORE" $TRAVIS_BUILD_DIR
   checkReturn $?
 else
   echo "Skipping PHP Codesniffer for PHP 5.3.3"


### PR DESCRIPTION
**JIRA Ticket**: no JIRA, work related to #714 

# What does this Pull Request do?

While working on Solr Search I discovered that I needed a custom ignore to skip the `SolrPhpClient` directory. This should allow a module to export a custom `CODESNIFFER_IGNORE` if it needs it but otherwise falls back to the default.

# How should this be tested?

Travis should still pass for Islandora to ensure that the default is taking effect, the opposite case will be tested when I open a PR on islandora_solr_search.

# Additional Notes:

Example:
* Does this change the interface, add a new feature, or otherwise change behaviours that would require updating documentation? no
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# Interested parties
@jonathangreen  @Islandora/7-x-1-x-committers
