### PR TITLE
add Home link to breadcrumbs

### DIFF
--- a/modules/islandora_breadcrumbs/src/IslandoraBreadcrumbBuilder.php
+++ b/modules/islandora_breadcrumbs/src/IslandoraBreadcrumbBuilder.php
@@ -7,12 +7,15 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Breadcrumb\Breadcrumb;
 use Drupal\Core\Breadcrumb\BreadcrumbBuilderInterface;
+use Drupal\Core\Link;
 use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
 
 /**
  * Provides breadcrumbs for nodes using a configured entity reference field.
  */
 class IslandoraBreadcrumbBuilder implements BreadcrumbBuilderInterface {
+  use StringTranslationTrait;
 
   /**
    * The configuration.
@@ -63,6 +66,7 @@ class IslandoraBreadcrumbBuilder implements BreadcrumbBuilderInterface {
     $nid = $route_match->getRawParameters()->get('node');
     $node = $this->nodeStorage->load($nid);
     $breadcrumb = new Breadcrumb();
+    $breadcrumb->addLink(Link::createFromRoute($this->t('Home'), '<front>'));
 
     $chain = [];
     $this->walkMembership($node, $chain);


### PR DESCRIPTION
**Github Issue**: https://github.com/Islandora/documentation/issues/1430

# What does this Pull Request do?

Adds a 'Home' link to the breadcrumbs generated by the islandora_breadcrumbs submodule.

# What's new?

Simply adds a single line to the module to include a 'Home' link to the breadcrumbs.

# How should this be tested?

- Create a collection and a child of that collection (sub-collection, image, whatever...)
- Visit that child's page and breadcrumbs will appear without a 'Home' link.
- Apply the PR
- Clear cache
- Visit the child's page again and the breadcrumbs will appear with a 'Home' link (appropriately translated to your site's language settings).

# Additional Notes:

N/A

# Interested parties
@Islandora/8-x-committers + @wgilling
