### PR TITLE
Add optional label text to datastream download links

### DIFF
--- a/islandora.module
+++ b/islandora.module
@@ -537,7 +537,10 @@ function islandora_theme() {
     ),
     'islandora_datastream_download_link' => array(
       'file' => 'theme/theme.inc',
-      'variables' => array('datastream' => NULL),
+      'variables' => array(
+        'datastream' => NULL,
+        'label' => NULL,
+      ),
     ),
     'islandora_datastream_version_link' => array(
       'file' => 'theme/theme.inc',

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -404,6 +404,7 @@ function template_process_islandora_objects_subset(&$variables) {
  * @param array $vars
  *   An array containing:
  *   - datastream: An AbstractDatastream for which to generate a download link.
+ *   - label: (Optional) The label for the link.
  *
  * @return string
  *   Markup containing the download url if the user has access, empty otherwise.
@@ -412,7 +413,13 @@ function theme_islandora_datastream_download_link(array $vars) {
   $datastream = $vars['datastream'];
   module_load_include('inc', 'islandora', 'includes/datastream');
 
-  $label = t('download');
+  if ($vars['label'] === NULL) {
+    $label = t('download');
+  }
+  else {
+    $label = check_plain($vars['label']);
+  }
+
   return islandora_datastream_access(ISLANDORA_VIEW_OBJECTS, $datastream) ?
     l($label, islandora_datastream_get_url($datastream, 'download')) :
     '';


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2480

* Related PR: #726  

# What does this Pull Request do?
Add optional label text to datastream download links

# What's new?
* Adds optional `label` argument to `theme_islandora_datastream_download_link()`

# How should this be tested?
Use `islandora_datastream_download_link()` in a theme, e.g. to add the ability to download the PDF of book or newspaper content. Use the `label` argument to provide text for the link.

# Interested parties
@Islandora/7-x-1-x-committers
