### PR TITLE
Add 'Original Name' field storage

### DIFF
--- a/islandora.module
+++ b/islandora.module
@@ -61,6 +61,7 @@ function islandora_rdf_namespaces() {
     'use' => 'http://pcdm.org/use#',
     'iana' => 'http://www.iana.org/assignments/relation/',
     'premis' => 'http://www.loc.gov/premis/rdf/v1#',
+    'premis3' => 'http://www.loc.gov/premis/rdf/v3/',
     'co' => 'http://purl.org/co/',
   ];
 }

--- a/modules/islandora_core_feature/config/install/field.storage.media.field_original_name.yml
+++ b/modules/islandora_core_feature/config/install/field.storage.media.field_original_name.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - media
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: media.field_original_name
+field_name: field_original_name
+entity_type: media
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/islandora_core_feature/config/install/field.storage.media.field_original_name.yml
+++ b/modules/islandora_core_feature/config/install/field.storage.media.field_original_name.yml
@@ -1,6 +1,9 @@
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - islandora_core_feature
   module:
     - media
 id: media.field_original_name

--- a/modules/islandora_core_feature/config/install/field.storage.media.field_original_name.yml
+++ b/modules/islandora_core_feature/config/install/field.storage.media.field_original_name.yml
@@ -2,11 +2,7 @@ langcode: en
 status: true
 dependencies:
   module:
-    - field_permissions
     - media
-third_party_settings:
-  field_permissions:
-    permission_type: public
 id: media.field_original_name
 field_name: field_original_name
 entity_type: media


### PR DESCRIPTION
**Github Issue**: https://github.com/Islandora/documentation/issues/1276

# What does this Pull Request do?

Adds the PREMIS 3 namespace and creates the field storage for an 'original name' field for media.

# How should this be tested?

- Apply this PR
- Apply https://github.com/Islandora/islandora_defaults/pull/13
- Import both the Islandora Core and Islandora Defaults features. E.g. `drush fim -y islandora_core_feature; drush fim -y islandora_defaults`
- Create a Media; you should see an 'Original Name' field. Plop any text you want in there.
- View the Media's JSON-LD; you should see the text from the original name field associated with the PREMIS 3 originalName predicate
- View the Media in Fedora; the PREMIS 3 originalName value should be there too.

# Additional Notes:

We should eventually figure out how to auto-populate this from the file upload widget.

# Interested parties
@mjordan, @Islandora/8-x-committers
