### PR TITLE
Versioning

### DIFF
--- a/src/EventGenerator/EventGenerator.php
+++ b/src/EventGenerator/EventGenerator.php
@@ -98,13 +98,12 @@ class EventGenerator implements EventGeneratorInterface {
       $event["type"] = ucfirst($data["event"]);
       $event["summary"] = ucfirst($data["event"]) . " a " . ucfirst($entity_type);
     }
-
+    $isNewRev = FALSE;
     if ($entity->getEntityType()->isRevisionable()) {
+      \Drupal::logger('islandora')->notice('its revisionable');
       $isNewRev = $this->isNewRevision($entity);
-      if ($isNewRev) {
-        $event["object"]["isNewVersion"] = $isNewRev;
-      }
     }
+    $event["object"]["isNewVersion"] = $isNewRev;
 
     // Add REST links for non-file entities.
     if ($entity_type != 'file') {
@@ -162,9 +161,8 @@ class EventGenerator implements EventGeneratorInterface {
    *   Is new version.
    */
   protected function isNewRevision(EntityInterface $entity) {
-    $bundle_entity_type = $entity->getEntityType()->getBundleEntityType();
-    $bundle_entity = \Drupal::entityTypeManager()->getStorage($bundle_entity_type)->load($entity->bundle());
-    return $bundle_entity->shouldCreateNewRevision();
+    $revision_ids = \Drupal::entityTypeManager()->getStorage($entity->getEntityTypeId())->revisionIds($entity);
+    return count($revision_ids) > 1;
   }
 
 }

--- a/src/EventGenerator/EventGenerator.php
+++ b/src/EventGenerator/EventGenerator.php
@@ -6,6 +6,8 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\islandora\IslandoraUtils;
 use Drupal\islandora\MediaSource\MediaSourceService;
 use Drupal\user\UserInterface;
+use Drupal\media\Entity\Media;
+use Drupal\Core\Entity\EntityStorageInterface;
 
 /**
  * The default EventGenerator implementation.
@@ -102,6 +104,7 @@ class EventGenerator implements EventGeneratorInterface {
     if ($entity->getEntityType()->isRevisionable()) {
       \Drupal::logger('islandora')->notice('its revisionable');
       $isNewRev = $this->isNewRevision($entity);
+      \Drupal::logger('is new revision')->notice($isNewRev);
     }
     $event["object"]["isNewVersion"] = $isNewRev;
 
@@ -161,8 +164,33 @@ class EventGenerator implements EventGeneratorInterface {
    *   Is new version.
    */
   protected function isNewRevision(EntityInterface $entity) {
-    $revision_ids = \Drupal::entityTypeManager()->getStorage($entity->getEntityTypeId())->revisionIds($entity);
-    return count($revision_ids) > 1;
+    if ($entity->getEntityTypeId() == "node") {
+      $revision_ids = \Drupal::entityTypeManager()->getStorage($entity->getEntityTypeId())->revisionIds($entity);
+      return count($revision_ids) > 1;
+    }
+    elseif ($entity->getEntityTypeId() == "media") {
+      $mediaStorage = \Drupal::entityTypeManager()->getStorage($entity->getEntityTypeId());
+      return count($this->getRevisionIds($entity, $mediaStorage)) > 1;
+    }
+  }
+
+  /**
+   * Method to get the revisionIds of a media object.
+   *
+   * @param \Drupal\media\Entity\Media $media
+   *   Media object.
+   * @param \Drupal\Core\Entity\EntityStorageInterface $media_storage
+   *   Media Storage.
+   */
+  protected function getRevisionIds(Media $media, EntityStorageInterface $media_storage) {
+    $result = $media_storage->getQuery()
+      ->allRevisions()
+      ->condition($media->getEntityType()->getKey('id'), $media->id())
+      ->sort($media->getEntityType()->getKey('revision'), 'DESC')
+      ->pager(50)
+      ->execute();
+    // \Drupal::logger('revision array')->notice('<pre><code>' . print_r(array_keys($result), TRUE) . '</code></pre>');
+    return array_keys($result);
   }
 
 }

--- a/src/EventGenerator/EventGenerator.php
+++ b/src/EventGenerator/EventGenerator.php
@@ -189,7 +189,6 @@ class EventGenerator implements EventGeneratorInterface {
       ->sort($media->getEntityType()->getKey('revision'), 'DESC')
       ->pager(50)
       ->execute();
-    // \Drupal::logger('revision array')->notice('<pre><code>' . print_r(array_keys($result), TRUE) . '</code></pre>');
     return array_keys($result);
   }
 

--- a/src/EventGenerator/EventGenerator.php
+++ b/src/EventGenerator/EventGenerator.php
@@ -100,13 +100,14 @@ class EventGenerator implements EventGeneratorInterface {
       $event["type"] = ucfirst($data["event"]);
       $event["summary"] = ucfirst($data["event"]) . " a " . ucfirst($entity_type);
     }
-    $isNewRev = FALSE;
-    if ($entity->getEntityType()->isRevisionable()) {
-      \Drupal::logger('islandora')->notice('its revisionable');
-      $isNewRev = $this->isNewRevision($entity);
-      \Drupal::logger('is new revision')->notice($isNewRev);
+
+    if ($data['event'] != "Generate Derivative") {
+      $isNewRev = FALSE;
+      if ($entity->getEntityType()->isRevisionable()) {
+        $isNewRev = $this->isNewRevision($entity);
+      }
+      $event["object"]["isNewVersion"] = $isNewRev;
     }
-    $event["object"]["isNewVersion"] = $isNewRev;
 
     // Add REST links for non-file entities.
     if ($entity_type != 'file') {
@@ -187,7 +188,6 @@ class EventGenerator implements EventGeneratorInterface {
       ->allRevisions()
       ->condition($media->getEntityType()->getKey('id'), $media->id())
       ->sort($media->getEntityType()->getKey('revision'), 'DESC')
-      ->pager(50)
       ->execute();
     return array_keys($result);
   }


### PR DESCRIPTION
All work done by @elizoller.  Can't take any credit on this one.  I just migrated this PR over from https://github.com/Islandora-CLAW/islandora/pull/154

**GitHub Issue**: Related to: (https://github.com/Islandora-CLAW/CLAW/issues/740)

# What does this Pull Request do?
* Allows versioning of an object to be initiated from Drupal node updates


# What's new?
* Adds a context action create_node_version_in_fedora which can be added to a context reaction.
* Adds the event type to the event object being passed to Alpaca
* Adds a "Version" event type
* This change could be added to the index "reaction" in the repository item context by default and/or added to documentation that this is how one "enables" versioning on a node


# How should this be tested?
* pull in the PR to your islandora modules - uninstall/re-enable islandora_core_feature
* add the "Create Node Version in Fedora" to the "Index" reaction in the repository_content context
* make sure that the "Version" event gets fired on node_update (could probably just run a debug)
* make sure that the event type is included in the emitted event object (could debug from EventGenerator or update an alpaca feature to try this)

# Additional Notes:
One important note is that using the IndexReaction for triggering the create_node_version_in_fedora means that the event is triggered as part of islandora_node_insert and islandora_node_update (i think...). Having it be part of node_update means that the version is created before the node is updated. 
Another way to do this is to use a new reaction (maybe called VersionReaction) that could then be included in any hooks in `islandora.module` although probably islandora_node_update makes the most sense.

# Interested parties
@Islandora-CLAW/committers
