### PR TITLE
Fix theme_islandora_datastream_view_link()

### DIFF
--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -432,7 +432,7 @@ function theme_islandora_datastream_download_link(array $vars) {
  */
 function theme_islandora_datastream_view_link(array $vars) {
   $datastream = $vars['datastream'];
-  module_load_include('inc', 'islandora', 'includes/utilities');
+  module_load_include('inc', 'islandora', 'includes/datastream');
 
   if ($vars['label'] === NULL) {
     $label = check_plain($datastream->id);


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2479

# What does this Pull Request do?

Fixes `theme_islandora_datastream_view_link()` to include the correct file. Additionally, improves the safety of the code.

# What's new?
* Replaces erroneous include of `includes/utilities` with `includes/datastream`. 
* Replaces `=== NULL` checks with `isset()`. 
* Adds `$version` variable, rather than passing `$vars['version']`

# How should this be tested?

Use `islandora_datastream_view_link()` in a theme, e.g. to add the ability to view the PDF of book or newspaper content.

# Interested parties
@Islandora/7-x-14-committers
