### PR TITLE
Dummy composer.json to see if it'll appease packagist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 cache.properties
 .DS_Store
 tests/test_config.ini
+vendor

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,7 @@
+{
+    "name": "islandora/islandora",
+    "description": "Core Islandora module",
+    "type": "drupal-module",
+    "license": "GPL-2.0+",
+    "require": {}
+}


### PR DESCRIPTION
**JIRA Ticket**: None, I be de-CLAWing Islandora 8

# What does this Pull Request do?

Packagist is rejecting `islandora/islandora` because 7.x doesn't have a `composer.json` file.  I'm testing the waters here with a dummy file just to see if it will appease our packagist overlords.  In theory, packagist just ignores branches without composer.json files, so I'm wondering if it's because 7.x is the default branch.  But switching that to 8 would be pretty disruptive and I'd rather give folks a heads up with time to prepare in case it messes with their builds.  For example, `islandora_vagrant` would be affected by this and need to be updated.  So I'm trying this first :laughing: 


# What's new?
The most bare-bones composer.json file humanly possible.

# How should this be tested?
A kind soul merges this and packagist is appeased... or not.  In that case, we'll revert.

# Interested parties
@Islandora/7-x-1-x-committers @Islandora/8-x-committers 
