### PR TITLE
Add more datastream paths as admin paths

### DIFF
--- a/islandora.module
+++ b/islandora.module
@@ -429,7 +429,10 @@ function islandora_admin_paths() {
   $paths['islandora/object/*/manage*'] = TRUE;
   $paths['islandora/object/*/delete*'] = TRUE;
   $paths['islandora/object/*/datastream/*/edit'] = TRUE;
-  $paths['islandora/object/*/datastream/*/version*'] = TRUE;
+  $paths['islandora/object/*/datastream/*/version'] = TRUE;
+  $paths['islandora/object/*/datastream/*/version/*/delete'] = TRUE;
+  $paths['islandora/object/*/datastream/*/version/*/revert'] = TRUE;
+  $paths['islandora/object/*/datastream/*/version/*/view'] = TRUE;
   $paths['islandora/object/*/datastream/*/replace'] = TRUE;
   $paths['islandora/object/*/datastream/*/delete'] = TRUE;
   return $paths;

--- a/islandora.module
+++ b/islandora.module
@@ -429,7 +429,9 @@ function islandora_admin_paths() {
   $paths['islandora/object/*/manage*'] = TRUE;
   $paths['islandora/object/*/delete*'] = TRUE;
   $paths['islandora/object/*/datastream/*/edit'] = TRUE;
-  $paths['islandora/object/*/datastream/*/versions'] = TRUE;
+  $paths['islandora/object/*/datastream/*/version*'] = TRUE;
+  $paths['islandora/object/*/datastream/*/replace'] = TRUE;
+  $paths['islandora/object/*/datastream/*/delete'] = TRUE;
   return $paths;
 }
 


### PR DESCRIPTION
**JIRA Ticket**: [ISLANDORA-2443](https://jira.duraspace.org/browse/ISLANDORA-2443)

# What does this Pull Request do?
Add missing datastream paths to the `hook_admin_paths` implementation.

# What's new?
Added `replace` and `delete` datastream paths to the list of administrative paths. Updated `version` path to catch all the version paths.

# How should this be tested?

Ensure that the following paths are being treated as admin paths (i.e. using the admin theme in lieu of any custom theme):
`/islandora/object/{object}/datastream/{datastream}/replace`
`/islandora/object/{object}/datastream/{datastream}/delete`
`/islandora/object/{object}/datastream/{datastream}/version`
`/islandora/object/{object}/datastream/{datastream}/version/{version_num}/view`
`/islandora/object/{object}/datastream/{datastream}/version/{version_num}/revert`

# Interested parties
@Islandora/7-x-1-x-committers
