### PR TITLE
Drupal uri predicate

### DIFF
--- a/src/Plugin/ContextReaction/JsonldSelfReferenceReaction.php
+++ b/src/Plugin/ContextReaction/JsonldSelfReferenceReaction.php
@@ -13,16 +13,18 @@ use Drupal\islandora\IslandoraUtils;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Map URI to predicate context reaction.
+ * Create a self-reference in RDF when creating JSON-LD.
+ *
+ * Formerly called "Map URI to predicate". Renamed for clarity.
  *
  * @ContextReaction(
  *   id = "islandora_map_uri_predicate",
- *   label = @Translation("Map URI to predicate")
+ *   label = @Translation("JSON-LD self-reference")
  * )
  */
-class MappingUriPredicateReaction extends NormalizerAlterReaction {
+class JsonldSelfReferenceReaction extends NormalizerAlterReaction {
 
-  const URI_PREDICATE = 'drupal_uri_predicate';
+  const SELF_REFERENCE_PREDICATE = 'drupal_uri_predicate';
 
   /**
    * Media source service.
@@ -69,7 +71,7 @@ class MappingUriPredicateReaction extends NormalizerAlterReaction {
    * {@inheritdoc}
    */
   public function summary() {
-    return $this->t('Map Drupal URI to configured predicate.');
+    return $this->t('When creating the JSON-LD for this Drupal entity, add a relationship to itself using this predicate.');
   }
 
   /**
@@ -77,11 +79,11 @@ class MappingUriPredicateReaction extends NormalizerAlterReaction {
    */
   public function execute(EntityInterface $entity = NULL, array &$normalized = NULL, array $context = NULL) {
     $config = $this->getConfiguration();
-    $drupal_predicate = $config[self::URI_PREDICATE];
-    if (!is_null($drupal_predicate) && !empty($drupal_predicate)) {
+    $self_ref_predicate = $config[self::SELF_REFERENCE_PREDICATE];
+    if (!is_null($self_ref_predicate) && !empty($self_ref_predicate)) {
       $url = $this->getSubjectUrl($entity);
       if ($context['needs_jsonldcontext'] === FALSE) {
-        $drupal_predicate = NormalizerBase::escapePrefix($drupal_predicate, $context['namespaces']);
+        $self_ref_predicate = NormalizerBase::escapePrefix($self_ref_predicate, $context['namespaces']);
       }
       if (isset($normalized['@graph']) && is_array($normalized['@graph'])) {
         foreach ($normalized['@graph'] as &$graph) {
@@ -91,24 +93,24 @@ class MappingUriPredicateReaction extends NormalizerAlterReaction {
               $file = $this->mediaSource->getSourceFile($entity);
               $graph['@id'] = $this->utils->getDownloadUrl($file);
             }
-            if (isset($graph[$drupal_predicate])) {
-              if (!is_array($graph[$drupal_predicate])) {
-                if ($graph[$drupal_predicate] == $url) {
+            if (isset($graph[$self_ref_predicate])) {
+              if (!is_array($graph[$self_ref_predicate])) {
+                if ($graph[$self_ref_predicate] == $url) {
                   // Don't add it if it already exists.
                   return;
                 }
-                $tmp = $graph[$drupal_predicate];
-                $graph[$drupal_predicate] = [$tmp];
+                $tmp = $graph[$self_ref_predicate];
+                $graph[$self_ref_predicate] = [$tmp];
               }
-              elseif (array_search($url, array_column($graph[$drupal_predicate], '@id'))) {
+              elseif (array_search($url, array_column($graph[$self_ref_predicate], '@id'))) {
                 // Don't add it if it already exists.
                 return;
               }
             }
             else {
-              $graph[$drupal_predicate] = [];
+              $graph[$self_ref_predicate] = [];
             }
-            $graph[$drupal_predicate][] = ["@id" => $url];
+            $graph[$self_ref_predicate][] = ["@id" => $url];
             return;
           }
         }
@@ -121,11 +123,11 @@ class MappingUriPredicateReaction extends NormalizerAlterReaction {
    */
   public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
     $config = $this->getConfiguration();
-    $form[self::URI_PREDICATE] = [
+    $form[self::SELF_REFERENCE_PREDICATE] = [
       '#type' => 'textfield',
-      '#title' => $this->t('Drupal URI predicate'),
-      '#description' => $this->t("The Drupal object's URI will be added to the resource with this predicate. Must use a defined prefix."),
-      '#default_value' => isset($config[self::URI_PREDICATE]) ? $config[self::URI_PREDICATE] : '',
+      '#title' => $this->t('Self-reference predicate'),
+      '#description' => $this->t("When creating the JSON-LD for this Drupal entity, add a relationship from the entity to itself using this predicate. It must use a defined RDF namespace prefix."),
+      '#default_value' => isset($config[self::SELF_REFERENCE_PREDICATE]) ? $config[self::SELF_REFERENCE_PREDICATE] : '',
       '#size' => 35,
     ];
     return $form;
@@ -135,19 +137,19 @@ class MappingUriPredicateReaction extends NormalizerAlterReaction {
    * {@inheritdoc}
    */
   public function validateConfigurationForm(array &$form, FormStateInterface $form_state) {
-    $drupal_predicate = $form_state->getValue(self::URI_PREDICATE);
-    if (!is_null($drupal_predicate) and !empty($drupal_predicate)) {
-      if (preg_match('/^https?:\/\//', $drupal_predicate)) {
+    $self_ref_predicate = $form_state->getValue(self::SELF_REFERENCE_PREDICATE);
+    if (!is_null($self_ref_predicate) and !empty($self_ref_predicate)) {
+      if (preg_match('/^https?:\/\//', $self_ref_predicate)) {
         // Can't validate all URIs so we have to trust them.
         return;
       }
-      elseif (preg_match('/^([^\s:]+):/', $drupal_predicate, $matches)) {
+      elseif (preg_match('/^([^\s:]+):/', $self_ref_predicate, $matches)) {
         $predicate_prefix = $matches[1];
         $rdf = rdf_get_namespaces();
         $rdf_prefixes = array_keys($rdf);
         if (!in_array($predicate_prefix, $rdf_prefixes)) {
           $form_state->setErrorByName(
-            self::URI_PREDICATE,
+            self::SELF_REFERENCE_PREDICATE,
             $this->t('Namespace prefix @prefix is not registered.',
               ['@prefix' => $predicate_prefix]
             )
@@ -156,7 +158,7 @@ class MappingUriPredicateReaction extends NormalizerAlterReaction {
       }
       else {
         $form_state->setErrorByName(
-          self::URI_PREDICATE,
+          self::SELF_REFERENCE_PREDICATE,
           $this->t('Predicate must use a defined prefix or be a full URI')
         );
       }
@@ -168,7 +170,7 @@ class MappingUriPredicateReaction extends NormalizerAlterReaction {
    * {@inheritdoc}
    */
   public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
-    $this->setConfiguration([self::URI_PREDICATE => $form_state->getValue(self::URI_PREDICATE)]);
+    $this->setConfiguration([self::SELF_REFERENCE_PREDICATE => $form_state->getValue(self::SELF_REFERENCE_PREDICATE)]);
   }
 
 }

--- a/tests/src/Functional/JsonldSelfReferenceReactionTest.php
+++ b/tests/src/Functional/JsonldSelfReferenceReactionTest.php
@@ -8,7 +8,7 @@ namespace Drupal\Tests\islandora\Functional;
  * @package Drupal\Tests\islandora\Functional
  * @group islandora
  */
-class MappingUriPredicateReactionTest extends IslandoraFunctionalTestBase {
+class JsonldSelfReferenceReactionTest extends IslandoraFunctionalTestBase {
 
   /**
    * {@inheritdoc}
@@ -37,7 +37,7 @@ class MappingUriPredicateReactionTest extends IslandoraFunctionalTestBase {
   }
 
   /**
-   * @covers \Drupal\islandora\Plugin\ContextReaction\MappingUriPredicateReaction
+   * @covers \Drupal\islandora\Plugin\ContextReaction\JsonldSelfReferenceReaction
    */
   public function testMappingReaction() {
     $account = $this->drupalCreateUser([
@@ -79,21 +79,21 @@ class MappingUriPredicateReactionTest extends IslandoraFunctionalTestBase {
     $this->drupalGet("admin/structure/context/$context_name");
     // Can't use an undefined prefix.
     $this->getSession()->getPage()
-      ->fillField("Drupal URI predicate", "bob:smith");
+      ->fillField("Self-reference predicate", "bob:smith");
     $this->getSession()->getPage()->pressButton("Save and continue");
     $this->assertSession()
       ->pageTextContains("Namespace prefix bob is not registered");
 
     // Can't use a straight string.
     $this->getSession()->getPage()
-      ->fillField("Drupal URI predicate", "woohoo");
+      ->fillField("Self-reference predicate", "woohoo");
     $this->getSession()->getPage()->pressButton("Save and continue");
     $this->assertSession()
       ->pageTextContains("Predicate must use a defined prefix or be a full URI");
 
     // Use an existing prefix.
     $this->getSession()->getPage()
-      ->fillField("Drupal URI predicate", "owl:sameAs");
+      ->fillField("Self-reference predicate", "owl:sameAs");
     $this->getSession()->getPage()->pressButton("Save and continue");
     $this->assertSession()
       ->pageTextContains("The context $context_name has been saved");
@@ -114,7 +114,7 @@ class MappingUriPredicateReactionTest extends IslandoraFunctionalTestBase {
     $this->drupalGet("admin/structure/context/$context_name");
     // Change to a random URL.
     $this->getSession()->getPage()
-      ->fillField("Drupal URI predicate", "http://example.org/first/second");
+      ->fillField("Self-reference predicate", "http://example.org/first/second");
     $this->getSession()->getPage()->pressButton("Save and continue");
     $this->assertSession()
       ->pageTextContains("The context $context_name has been saved");
@@ -135,7 +135,7 @@ class MappingUriPredicateReactionTest extends IslandoraFunctionalTestBase {
   }
 
   /**
-   * @covers \Drupal\islandora\Plugin\ContextReaction\MappingUriPredicateReaction
+   * @covers \Drupal\islandora\Plugin\ContextReaction\JsonldSelfReferenceReaction
    */
   public function testMappingReactionForMedia() {
     $account = $this->drupalCreateUser([
@@ -172,7 +172,7 @@ class MappingUriPredicateReactionTest extends IslandoraFunctionalTestBase {
 
     // Use an existing prefix.
     $this->getSession()->getPage()
-      ->fillField("Drupal URI predicate", "iana:describedby");
+      ->fillField("Self-reference predicate", "iana:describedby");
     $this->getSession()->getPage()->pressButton("Save and continue");
     $this->assertSession()
       ->pageTextContains("The context $context_name has been saved");

--- a/tests/src/Functional/JsonldTypeAlterReactionTest.php
+++ b/tests/src/Functional/JsonldTypeAlterReactionTest.php
@@ -8,7 +8,7 @@ namespace Drupal\Tests\islandora\Functional;
  * @package Drupal\Tests\islandora\Functional
  * @group islandora
  */
-class JsonldTypeAlterReactionTest extends MappingUriPredicateReactionTest {
+class JsonldTypeAlterReactionTest extends JsonldSelfReferenceReactionTest {
 
   /**
    * @covers \Drupal\islandora\Plugin\ContextReaction\JsonldTypeAlterReaction


### PR DESCRIPTION
Originally from @rosiel.  Can't take any credit for this one!  Migrated over from Islandora-CLAW/islandora.

**GitHub Issue**: https://github.com/Islandora-CLAW/CLAW/issues/1303

To channel @seth-shaw-unlv , 🎶 If I go there's just no telling how far I'll go 🎶

*  Per Eli's and my diagram, this is how we put (excuse the lazy rdf) `<node/1> schema:sameAs <node/1>` in the JSON-LD of node/1,  in order to have `<fedoraURI> schema:sameAs <node/1>`. The schema:sameAs is the "Drupal URI Predicate" in the "Map Drupal URI to Predicate" reaction. Those labels, alone, do not explain what's going on.

# What does this Pull Request do?

Renames almost all uses of "Map URI to predicate"-type wording into "JSON-LD Self-Reference Predicate"-type wording.

# What's new?

Front-end: 

* Renames the Reaction's human-readable label to "JSON-LD self-reference".
* Renames the human-readable label variable in the config form to 'Self-reference predicate'
* Renames the human-readable description of that variable in the config form to "When creating the JSON-LD for this Drupal entity, add a relationship from the entity to itself using this predicate. It must use a defined RDF namespace prefix."
* renames the human-readable summary for this reaction (! where does this appear??) to 'When creating the JSON-LD for this Drupal entity, add a relationship to itself using this predicate.'

Back-end:

* renames the Reaction's class to `JsonldSelfReferenceReaction`, and renames the php file.
* renames the constant to `SELF_REFERENCE_PREDICATE`
* renames some internal variables
* renames the test files to match, and to find the correct config form field.

Does not change:

* the internal id of the reaction remains `islandora_map_uri_predicate`

Could this change impact execution of existing code?

* I don't think so. I think that because the internal id didn't change, this should just work (after a cache clear)

# How should this be tested?

* Pull this code into islandora
* *Clear your cache*
* Look at existing Contexts that contain this reaction (e.g. Content). The wording above should appear in the interface.
* the context should continue to work as intended, i.e. this causes a "schema:sameAs" to appear in the json-ld of the node, pointing to itself.
* you can add this reaction to another context and it works as intended. 
* best way to test: show this to someone who doesn't know how this works and ask them what they think it does.


# Additional Notes:
...

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora-CLAW/committers
