### PR TITLE
Injecting interfaces instead of actual classes

### DIFF
--- a/src/ContextReaction/DisplayAlterReaction.php
+++ b/src/ContextReaction/DisplayAlterReaction.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\islandora\ContextReaction;
 
-use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\context\ContextReactionPluginBase;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
@@ -18,14 +18,14 @@ abstract class DisplayAlterReaction extends ContextReactionPluginBase implements
   /**
    * View mode storage.
    *
-   * @var \Drupal\Core\Entity\EntityTypeManager
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
   protected $entityTypeManager;
 
   /**
    * {@inheritdoc}
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManager $entity_type_manager) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->entityTypeManager = $entity_type_manager;
   }

--- a/src/Controller/ManageMembersController.php
+++ b/src/Controller/ManageMembersController.php
@@ -5,7 +5,7 @@ namespace Drupal\islandora\Controller;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Render\RendererInterface;
 use Drupal\Core\Entity\Controller\EntityController;
-use Drupal\Core\Entity\EntityFieldManager;
+use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\Core\Link;
 use Drupal\node\NodeInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -25,7 +25,7 @@ class ManageMembersController extends EntityController {
   /**
    * The entity field manager.
    *
-   * @var \Drupal\Core\Entity\EntityFieldManager
+   * @var \Drupal\Core\Entity\EntityFieldManagerInterface
    */
   protected $entityFieldManger;
 
@@ -41,14 +41,14 @@ class ManageMembersController extends EntityController {
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager.
-   * @param \Drupal\Core\Entity\EntityFieldManager $entity_field_manager
+   * @param \Drupal\Core\Entity\EntityFieldManagerInterface $entity_field_manager
    *   The entity field manager.
    * @param \Drupal\Core\Render\RendererInterface $renderer
    *   The renderer.
    */
   public function __construct(
     EntityTypeManagerInterface $entity_type_manager,
-    EntityFieldManager $entity_field_manager,
+    EntityFieldManagerInterface $entity_field_manager,
     RendererInterface $renderer
   ) {
     $this->entityTypeManager = $entity_type_manager;

--- a/src/EventGenerator/EmitEvent.php
+++ b/src/EventGenerator/EmitEvent.php
@@ -5,7 +5,7 @@ namespace Drupal\islandora\EventGenerator;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Action\ConfigurableActionBase;
 use Drupal\Core\Entity\EntityInterface;
-use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Session\AccountInterface;
@@ -30,7 +30,7 @@ abstract class EmitEvent extends ConfigurableActionBase implements ContainerFact
   /**
    * Entity type manager.
    *
-   * @var \Drupal\Core\Entity\EntityTypeManager
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
   protected $entityTypeManager;
 
@@ -66,7 +66,7 @@ abstract class EmitEvent extends ConfigurableActionBase implements ContainerFact
    *   The plugin implementation definition.
    * @param \Drupal\Core\Session\AccountInterface $account
    *   Current user.
-   * @param \Drupal\Core\Entity\EntityTypeManager $entity_type_manager
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   Entity type manager.
    * @param \Drupal\islandora\EventGenerator\EventGeneratorInterface $event_generator
    *   EventGenerator service to serialize AS2 events.
@@ -80,7 +80,7 @@ abstract class EmitEvent extends ConfigurableActionBase implements ContainerFact
     $plugin_id,
     $plugin_definition,
     AccountInterface $account,
-    EntityTypeManager $entity_type_manager,
+    EntityTypeManagerInterface $entity_type_manager,
     EventGeneratorInterface $event_generator,
     StatefulStomp $stomp,
     JwtAuth $auth

--- a/src/EventSubscriber/LinkHeaderSubscriber.php
+++ b/src/EventSubscriber/LinkHeaderSubscriber.php
@@ -3,9 +3,9 @@
 namespace Drupal\islandora\EventSubscriber;
 
 use Drupal\Core\Access\AccessManagerInterface;
-use Drupal\Core\Entity\EntityFieldManager;
+use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\Core\Entity\EntityInterface;
-use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\islandora\IslandoraUtils;
@@ -25,14 +25,14 @@ abstract class LinkHeaderSubscriber implements EventSubscriberInterface {
   /**
    * The entity type manager.
    *
-   * @var \Drupal\Core\Entity\EntityTypeManager
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
   protected $entityTypeManager;
 
   /**
    * The entity field manager.
    *
-   * @var \Drupal\Core\Entity\EntityFieldManager
+   * @var \Drupal\Core\Entity\EntityFieldManagerInterface
    */
   protected $entityFieldManager;
 
@@ -74,9 +74,9 @@ abstract class LinkHeaderSubscriber implements EventSubscriberInterface {
   /**
    * Constructor.
    *
-   * @param \Drupal\Core\Entity\EntityTypeManager $entity_type_manager
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager.
-   * @param \Drupal\Core\Entity\EntityFieldManager $entity_field_manager
+   * @param \Drupal\Core\Entity\EntityFieldManagerInterface $entity_field_manager
    *   The entity field manager.
    * @param \Drupal\Core\Access\AccessManagerInterface $access_manager
    *   The access manager.
@@ -90,8 +90,8 @@ abstract class LinkHeaderSubscriber implements EventSubscriberInterface {
    *   Islandora utils.
    */
   public function __construct(
-    EntityTypeManager $entity_type_manager,
-    EntityFieldManager $entity_field_manager,
+    EntityTypeManagerInterface $entity_type_manager,
+    EntityFieldManagerInterface $entity_field_manager,
     AccessManagerInterface $access_manager,
     AccountInterface $account,
     RouteMatchInterface $route_match,

--- a/src/Form/IslandoraSettingsForm.php
+++ b/src/Form/IslandoraSettingsForm.php
@@ -3,7 +3,7 @@
 namespace Drupal\islandora\Form;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
-use Drupal\Core\Entity\EntityTypeBundleInfo;
+use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Site\Settings;
@@ -30,7 +30,7 @@ class IslandoraSettingsForm extends ConfigFormBase {
   /**
    * To list the available bundle types.
    *
-   * @var \Drupal\Core\Entity\EntityTypeBundleInfo
+   * @var \Drupal\Core\Entity\EntityTypeBundleInfoInterface
    */
   private $entityTypeBundleInfo;
 
@@ -39,10 +39,10 @@ class IslandoraSettingsForm extends ConfigFormBase {
    *
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
    *   The factory for configuration objects.
-   * @param \Drupal\Core\Entity\EntityTypeBundleInfo $entity_type_bundle_info
+   * @param \Drupal\Core\Entity\EntityTypeBundleInfoInterface $entity_type_bundle_info
    *   The EntityTypeBundleInfo service.
    */
-  public function __construct(ConfigFactoryInterface $config_factory, EntityTypeBundleInfo $entity_type_bundle_info) {
+  public function __construct(ConfigFactoryInterface $config_factory, EntityTypeBundleInfoInterface $entity_type_bundle_info) {
     $this->setConfigFactory($config_factory);
     $this->entityTypeBundleInfo = $entity_type_bundle_info;
   }

--- a/src/IslandoraUtils.php
+++ b/src/IslandoraUtils.php
@@ -5,8 +5,8 @@ namespace Drupal\islandora;
 use Drupal\context\ContextManager;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityInterface;
-use Drupal\Core\Entity\EntityFieldManager;
-use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\Core\Entity\EntityFieldManagerInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\Query\QueryException;
 use Drupal\Core\Entity\Query\QueryFactory;
 use Drupal\Core\Entity\Query\QueryInterface;
@@ -35,14 +35,14 @@ class IslandoraUtils {
   /**
    * The entity type manager.
    *
-   * @var \Drupal\Core\Entity\EntityTypeManager
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
   protected $entityTypeManager;
 
   /**
    * The entity field manager.
    *
-   * @var \Drupal\Core\Entity\EntityFieldManager
+   * @var \Drupal\Core\Entity\EntityFieldManagerInterface
    */
   protected $entityFieldManager;
 
@@ -77,9 +77,9 @@ class IslandoraUtils {
   /**
    * Constructor.
    *
-   * @param \Drupal\Core\Entity\EntityTypeManager $entity_type_manager
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager.
-   * @param \Drupal\Core\Entity\EntityFieldManager $entity_field_manager
+   * @param \Drupal\Core\Entity\EntityFieldManagerInterface $entity_field_manager
    *   The entity field manager.
    * @param \Drupal\Core\Entity\Query\QueryFactory $entity_query
    *   Entity query.
@@ -91,8 +91,8 @@ class IslandoraUtils {
    *   Language manager.
    */
   public function __construct(
-    EntityTypeManager $entity_type_manager,
-    EntityFieldManager $entity_field_manager,
+    EntityTypeManagerInterface $entity_type_manager,
+    EntityFieldManagerInterface $entity_field_manager,
     QueryFactory $entity_query,
     ContextManager $context_manager,
     FlysystemFactory $flysystem_factory,

--- a/src/MediaSource/MediaSourceService.php
+++ b/src/MediaSource/MediaSourceService.php
@@ -2,9 +2,9 @@
 
 namespace Drupal\islandora\MediaSource;
 
-use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\Query\QueryFactory;
-use Drupal\Core\File\FileSystem;
+use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\file\FileInterface;
@@ -25,7 +25,7 @@ class MediaSourceService {
   /**
    * The entity type manager.
    *
-   * @var \Drupal\Core\Entity\EntityTypeManager
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
   protected $entityTypeManager;
 
@@ -53,7 +53,7 @@ class MediaSourceService {
   /**
    * File system service.
    *
-   * @var \Drupal\Core\File\FileSystem
+   * @var \Drupal\Core\File\FileSystemInterface
    */
   protected $fileSystem;
 
@@ -67,7 +67,7 @@ class MediaSourceService {
   /**
    * Constructor.
    *
-   * @param \Drupal\Core\Entity\EntityTypeManager $entity_type_manager
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager.
    * @param \Drupal\Core\Session\AccountInterface $account
    *   The current user.
@@ -75,17 +75,17 @@ class MediaSourceService {
    *   Language manager.
    * @param \Drupal\Core\Entity\Query\QueryFactory $entity_query
    *   Entity query.
-   * @param \Drupal\Core\File\FileSystem $file_system
+   * @param \Drupal\Core\File\FileSystemInterface $file_system
    *   File system service.
    * @param \Drupal\islandora\IslandoraUtils $islandora_utils
    *   Utility service.
    */
   public function __construct(
-    EntityTypeManager $entity_type_manager,
+    EntityTypeManagerInterface $entity_type_manager,
     AccountInterface $account,
     LanguageManagerInterface $language_manager,
     QueryFactory $entity_query,
-    FileSystem $file_system,
+    FileSystemInterface $file_system,
     IslandoraUtils $islandora_utils
   ) {
     $this->entityTypeManager = $entity_type_manager;

--- a/src/Plugin/Action/AbstractGenerateDerivative.php
+++ b/src/Plugin/Action/AbstractGenerateDerivative.php
@@ -3,7 +3,7 @@
 namespace Drupal\islandora\Plugin\Action;
 
 use Drupal\Core\Entity\EntityInterface;
-use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Url;
@@ -12,7 +12,7 @@ use Drupal\islandora\EventGenerator\EmitEvent;
 use Drupal\islandora\EventGenerator\EventGeneratorInterface;
 use Drupal\islandora\MediaSource\MediaSourceService;
 use Drupal\jwt\Authentication\Provider\JwtAuth;
-use Drupal\token\Token;
+use Drupal\token\TokenInterface;
 use Stomp\StatefulStomp;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -38,7 +38,7 @@ class AbstractGenerateDerivative extends EmitEvent {
   /**
    * Token replacement service.
    *
-   * @var \Drupal\token\Token
+   * @var \Drupal\token\TokenInterface
    */
   protected $token;
 
@@ -53,7 +53,7 @@ class AbstractGenerateDerivative extends EmitEvent {
    *   The plugin implementation definition.
    * @param \Drupal\Core\Session\AccountInterface $account
    *   Current user.
-   * @param \Drupal\Core\Entity\EntityTypeManager $entity_type_manager
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   Entity type manager.
    * @param \Drupal\islandora\EventGenerator\EventGeneratorInterface $event_generator
    *   EventGenerator service to serialize AS2 events.
@@ -65,7 +65,7 @@ class AbstractGenerateDerivative extends EmitEvent {
    *   Islandora utility functions.
    * @param \Drupal\islandora\MediaSource\MediaSourceService $media_source
    *   Media source service.
-   * @param \Drupal\token\Token $token
+   * @param \Drupal\token\TokenInterface $token
    *   Token service.
    */
   public function __construct(
@@ -73,13 +73,13 @@ class AbstractGenerateDerivative extends EmitEvent {
     $plugin_id,
     $plugin_definition,
     AccountInterface $account,
-    EntityTypeManager $entity_type_manager,
+    EntityTypeManagerInterface $entity_type_manager,
     EventGeneratorInterface $event_generator,
     StatefulStomp $stomp,
     JwtAuth $auth,
     IslandoraUtils $utils,
     MediaSourceService $media_source,
-    Token $token
+    TokenInterface $token
   ) {
     parent::__construct(
       $configuration,

--- a/src/Plugin/Action/EmitFileEvent.php
+++ b/src/Plugin/Action/EmitFileEvent.php
@@ -3,8 +3,8 @@
 namespace Drupal\islandora\Plugin\Action;
 
 use Drupal\Core\Entity\EntityInterface;
-use Drupal\Core\Entity\EntityTypeManager;
-use Drupal\Core\File\FileSystem;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Site\Settings;
 use Drupal\jwt\Authentication\Provider\JwtAuth;
@@ -27,7 +27,7 @@ class EmitFileEvent extends EmitEvent {
   /**
    * File system service.
    *
-   * @var \Drupal\Core\File\FileSystem
+   * @var \Drupal\Core\File\FileSystemInterface
    */
   protected $fileSystem;
 
@@ -42,7 +42,7 @@ class EmitFileEvent extends EmitEvent {
    *   The plugin implementation definition.
    * @param \Drupal\Core\Session\AccountInterface $account
    *   Current user.
-   * @param \Drupal\Core\Entity\EntityTypeManager $entity_type_manager
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   Entity type manager.
    * @param \Drupal\islandora\EventGenerator\EventGeneratorInterface $event_generator
    *   EventGenerator service to serialize AS2 events.
@@ -50,7 +50,7 @@ class EmitFileEvent extends EmitEvent {
    *   Stomp client.
    * @param \Drupal\jwt\Authentication\Provider\JwtAuth $auth
    *   JWT Auth client.
-   * @param \Drupal\Core\File\FileSystem $file_system
+   * @param \Drupal\Core\File\FileSystemInterface $file_system
    *   File system service.
    */
   public function __construct(
@@ -58,11 +58,11 @@ class EmitFileEvent extends EmitEvent {
     $plugin_id,
     $plugin_definition,
     AccountInterface $account,
-    EntityTypeManager $entity_type_manager,
+    EntityTypeManagerInterface $entity_type_manager,
     EventGeneratorInterface $event_generator,
     StatefulStomp $stomp,
     JwtAuth $auth,
-    FileSystem $file_system
+    FileSystemInterface $file_system
   ) {
     parent::__construct(
       $configuration,

--- a/src/Plugin/Action/EmitMediaEvent.php
+++ b/src/Plugin/Action/EmitMediaEvent.php
@@ -3,7 +3,7 @@
 namespace Drupal\islandora\Plugin\Action;
 
 use Drupal\Core\Entity\EntityInterface;
-use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\jwt\Authentication\Provider\JwtAuth;
 use Drupal\islandora\EventGenerator\EmitEvent;
@@ -41,7 +41,7 @@ class EmitMediaEvent extends EmitEvent {
    *   The plugin implementation definition.
    * @param \Drupal\Core\Session\AccountInterface $account
    *   Current user.
-   * @param \Drupal\Core\Entity\EntityTypeManager $entity_type_manager
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   Entity type manager.
    * @param \Drupal\islandora\EventGenerator\EventGeneratorInterface $event_generator
    *   EventGenerator service to serialize AS2 events.
@@ -57,7 +57,7 @@ class EmitMediaEvent extends EmitEvent {
     $plugin_id,
     $plugin_definition,
     AccountInterface $account,
-    EntityTypeManager $entity_type_manager,
+    EntityTypeManagerInterface $entity_type_manager,
     EventGeneratorInterface $event_generator,
     StatefulStomp $stomp,
     JwtAuth $auth,

--- a/src/Plugin/Condition/FileUsesFilesystem.php
+++ b/src/Plugin/Condition/FileUsesFilesystem.php
@@ -3,7 +3,7 @@
 namespace Drupal\islandora\Plugin\Condition;
 
 use Drupal\Core\Condition\ConditionPluginBase;
-use Drupal\Core\File\FileSystem;
+use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\file\FileInterface;
@@ -33,7 +33,7 @@ class FileUsesFilesystem extends ConditionPluginBase implements ContainerFactory
   /**
    * File system service.
    *
-   * @var \Drupal\Core\File\FileSystem
+   * @var \Drupal\Core\File\FileSystemInterface
    */
   protected $fileSystem;
 
@@ -51,7 +51,7 @@ class FileUsesFilesystem extends ConditionPluginBase implements ContainerFactory
    *   The plugin implementation definition.
    * @param \Drupal\islandora\IslandoraUtils $utils
    *   Islandora utility functions.
-   * @param \Drupal\Core\File\FileSystem $file_system
+   * @param \Drupal\Core\File\FileSystemInterface $file_system
    *   File system service.
    */
   public function __construct(
@@ -59,7 +59,7 @@ class FileUsesFilesystem extends ConditionPluginBase implements ContainerFactory
     $plugin_id,
     $plugin_definition,
     IslandoraUtils $utils,
-    FileSystem $file_system
+    FileSystemInterface $file_system
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->utils = $utils;

--- a/src/Plugin/Condition/MediaHasMimetype.php
+++ b/src/Plugin/Condition/MediaHasMimetype.php
@@ -3,7 +3,7 @@
 namespace Drupal\islandora\Plugin\Condition;
 
 use Drupal\Core\Condition\ConditionPluginBase;
-use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\islandora\IslandoraUtils;
@@ -37,7 +37,7 @@ class MediaHasMimetype extends ConditionPluginBase implements ContainerFactoryPl
   /**
    * Term storage.
    *
-   * @var \Drupal\Core\Entity\EntityTypeManager
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
   protected $entityTypeManager;
 
@@ -62,7 +62,7 @@ class MediaHasMimetype extends ConditionPluginBase implements ContainerFactoryPl
    *   The plugin implementation definition.
    * @param \Drupal\islandora\IslandoraUtils $utils
    *   Islandora utility functions.
-   * @param \Drupal\Core\Entity\EntityTypeManager $entity_type_manager
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   Entity type manager.
    * @param \Drupal\islandora\MediaSource\MediaSourceService $media_source
    *   Media source service.
@@ -72,7 +72,7 @@ class MediaHasMimetype extends ConditionPluginBase implements ContainerFactoryPl
     $plugin_id,
     $plugin_definition,
     IslandoraUtils $utils,
-    EntityTypeManager $entity_type_manager,
+    EntityTypeManagerInterface $entity_type_manager,
     MediaSourceService $media_source
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $utils);

--- a/src/Plugin/Condition/MediaUsesFilesystem.php
+++ b/src/Plugin/Condition/MediaUsesFilesystem.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\islandora\Plugin\Condition;
 
-use Drupal\Core\File\FileSystem;
+use Drupal\Core\File\FileSystemInterface;
 use Drupal\islandora\MediaSource\MediaSourceService;
 use Drupal\islandora\IslandoraUtils;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -41,7 +41,7 @@ class MediaUsesFilesystem extends FileUsesFilesystem {
    *   The plugin implementation definition.
    * @param \Drupal\islandora\IslandoraUtils $utils
    *   Islandora utility functions.
-   * @param \Drupal\Core\File\FileSystem $file_system
+   * @param \Drupal\Core\File\FileSystemInterface $file_system
    *   File system service.
    * @param \Drupal\islandora\MediaSource\MediaSourceService $media_source
    *   Media source service.
@@ -51,7 +51,7 @@ class MediaUsesFilesystem extends FileUsesFilesystem {
     $plugin_id,
     $plugin_definition,
     IslandoraUtils $utils,
-    FileSystem $file_system,
+    FileSystemInterface $file_system,
     MediaSourceService $media_source
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $utils, $file_system);

--- a/src/Plugin/Condition/NodeHadNamespace.php
+++ b/src/Plugin/Condition/NodeHadNamespace.php
@@ -4,7 +4,7 @@ namespace Drupal\islandora\Plugin\Condition;
 
 use Drupal\Core\Condition\ConditionPluginBase;
 use Drupal\Core\Entity\EntityInterface;
-use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\islandora\IslandoraUtils;
@@ -33,7 +33,7 @@ class NodeHadNamespace extends ConditionPluginBase implements ContainerFactoryPl
   /**
    * Term storage.
    *
-   * @var \Drupal\Core\Entity\EntityTypeManager
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
   protected $entityTypeManager;
 
@@ -51,7 +51,7 @@ class NodeHadNamespace extends ConditionPluginBase implements ContainerFactoryPl
    *   The plugin implementation definition.
    * @param \Drupal\islandora\IslandoraUtils $utils
    *   Islandora utils.
-   * @param \Drupal\Core\Entity\EntityTypeManager $entity_type_manager
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   Entity type manager.
    */
   public function __construct(
@@ -59,7 +59,7 @@ class NodeHadNamespace extends ConditionPluginBase implements ContainerFactoryPl
     $plugin_id,
     $plugin_definition,
     IslandoraUtils $utils,
-    EntityTypeManager $entity_type_manager
+    EntityTypeManagerInterface $entity_type_manager
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->utils = $utils;

--- a/src/Plugin/Condition/NodeHasParent.php
+++ b/src/Plugin/Condition/NodeHasParent.php
@@ -4,7 +4,7 @@ namespace Drupal\islandora\Plugin\Condition;
 
 use Drupal\Core\Condition\ConditionPluginBase;
 use Drupal\Core\Entity\EntityInterface;
-use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -25,7 +25,7 @@ class NodeHasParent extends ConditionPluginBase implements ContainerFactoryPlugi
   /**
    * Node storage.
    *
-   * @var \Drupal\Core\Entity\EntityTypeManager
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
   protected $entityTypeManager;
 
@@ -41,14 +41,14 @@ class NodeHasParent extends ConditionPluginBase implements ContainerFactoryPlugi
    *   The plugin_id for the plugin instance.
    * @param mixed $plugin_definition
    *   The plugin implementation definition.
-   * @param \Drupal\Core\Entity\EntityTypeManager $entity_type_manager
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   Entity type manager.
    */
   public function __construct(
     array $configuration,
     $plugin_id,
     $plugin_definition,
-    EntityTypeManager $entity_type_manager
+    EntityTypeManagerInterface $entity_type_manager
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->entityTypeManager = $entity_type_manager;

--- a/src/Plugin/Condition/NodeHasTerm.php
+++ b/src/Plugin/Condition/NodeHasTerm.php
@@ -4,7 +4,7 @@ namespace Drupal\islandora\Plugin\Condition;
 
 use Drupal\Core\Condition\ConditionPluginBase;
 use Drupal\Core\Entity\EntityInterface;
-use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\islandora\IslandoraUtils;
@@ -33,7 +33,7 @@ class NodeHasTerm extends ConditionPluginBase implements ContainerFactoryPluginI
   /**
    * Term storage.
    *
-   * @var \Drupal\Core\Entity\EntityTypeManager
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
   protected $entityTypeManager;
 
@@ -51,7 +51,7 @@ class NodeHasTerm extends ConditionPluginBase implements ContainerFactoryPluginI
    *   The plugin implementation definition.
    * @param \Drupal\islandora\IslandoraUtils $utils
    *   Islandora utils.
-   * @param \Drupal\Core\Entity\EntityTypeManager $entity_type_manager
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   Entity type manager.
    */
   public function __construct(
@@ -59,7 +59,7 @@ class NodeHasTerm extends ConditionPluginBase implements ContainerFactoryPluginI
     $plugin_id,
     $plugin_definition,
     IslandoraUtils $utils,
-    EntityTypeManager $entity_type_manager
+    EntityTypeManagerInterface $entity_type_manager
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->utils = $utils;

--- a/src/Plugin/Condition/NodeIsPublished.php
+++ b/src/Plugin/Condition/NodeIsPublished.php
@@ -3,7 +3,7 @@
 namespace Drupal\islandora\Plugin\Condition;
 
 use Drupal\Core\Condition\ConditionPluginBase;
-use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -23,7 +23,7 @@ class NodeIsPublished extends ConditionPluginBase implements ContainerFactoryPlu
   /**
    * Term storage.
    *
-   * @var \Drupal\Core\Entity\EntityTypeManager
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
   protected $entityTypeManager;
 
@@ -39,14 +39,14 @@ class NodeIsPublished extends ConditionPluginBase implements ContainerFactoryPlu
    *   The plugin_id for the plugin instance.
    * @param mixed $plugin_definition
    *   The plugin implementation definition.
-   * @param \Drupal\Core\Entity\EntityTypeManager $entity_type_manager
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   Entity type manager.
    */
   public function __construct(
     array $configuration,
     $plugin_id,
     $plugin_definition,
-    EntityTypeManager $entity_type_manager
+    EntityTypeManagerInterface $entity_type_manager
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->entityTypeManager = $entity_type_manager;


### PR DESCRIPTION

**Github Issue**: https://github.com/Islandora/documentation/issues/1361

# What does this Pull Request do?

Replaces type hints in constructors to use interfaces instead of implementing classes.

# What's new?

In constructors, you should see the following values replaced:

- `EntityTypeManager` -> `EntityTypeManagerInterface`
- `EntityFieldManager` -> `EntityFieldManagerInterface`
- `FileSystem` -> `FileSystemInterface`
- `Token` -> `TokenInterface`

# How should this be tested?

Nothing should break.  @qadan should be able to use webprofiler?

# Interested parties
@Islandora/8-x-committers @qadan 
