### PR TITLE
No longer double negating conditions

### DIFF
--- a/src/Plugin/Condition/EntityBundle.php
+++ b/src/Plugin/Condition/EntityBundle.php
@@ -61,11 +61,11 @@ class EntityBundle extends ConditionPluginBase {
       if ($context->hasContextValue()) {
         $entity = $context->getContextValue();
         if (!empty($this->configuration['bundles'][$entity->bundle()])) {
-          return !$this->isNegated();
+          return TRUE;
         }
       }
     }
-    return $this->isNegated();
+    return FALSE;
   }
 
   /**

--- a/src/Plugin/Condition/MediaHasMimetype.php
+++ b/src/Plugin/Condition/MediaHasMimetype.php
@@ -152,7 +152,7 @@ class MediaHasMimetype extends ConditionPluginBase implements ContainerFactoryPl
       foreach ($media as $medium) {
         $file = $this->mediaSource->getSourceFile($medium);
         if (in_array($file->getMimeType(), $mimetypes)) {
-          return $this->isNegated() ? FALSE : TRUE;
+          return TRUE;
         }
       }
     }

--- a/src/Plugin/Condition/NodeHadNamespace.php
+++ b/src/Plugin/Condition/NodeHadNamespace.php
@@ -154,12 +154,12 @@ class NodeHadNamespace extends ConditionPluginBase implements ContainerFactoryPl
       foreach ($registered_namespaces as &$registered_namespace) {
         $registered_namespace = trim($registered_namespace);
         if (in_array($namespace, $registered_namespaces)) {
-          return $this->isNegated() ? FALSE : TRUE;
+          return TRUE;
         }
       }
     }
 
-    return $this->isNegated() ? TRUE : FALSE;
+    return FALSE;
   }
 
   /**

--- a/src/Plugin/Condition/NodeHasParent.php
+++ b/src/Plugin/Condition/NodeHasParent.php
@@ -145,12 +145,13 @@ class NodeHasParent extends ConditionPluginBase implements ContainerFactoryPlugi
           $nids = $field->getValue();
           foreach ($nids as $nid) {
             if ($nid['target_id'] == $this->configuration['parent_nid']) {
-              return $this->isNegated() ? FALSE : TRUE;
+              return TRUE;
             }
           }
         }
       }
     }
+    return FALSE;
   }
 
   /**

--- a/src/Plugin/Condition/NodeIsPublished.php
+++ b/src/Plugin/Condition/NodeIsPublished.php
@@ -72,11 +72,12 @@ class NodeIsPublished extends ConditionPluginBase implements ContainerFactoryPlu
     if (!$node  && !$this->isNegated()) {
       return FALSE;
     }
-    if ($node->isPublished() && !$this->isNegated()) {
-      return TRUE;
+    elseif (!$node) {
+      return FALSE;
     }
-
-    return FALSE;
+    else {
+      return $node->isPublished();
+    }
   }
 
   /**


### PR DESCRIPTION
**Github Issue**: Resolves https://github.com/Islandora/documentation/issues/1325

# What does this Pull Request do?

Stops doing negation logic in our Condition plugins so they can be negated downstream.

# What's new?
Less checks using `isNegated()`.

# How should this be tested?

Pull down the PR and set up contexts using these Conditions to do something simple like switch themes:

- `EntityBundle`
- `MediaHasMimetype`
- `NodeHadNamespace`
- `NodeHasParent`
- `NodeIsPublished`

The contexts should behave as expected both normally and when negated.

# Interested parties
@Islandora/8-x-committers @qadan 
