### PR TITLE
Add userid option to migrate:rollback

### DIFF
--- a/src/Commands/IslandoraCommands.php
+++ b/src/Commands/IslandoraCommands.php
@@ -53,7 +53,7 @@ class IslandoraCommands extends DrushCommands {
   /**
    * Validate the provided userid.
    */
-  public function validateUser(CommandData $commandData) {
+  protected function validateUser(CommandData $commandData) {
     $userid = $commandData->input()->getOption('userid');
     if ($userid) {
       $account = User::load($userid);
@@ -84,7 +84,7 @@ class IslandoraCommands extends DrushCommands {
   /**
    * Switch the active user account using the provided userid.
    */
-  public function switchUser(CommandData $commandData) {
+  protected function switchUser(CommandData $commandData) {
     $userid = $commandData->input()->getOption('userid');
     if ($userid) {
       $account = User::load($userid);
@@ -125,7 +125,7 @@ class IslandoraCommands extends DrushCommands {
   /**
    * Switch the user back.
    */
-  public function switchUserBack(CommandData $commandData) {
+  protected function switchUserBack(CommandData $commandData) {
     if ($commandData->input()->getOption('userid')) {
       $accountSwitcher = \Drupal::service('account_switcher');
       $this->logger()->notice(dt(

--- a/src/Commands/IslandoraCommands.php
+++ b/src/Commands/IslandoraCommands.php
@@ -24,9 +24,34 @@ class IslandoraCommands extends DrushCommands {
   }
 
   /**
-   * Validate the provided userid.
+   * Add the userid option.
+   *
+   * @hook option migrate:rollback
+   * @option userid User ID to rollback the migration.
+   */
+  public function optionsetRollbackUser($options = ['userid' => self::REQ]) {
+  }
+
+  /**
+   * Implement migrate import validate hook.
    *
    * @hook validate migrate:import
+   */
+  public function validateUserImport(CommandData $commandData) {
+    $this->validateUser($commandData);;
+  }
+
+  /**
+   * Implement migrate rollback validate hook.
+   *
+   * @hook validate migrate:rollback
+   */
+  public function validateUserRollback(CommandData $commandData) {
+    $this->validateUser($commandData);
+  }
+
+  /**
+   * Validate the provided userid.
    */
   public function validateUser(CommandData $commandData) {
     $userid = $commandData->input()->getOption('userid');
@@ -39,11 +64,27 @@ class IslandoraCommands extends DrushCommands {
   }
 
   /**
-   * Switch the active user account to perform the import.
+   * Implement migrate import pre-command hook.
    *
    * @hook pre-command migrate:import
    */
   public function preImport(CommandData $commandData) {
+    $this->switchUser($commandData);
+  }
+
+  /**
+   * Implement migrate rollback pre-command hook.
+   *
+   * @hook pre-command migrate:rollback
+   */
+  public function preRollback(CommandData $commandData) {
+    $this->switchUser($commandData);
+  }
+
+  /**
+   * Switch the active user account using the provided userid.
+   */
+  public function switchUser(CommandData $commandData) {
     $userid = $commandData->input()->getOption('userid');
     if ($userid) {
       $account = User::load($userid);
@@ -64,11 +105,27 @@ class IslandoraCommands extends DrushCommands {
   }
 
   /**
-   * Switch the user back once the migration is complete.
+   * Implement migrate import post-command hook.
    *
    * @hook post-command migrate:import
    */
   public function postImport($result, CommandData $commandData) {
+    $this->switchUserBack($commandData);
+  }
+
+  /**
+   * Implement migrate rollback post-command hook.
+   *
+   * @hook post-command migrate:rollback
+   */
+  public function postRollback($result, CommandData $commandData) {
+    $this->switchUserBack($commandData);
+  }
+
+  /**
+   * Switch the user back.
+   */
+  public function switchUserBack(CommandData $commandData) {
     if ($commandData->input()->getOption('userid')) {
       $accountSwitcher = \Drupal::service('account_switcher');
       $this->logger()->notice(dt(


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1322

# What does this Pull Request do?

Adds the userid option to the Drush migrate:rollback command.

# What's new?
* pulls validating the option, switching the user, and switching the user back into separate functions.
* modifies the existing functions to call the generalized ones.
* adds new functions to implement the hooks for rollback.
* Does this change require documentation to be updated? No. 
* Does this change add any new dependencies? No.
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? No.
* Could this change impact execution of existing code? No.

# How should this be tested?

* Try to rollback a migration using the drush command; you won't see a message about user switching and, even if you don't get an error, Fedora won't reflect the changes.
* Apply the PR.
* Do another rollback using the userid flag and the userid of an account with the fedoraAdmin role. You should see a notice with "Now acting as user" and the changes should be reflected in Fedora.
* Do the migration again, using the userid flag again, and all the stuff should show up in Fedora.

# Interested parties
@Islandora/8-x-committers, esp @dannylamb. We'll tag @DonRichards 'cause he 👍 the issue.
