### PR TITLE
 ISLANDORA-2444 Update readme with Awesome link

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ By default, objects with the [Fedora state](https://wiki.duraspace.org/display/F
 
 * Hooks provided by Islandora are documented in `islandora.api.php`. 
 * A [detailed tutorial](https://github.com/Islandora/islandora/wiki/Multi-paged-Ingest-Forms) on extending the multi-page ingest forms is available on the Github (developers') Wiki.
-
+* Additional modules developed by members of the Islandora community to extend Islandora can be found on the curated [Islandora Awesome](https://github.com/Islandora-Labs/islandora_awesome) list.
 
 ## Documentation
 


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2444

* Other Relevant Links: https://wiki.duraspace.org/display/ISLANDORA/Start

# What does this Pull Request do?

I received feedback from the audience at an Islandora session at OR2019 that a way to find the modules developed by our community would be really helpful. This [exists](https://github.com/Islandora-Labs/islandora_awesome), but clearly it needs to be easier to find. 

This adds a link with a brief description. There's a similar addition on the [front page](https://wiki.duraspace.org/display/ISLANDORA/Start) of the user wiki docs.

# What's new?
One new line in the readme.

# How should this be tested?

Verify that wording is clear; test that the link resolves.

# Interested parties
@DonRichards as Documentation Manager for 7.x-1.13, do you want to have a look at this?
