### PR TITLE
Issue 1266

### DIFF
--- a/islandora.install
+++ b/islandora.install
@@ -61,16 +61,16 @@ function islandora_update_8001(&$sandbox) {
 function islandora_update_8002(&$sandbox) {
   $config_factory = \Drupal::service('config.factory')->getEditable(IslandoraSettingsForm::CONFIG_NAME);
 
-  $changed = false;
+  $changed = FALSE;
   $gemini_url = $config_factory->get(IslandoraSettingsForm::GEMINI_URL);
   $pseudo_bundles = $config_factory->get(IslandoraSettingsForm::GEMINI_PSEUDO);
   if (!isset($gemini_url)) {
     $config_factory->set(IslandoraSettingsForm::GEMINI_URL, '');
-    $changed = true;
+    $changed = TRUE;
   }
   if (!isset($pseudo_bundles)) {
     $config_factory->set(IslandoraSettingsForm::GEMINI_PSEUDO, []);
-    $changed = true;
+    $changed = TRUE;
   }
   if ($changed) {
     $config_factory->save();

--- a/islandora.install
+++ b/islandora.install
@@ -5,6 +5,8 @@
  * Install/update hook implementations.
  */
 
+use Drupal\islandora\Form\IslandoraSettingsForm;
+
 /**
  * Implements hook_schema().
  */
@@ -51,4 +53,27 @@ function islandora_update_8001(&$sandbox) {
   if ($action) {
     $action->delete();
   }
+}
+
+/**
+ * Add in default Gemini URI and Pseudo bundle setting values.
+ */
+function islandora_update_8002(&$sandbox) {
+  $config_factory = \Drupal::service('config.factory')->getEditable(IslandoraSettingsForm::CONFIG_NAME);
+
+  $changed = false;
+  $gemini_url = $config_factory->get(IslandoraSettingsForm::GEMINI_URL);
+  $pseudo_bundles = $config_factory->get(IslandoraSettingsForm::GEMINI_PSEUDO);
+  if (!isset($gemini_url)) {
+    $config_factory->set(IslandoraSettingsForm::GEMINI_URL, '');
+    $changed = true;
+  }
+  if (!isset($pseudo_bundles)) {
+    $config_factory->set(IslandoraSettingsForm::GEMINI_PSEUDO, []);
+    $changed = true;
+  }
+  if ($changed) {
+    $config_factory->save();
+  }
+
 }

--- a/islandora.module
+++ b/islandora.module
@@ -379,31 +379,37 @@ function islandora_entity_extra_field_info() {
  * Implements hook_entity_view().
  */
 function islandora_entity_view(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display, $view_mode) {
-  $route_match_item = \Drupal::routeMatch()->getParameters()->all();
-  // Get the parameter, which might be node, media or taxonomy term.
-  $current_entity = reset($route_match_item);
-  // Match exactly to ensure they are the same entity type too.
-  if ($entity === $current_entity) {
-    if ($display->getComponent('field_gemini_uri')) {
-      $gemini = \Drupal::service('islandora.gemini.lookup');
-      if ($gemini instanceof GeminiLookup) {
-        $fedora_uri = $gemini->lookup($entity);
-        if (!is_null($fedora_uri)) {
-          $build['field_gemini_uri'] = [
-            '#type' => 'container',
-            '#attributes' => [
-              'id' => 'field-gemini-uri',
-            ],
-            'internal_label' => [
-              '#type' => 'item',
-              '#title' => t('Fedora URI'),
-              'internal_uri' => [
-                '#type' => 'link',
-                '#title' => t("@url", ['@url' => $fedora_uri]),
-                '#url' => Url::fromUri($fedora_uri),
+  $config_factory = \Drupal::service('config.factory')->get(IslandoraSettingsForm::CONFIG_NAME);
+  $gemini_url = $config_factory->get(IslandoraSettingsForm::GEMINI_URL);
+  $pseudo_fields = $config_factory->get(IslandoraSettingsForm::GEMINI_PSEUDO);
+  // If we aren't configured then don't display.
+  if (!empty($gemini_url) && count($pseudo_fields) > 0) {
+    $route_match_item = \Drupal::routeMatch()->getParameters()->all();
+    // Get the parameter, which might be node, media or taxonomy term.
+    $current_entity = reset($route_match_item);
+    // Match exactly to ensure they are the same entity type too.
+    if ($entity === $current_entity) {
+      if ($display->getComponent('field_gemini_uri')) {
+        $gemini = \Drupal::service('islandora.gemini.lookup');
+        if ($gemini instanceof GeminiLookup) {
+          $fedora_uri = $gemini->lookup($entity);
+          if (!is_null($fedora_uri)) {
+            $build['field_gemini_uri'] = [
+              '#type' => 'container',
+              '#attributes' => [
+                'id' => 'field-gemini-uri',
               ],
-            ],
-          ];
+              'internal_label' => [
+                '#type' => 'item',
+                '#title' => t('Fedora URI'),
+                'internal_uri' => [
+                  '#type' => 'link',
+                  '#title' => t("@url", ['@url' => $fedora_uri]),
+                  '#url' => Url::fromUri($fedora_uri),
+                ],
+              ],
+            ];
+          }
         }
       }
     }


### PR DESCRIPTION
All work done by @whikloj.  Can't take any credit for this one.  I just migrated it over from https://github.com/Islandora-CLAW/islandora/pull/172

**GitHub Issue**: https://github.com/Islandora-CLAW/CLAW/issues/1266

Alternative to #158 

# What does this Pull Request do?

Adds an update hook to set the default settings. These were added in the `config/install/islandora.settings.yml` but if you had Islandora installed and just updated the module it doesn't install those and the two settings would be empty.

This was my fault and a mea culpa. But also to note we have users with the code running so changes have to be more deliberate.

# What's new?
* Does this change require documentation to be updated? no
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository
 (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# How should this be tested?

I tried to test this, but the issue seems to be that you need a very specific case to get it.

This includes an update hook to set the default settings, which assumes you pulled a newer version of islandora over an older one.

This will setup the basic variables, but before you can use the Fedora URI field you still need to go into the Islandora Settings and set the Gemini URL and select some pseudo bundles.

But... it also does not allow you to try to render the pseudo field if you haven't configured it (at all), this avoids the Client Error


# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora-CLAW/committers
