### PR TITLE
Stop running "style" coder check

### DIFF
--- a/tests/scripts/travis_scripts.sh
+++ b/tests/scripts/travis_scripts.sh
@@ -22,7 +22,7 @@ checkReturn $?
 
 # Coding standards
 echo "Drush coder-review"
-drush coder-review --reviews=production,security,style,i18n,potx $TRAVIS_BUILD_DIR
+drush coder-review --reviews=production,security,i18n,potx $TRAVIS_BUILD_DIR
 checkReturn $?
 
 # Skip code sniffer for PHP 5.3.3

--- a/theme/islandora-object.tpl.php
+++ b/theme/islandora-object.tpl.php
@@ -1,5 +1,6 @@
 <?php
 
+// @codingStandardsIgnoreStart
 /**
  * @file
  * The default object view.
@@ -57,6 +58,7 @@
  * do something here
  * }
  */
+// @codingStandardsIgnoreEnd
 ?>
 <div class="islandora-object islandora">
   <h2><?php print t('Details'); ?></h2>

--- a/theme/islandora-object.tpl.php
+++ b/theme/islandora-object.tpl.php
@@ -46,7 +46,6 @@
  * and each element has an array of values.
  * dc.title can have none, one or many titles
  * this is the case for all dc elements.
- *
  */
 ?>
 <div class="islandora-object islandora">

--- a/theme/islandora-object.tpl.php
+++ b/theme/islandora-object.tpl.php
@@ -1,6 +1,5 @@
 <?php
 
-// @codingStandardsIgnoreStart
 /**
  * @file
  * The default object view.
@@ -20,10 +19,7 @@
  *
  * to test if a datastream exists isset($object['dsid'])
  *
- * to iterate over datastreams:
- * foreach ($object as $ds) {
- *   $ds->label, etc
- * }
+ * to iterate over datastreams do a "foreach ($object as $ds) {}"
  *
  * each $ds in the above loop has the following properties:
  *    $ds->label             - The label for this datastream.
@@ -51,14 +47,7 @@
  * dc.title can have none, one or many titles
  * this is the case for all dc elements.
  *
- *
- *
- * we can get a list of datastreams by doing
- * foreach ($object as $ds) {
- * do something here
- * }
  */
-// @codingStandardsIgnoreEnd
 ?>
 <div class="islandora-object islandora">
   <h2><?php print t('Details'); ?></h2>


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2424

# What does this Pull Request do?

Stop running code sniffer via coder-review, we run phpcs separately right after this.

This is specifically because the newer versions of coder-review do not seem to respect the `// @codingStandardsIgnoreStart`, `// @codingStandardsIgnoreFile`, or `// phpcs:ignoreFile`  statements

This is the reason that https://github.com/Islandora/islandora_solr_search/pull/359 can't pass due to SolrPhpClient.

An alternative solution would be to make the set of checks customizable, but then we could have a changing set of checks per module.

# What's new?
Remove the `style` check and leave the others.

# How should this be tested?

Things that pass should still pass, things that would fail on a style check here should fail on phpcs.

# Additional Notes:

I am out of ideas on this one (specifically https://github.com/Islandora/islandora_solr_search/pull/359) but I'm also not clear what the "style" review really entails. I have dug through the coder-review as best as I could but if this seems dangerous to anyone, please speak up.



Example:
* Does this change the interface, add a new feature, or otherwise change behaviours that would require updating documentation? no
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# Interested parties
@Islandora/7-x-1-x-committers
