### PR TITLE
Remove typehint to allow false, if parent object not ingested yet

### DIFF
--- a/islandora.module
+++ b/islandora.module
@@ -920,14 +920,14 @@ function islandora_object_datastream_tokened_access_callback($perm, $object = NU
  *
  * @param array $perms
  *   Array of user permission to test for.
- * @param AbstractObject $object
- *   The object to test, if NULL given the object doesn't exist or is
+ * @param AbstractObject|bool|NULL $object
+ *   The object to test, if NULL or false given the object doesn't exist or is
  *   inaccessible.
  *
  * @return bool
  *   TRUE if the user is allowed to access this object, FALSE otherwise.
  */
-function islandora_object_manage_access_callback(array $perms, AbstractObject $object = NULL) {
+function islandora_object_manage_access_callback(array $perms, $object = NULL) {
   module_load_include('inc', 'islandora', 'includes/utilities');
 
   if (!$object && !islandora_describe_repository()) {


### PR DESCRIPTION
**ISLANDORA-2418**: (https://jira.duraspace.org/browse/ISLANDORA-2418)

# What does this Pull Request do?
This pull request will prevent the following PHP error caused when access to an object not yet created is requested. 
Error produced:
`Argument 2 passed to islandora_object_manage_access_callback() must be an instance of AbstractObject, boolean given... defined in islandora_object_manage_access_callback() (line 930 of /var/www/drupal7/sites/all/modules/islandora/islandora.module)`.

# What's new?
* The PR removes the typehint restricting the type that can be passing to the function islandora_object_manage_access_callback as FALSE can also be passed if the object does not exist.

# How should this be tested?
### --- Before merging code ---
* Create a batch ingest that creates at least one child compound object with a parent that does not exist.
    ** A module like the Islandora Spreadsheet Ingest module can be used.
* Once ingested, navigate to the object and the PHP error, "Argument 2 passed to islandora_object_manage_access_callback() must be an instance of AbstractObject..." should be produced.

### --- After merging the code from this PR ---
* The error will not be seen and the object should load with no issues.

# Interested parties
@Islandora/7-x-1-x-committers
@DiegoPino 
@jonathangreen 
@jordandukart 