### PR TITLE
Videojs

### DIFF
--- a/modules/islandora_videojs/islandora_videojs.info.yml
+++ b/modules/islandora_videojs/islandora_videojs.info.yml
@@ -1,0 +1,7 @@
+name: 'Islandora Videojs'
+description: 'Islandora Videojs overrides'
+type: module
+package: Islandora
+core: 8.x
+dependencies:
+  - islandora

--- a/modules/islandora_videojs/islandora_videojs.module
+++ b/modules/islandora_videojs/islandora_videojs.module
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * @file
+ * Contains islandora_videojs.module.
+ *
+ * This file is part of the Islandora Project.
+ *
+ * (c) Islandora Foundation
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Drupal\Core\Routing\RouteMatchInterface;
+
+/**
+ * Implements hook_help().
+ */
+function islandora_videojs_help($route_name, RouteMatchInterface $route_match) {
+  switch ($route_name) {
+    // Main module help for the islandora module.
+    case 'help.page.islandora_videojs':
+      $output = '';
+      $output .= '<h3>' . t('About') . '</h3>';
+      $output .= '<p>' . t('Islandora Videojs overrides.') . '</p>';
+      $output .= '<p>' . t('Customizes videojs.') . '</p>';
+      return $output;
+
+    default:
+  }
+}
+
+
+function islandora_videojs_theme_registry_alter(&$theme_registry) {
+  $module_path = drupal_get_path('module', 'islandora_videojs');
+
+  // Use the templates in my module's template folder.
+  $theme_registry['videojs'] = $theme_registry['videojs'];
+  $theme_registry['videojs']['path'] = $module_path . '/templates';
+  $theme_registry['videojs']['template'] = 'videojs';
+}
+
+
+function islandora_videojs_theme($existing, $type, $theme, $path) {
+  return array(
+    'videojs' => array(
+      'variables' => array('items' => NULL, 'player_attributes' => NULL, 'testvar' => 'testvalue'),
+      'base hook' => 'videojs'
+    ),
+  );
+}
+
+
+
+

--- a/modules/islandora_videojs/islandora_videojs.module
+++ b/modules/islandora_videojs/islandora_videojs.module
@@ -41,6 +41,9 @@ function islandora_videojs_theme_registry_alter(&$theme_registry) {
 }
 
 
+/**
+* videojs theme override
+*/
 function islandora_videojs_theme($existing, $type, $theme, $path) {
   $transcript_urls = get_transcript_urls();
   return array(
@@ -51,7 +54,9 @@ function islandora_videojs_theme($existing, $type, $theme, $path) {
   );
 }
 
-
+/**
+* returns the urls of the transcript of a repository item
+*/
 function get_transcript_urls() {
   // Get the nid
   $node = \Drupal::routeMatch()->getParameter('node');

--- a/modules/islandora_videojs/islandora_videojs.module
+++ b/modules/islandora_videojs/islandora_videojs.module
@@ -31,7 +31,6 @@ function islandora_videojs_help($route_name, RouteMatchInterface $route_match) {
   }
 }
 
-
 function islandora_videojs_theme_registry_alter(&$theme_registry) {
   $module_path = drupal_get_path('module', 'islandora_videojs');
 
@@ -43,14 +42,61 @@ function islandora_videojs_theme_registry_alter(&$theme_registry) {
 
 
 function islandora_videojs_theme($existing, $type, $theme, $path) {
+  $transcript_urls = get_transcript_urls();
   return array(
     'videojs' => array(
-      'variables' => array('items' => NULL, 'player_attributes' => NULL, 'testvar' => 'testvalue'),
+      'variables' => array('items' => NULL, 'player_attributes' => NULL, 'mimes' => NULL, 'transcript_urls' => $transcript_urls),
       'base hook' => 'videojs'
     ),
   );
 }
 
+
+function get_transcript_urls() {
+  // Get the nid
+  $node = \Drupal::routeMatch()->getParameter('node');
+  $nid = NULL;
+  if ($node instanceof \Drupal\node\NodeInterface) {
+    $nid = $node->id();
+  }
+
+  $transcript_urls = array();
+
+  if ($nid != NULL) {
+    // media url
+    global $base_url;
+    $media_url = $base_url. '/node/' . $nid . '/media';
+
+    try {
+        $media_client = new \GuzzleHttp\Client();
+        $media_response = $media_client->request('GET', $media_url, [
+            'http_errors' => false,
+            'auth' => ['admin', 'islandora'],
+            'query' => ['_format' => 'json']
+        ]);
+        $code = $media_response->getStatusCode();
+
+        if ($code = 200) {
+
+        // Loop through media to find the transcripts
+        $media_list = (string) $media_response->getBody();
+        $media_list = json_decode($media_list, true);
+        foreach ($media_list as $media) {
+          if ($media['field_media_use'][0]['url'] == "/taxonomy/term/20") {
+             $file_url = $media['field_media_file'][0]['url'];
+             $transcript_urls[] = $file_url;
+          }
+        }
+        }
+    }
+    catch (\Exception $e) {
+      \Drupal::logger('islandora_videojs')->notice("Error in getting transcripts: " . $e->getMessage());
+    }
+
+  }
+
+  return $transcript_urls;
+}
 
 
 

--- a/modules/islandora_videojs/templates/videojs.html.twig
+++ b/modules/islandora_videojs/templates/videojs.html.twig
@@ -1,0 +1,23 @@
+{#
+/**
+ * @file
+ * Default theme implementation to display a formatted video field.
+ *
+ * Available variables:
+ * - items: A collection of videos.
+ * - player_attributes: Player options including the following:
+ *   - width: The width of the video (if known).
+ *   - height: The height of the video (if known).
+ *   - autoplay: Autoplay on or off
+ *
+ * @ingroup themeable
+ */
+#}
+<h3>Videojs Test {{ testvar }} </h3>
+<video data-setup="{}" class="video-js vjs-default-skin" preload="{{ player_attributes.preload }}" {{ player_attributes.controls ? 'controls' : '' }} style="width:{{ player_attributes.width }}px;height:{{ player_attributes.height }}px;" {{ player_attributes.autoplay ? 'autoplay' : '' }} {{ player_attributes.loop ? 'loop' : '' }} {{ player_attributes.muted ? 'muted' : '' }}>
+  {% for user in items %}
+    <source src="{{ user }}"/>
+  {% endfor %}
+<track srclang="en" label="English" kind="captions" src="http://localhost:8000/_flysystem/fedora/2019-02/MEDIATRACK_en.vtt" default />
+
+</video>

--- a/modules/islandora_videojs/templates/videojs.html.twig
+++ b/modules/islandora_videojs/templates/videojs.html.twig
@@ -13,11 +13,14 @@
  * @ingroup themeable
  */
 #}
-<h3>Videojs Test {{ testvar }} </h3>
+<h3>Videojs Test </h3>
 <video data-setup="{}" class="video-js vjs-default-skin" preload="{{ player_attributes.preload }}" {{ player_attributes.controls ? 'controls' : '' }} style="width:{{ player_attributes.width }}px;height:{{ player_attributes.height }}px;" {{ player_attributes.autoplay ? 'autoplay' : '' }} {{ player_attributes.loop ? 'loop' : '' }} {{ player_attributes.muted ? 'muted' : '' }}>
   {% for user in items %}
-    <source src="{{ user }}"/>
+    <source src="{{ user }}" type="{{ mimes[ loop.index - 1 ] }}"/>
   {% endfor %}
-<track srclang="en" label="English" kind="captions" src="http://localhost:8000/_flysystem/fedora/2019-02/MEDIATRACK_en.vtt" default />
+
+  {% for transcript_url in transcript_urls %}
+    <track srclang="en" label="English" kind="captions" src="{{ transcript_url }}" default />
+  {% endfor %}
 
 </video>


### PR DESCRIPTION
! Important - This is for review and feedback.  

**JIRA Ticket**: (link)
* https://github.com/Islandora/documentation/issues/1305
* https://github.com/Islandora/documentation/issues/1003

* Drupal core issue about vtt - https://www.drupal.org/project/drupal/issues/3057144
* Drupal videojs module issue about audio support - https://www.drupal.org/project/videojs/issues/2698357

# What does this Pull Request do?
This PR enables you to add transcript(s) to video/audio objects when using videojs viewer.

# What's new?
* islandora_videojs sub module which is a plugin extending https://www.drupal.org/project/videojs module.

# How should this be tested?
* Install videojs module.  This branch: https://github.com/Natkeeran/videojs/tree/mimes.  This adds the mimetypes info needed to display audio.
* Get this PR for islandora.
* Add transcript vocabulary item: `http://localhost:8000/admin/structure/taxonomy/manage/islandora_media_use/overview` (note the path)
* (Verify that path is same as here: https://github.com/digitalutsc/islandora/blob/videojs/modules/islandora_videojs/islandora_videojs.module#L90.  I am not sure what is the best method to filter for transcript media files.  At the least, this will be made into a config.)
* Modify the field.field.media.file.field_media_file.yml config to allow for vtt extensions to be uploaded.
* Note that currently authentication is hard coded: https://github.com/digitalutsc/islandora/blob/videojs/modules/islandora_videojs/islandora_videojs.module#L79
* Go to audio and video Manage display and choose Video.js: `http://localhost:8000/admin/structure/media/manage/audio/display` and `http://localhost:8000/admin/structure/media/manage/video/display`
* Create an audio and/or video.  Add a media -> file.  Select Transcript for  `Media Use`. Save.
* In the viewer, it should display the captions.

# Notes and Questions
* Is videojs the player we are looking to support?
* Do we want to create PR for videojs drupal module to add the mimetypes?  
* Can we better implement this: https://github.com/digitalutsc/islandora/blob/videojs/modules/islandora_videojs/islandora_videojs.module#L60.  i.e jsonapi?.  What is the best method to filter for a particular media use other than to use the term path (i.e `/taxonomy/term/20`)?
* Language can be easily added by adding a language field and passing that to the twig template.

# Interested parties
@dannylamb @seth-shaw-unlv @DonRichards 
