### PR TITLE
Jsonld alter caching

### DIFF
--- a/islandora.module
+++ b/islandora.module
@@ -253,6 +253,16 @@ function islandora_jsonld_alter_normalized_array(EntityInterface $entity, array 
   $context_manager = \Drupal::service('context.manager');
   foreach ($context_manager->getActiveReactions('\Drupal\islandora\ContextReaction\NormalizerAlterReaction') as $reaction) {
     $reaction->execute($entity, $normalized, $context);
+    foreach ($context_manager->getActiveContexts() as $context_config) {
+      try {
+        if ($context_config->getReaction($reaction->getPluginId())) {
+          $context['cacheability']->addCacheTags($context_config->getCacheTags());
+        };
+      }
+      catch (Drupal\Component\Plugin\Exception\PluginNotFoundException $e) {
+        // Squash :(
+      }
+    }
   }
 }
 

--- a/islandora.module
+++ b/islandora.module
@@ -14,6 +14,7 @@
  * @author Diego Pino Navarro <dpino@metro.org> https://github.com/diegopino
  */
 
+use Drupal\Component\Plugin\Exception\PluginNotFoundException;
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
@@ -259,8 +260,8 @@ function islandora_jsonld_alter_normalized_array(EntityInterface $entity, array 
           $context['cacheability']->addCacheTags($context_config->getCacheTags());
         };
       }
-      catch (Drupal\Component\Plugin\Exception\PluginNotFoundException $e) {
-        // Squash :(
+      catch (PluginNotFoundException $e) {
+        // Squash :(.
       }
     }
   }

--- a/tests/src/Functional/JsonldSelfReferenceReactionTest.php
+++ b/tests/src/Functional/JsonldSelfReferenceReactionTest.php
@@ -98,6 +98,10 @@ class JsonldSelfReferenceReactionTest extends IslandoraFunctionalTestBase {
     $this->assertSession()
       ->pageTextContains("The context $context_name has been saved");
 
+    // The first time a Context is saved, you need to clear the cache.
+    // Subsequent changes to the context don't need a cache rebuild, though.
+    drupal_flush_all_caches();
+
     $new_contents = $this->drupalGet($url . '?_format=jsonld');
     $json = \GuzzleHttp\json_decode($new_contents, TRUE);
     $this->assertEquals(
@@ -176,6 +180,10 @@ class JsonldSelfReferenceReactionTest extends IslandoraFunctionalTestBase {
     $this->getSession()->getPage()->pressButton("Save and continue");
     $this->assertSession()
       ->pageTextContains("The context $context_name has been saved");
+
+    // The first time a Context is saved, you need to clear the cache.
+    // Subsequent changes to the context don't need a cache rebuild, though.
+    drupal_flush_all_caches();
 
     $new_contents = $this->drupalGet($media_url . '?_format=jsonld');
     $json = \GuzzleHttp\json_decode($new_contents, TRUE);

--- a/tests/src/Functional/JsonldTypeAlterReactionTest.php
+++ b/tests/src/Functional/JsonldTypeAlterReactionTest.php
@@ -75,6 +75,10 @@ class JsonldTypeAlterReactionTest extends JsonldSelfReferenceReactionTest {
     $this->getSession()->getPage()->findById("edit-conditions-entity-bundle-context-mapping-node")->selectOption("@node.node_route_context:node");
     $this->getSession()->getPage()->pressButton(t('Save and continue'));
 
+    // The first time a Context is saved, you need to clear the cache.
+    // Subsequent changes to the context don't need a cache rebuild, though.
+    drupal_flush_all_caches();
+
     // Check for the new @type from the field_type_predicate value.
     $new_contents = $this->drupalGet($url . '?_format=jsonld');
     $json = \GuzzleHttp\json_decode($new_contents, TRUE);


### PR DESCRIPTION

**Github Issue**: https://github.com/Islandora/documentation/issues/1379

# What does this Pull Request do?

Fixes tests by changing how we invalidate caching with our jsonld alters... and nudging the tests a little.

# What's new?
I add some cache tags to the `$context['cacheability']` metadata provided in the alter function.

# How should this be tested?

Before this PR:
* View a node's jsonld, it probabaly has `schema:sameAs` with the Drupal URL in there.
* Go edit the `Content` context and change the self reference URL to `owl:sameAs`.
* View the node's jsonld again, but you don't see `owl:sameAs`.  It's still `schema:sameAs`!

After this PR:
* View a node's jsonld, it probabaly has `schema:sameAs` with the Drupal URL in there.
* Go edit the `Content` context and change the self reference URL to `owl:sameAs`.
* View the node's jsonld again, and you'll see `owl:sameAs` as expected.

# Additional Notes:
This unblocks a bunch of PRs because tests are failing.

# Interested parties
@Islandora/8-x-committers 
