### PR TITLE
Adds prefix for dcterms to module

### DIFF
--- a/islandora.module
+++ b/islandora.module
@@ -51,6 +51,7 @@ function islandora_rdf_namespaces() {
   return [
     'ldp'  => 'http://www.w3.org/ns/ldp#',
     'dc11' => 'http://purl.org/dc/elements/1.1/',
+    'dcterms' => 'http://purl.org/dc/terms/',
     'nfo' => 'http://www.semanticdesktop.org/ontologies/2007/03/22/nfo/v1.1/',
     'ebucore' => 'http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#',
     'fedora' => 'http://fedora.info/definitions/v4/repository#',

--- a/tests/src/Functional/JsonldSelfReferenceReactionTest.php
+++ b/tests/src/Functional/JsonldSelfReferenceReactionTest.php
@@ -28,7 +28,7 @@ class JsonldSelfReferenceReactionTest extends IslandoraFunctionalTestBase {
       ->setBundleMapping(['types' => $types])
       ->setFieldMapping('created', $created_mapping)
       ->setFieldMapping('title', [
-        'properties' => ['dc:title'],
+        'properties' => ['dcterms:title'],
         'datatype' => 'xsd:string',
       ])
       ->save();


### PR DESCRIPTION

**JIRA Ticket**: https://github.com/Islandora/documentation/issues/1412

# What does this Pull Request do?
This adds the prefix `dcterms` to the module mapping. Note that this prefix is a duplicate of the `dc` prefix that drupal defines. They both point to `http://purl.org/dc/terms/`. (drupal doesn't have a prefix for dc elements - hence islandora.module defining `dc11` pointing to that.)

The reason I'm adding this is because the prefix `dcterms` is used in the rdf mappings in islandora_defaults.  There's a bigger question of whether or not we should use `dc` or `dcterms`, but for now this fixes the issue see in the above ticket. 


# What's new?
This is almost a one liner to add the `dcterms` prefix and a tweak to the test code to use `dcterms` instead of `dc` -  that change is questionable and I can take it out if desired.

Example:
* adds `dcterms` prefix to namespace mapping
# How should this be tested?

First, create a repository object. Make sure you add some of Genre, Language, Table of Contents, Temporal, Spatial -- these all use `dcterms`  prefix. Before this change, once you saved, you'd see the brackets around information like so: `<dcterms:spatial>`  <-- that means fedora thinks that's a fully qualified URL.  With this change you won't see the `<>`'s anymore because islandora will know it's a prefix now. 

You have to do a curl on fedora URL of the object to see the `<>`'s, as you won't see the issue in the drupal interface. 


# Interested parties
@seth-shaw-unlv @dannylamb @whikloj 