### PR TITLE
Using context_definitions annotation instead of the deprecated contex…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,12 +27,11 @@ install:
   - $SCRIPT_DIR/travis_setup_drupal.sh
   - git -C "$TRAVIS_BUILD_DIR" checkout -b travis-testing
   - cd $DRUPAL_DIR;
+  - chmod -R u+w web/sites/default
   - COMPOSER_MEMORY_LIMIT=-1 php -d memory_limit=-1 $COMPOSER_PATH config repositories.local path "$TRAVIS_BUILD_DIR"
   - COMPOSER_MEMORY_LIMIT=-1 php -d memory_limit=-1 $COMPOSER_PATH require "islandora/islandora:dev-travis-testing as dev-8.x-1.x" --prefer-source --update-with-dependencies
-  - cd web; drush --uri=127.0.0.1:8282 en -y islandora
-  - (drush -y --uri=127.0.0.1:8282 en islandora_core_feature; drush -y --uri=127.0.0.1:8282 fim islandora_core_feature)
-  - drush -y --uri=127.0.0.1:8282 en islandora_audio islandora_breadcrumbs islandora_iiif islandora_image islandora_video
-  - (drush -y --uri=127.0.0.1:8282 en islandora_text_extraction_defaults; drush -y --uri=127.0.0.1:8282 fim islandora_text_extraction_defaults)
+  - drush --uri=127.0.0.1:8282 en -y islandora_audio islandora_breadcrumbs islandora_iiif islandora_image islandora_video islandora_text_extraction_defaults
+  - drush --uri=127.0.0.1:8282 fim -y islandora_core_feature,islandora_text_extraction_defaults
 
 script:
   - $SCRIPT_DIR/travis_scripts.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ install:
   - chmod -R u+w web/sites/default
   - COMPOSER_MEMORY_LIMIT=-1 php -d memory_limit=-1 $COMPOSER_PATH config repositories.local path "$TRAVIS_BUILD_DIR"
   - COMPOSER_MEMORY_LIMIT=-1 php -d memory_limit=-1 $COMPOSER_PATH require "islandora/islandora:dev-travis-testing as dev-8.x-1.x" --prefer-source --update-with-dependencies
+  - cd web
   - drush --uri=127.0.0.1:8282 en -y islandora_audio islandora_breadcrumbs islandora_iiif islandora_image islandora_video islandora_text_extraction_defaults
   - drush --uri=127.0.0.1:8282 fim -y islandora_core_feature,islandora_text_extraction_defaults
 

--- a/modules/islandora_breadcrumbs/tests/src/Functional/BreadcrumbsTest.php
+++ b/modules/islandora_breadcrumbs/tests/src/Functional/BreadcrumbsTest.php
@@ -101,9 +101,10 @@ class BreadcrumbsTest extends IslandoraFunctionalTestBase {
    */
   public function testDefaults() {
     $breadcrumbs = [
-      $this->nodeC->toUrl()->toString() => $this->nodeC->label(),
-      $this->nodeB->toUrl()->toString() => $this->nodeB->label(),
+      Url::fromRoute('<front>')->toString() => 'Home',
       $this->nodeA->toUrl()->toString() => $this->nodeA->label(),
+      $this->nodeB->toUrl()->toString() => $this->nodeB->label(),
+      $this->nodeC->toUrl()->toString() => $this->nodeC->label(),
     ];
     $this->assertBreadcrumb($this->nodeD->toUrl()->toString(), $breadcrumbs);
 

--- a/modules/islandora_breadcrumbs/tests/src/Functional/BreadcrumbsTest.php
+++ b/modules/islandora_breadcrumbs/tests/src/Functional/BreadcrumbsTest.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\Tests\islandora_breadcrumbs\Functional;
 
+use Drupal\Core\Url;
 use Drupal\Tests\islandora\Functional\IslandoraFunctionalTestBase;
 use Drupal\Tests\system\Functional\Menu\AssertBreadcrumbTrait;
 
@@ -85,6 +86,14 @@ class BreadcrumbsTest extends IslandoraFunctionalTestBase {
     ]);
     $this->nodeD->set('field_member_of', [$this->nodeC->id()]);
     $this->nodeD->save();
+    
+    $this->drupalPlaceBlock(
+      'system_breadcrumb_block',
+      [
+        'region' => 'content',
+        'theme' => $this->config('system.theme')->get('default'),
+      ]
+    );
   }
 
   /**

--- a/modules/islandora_breadcrumbs/tests/src/Functional/BreadcrumbsTest.php
+++ b/modules/islandora_breadcrumbs/tests/src/Functional/BreadcrumbsTest.php
@@ -86,7 +86,7 @@ class BreadcrumbsTest extends IslandoraFunctionalTestBase {
     ]);
     $this->nodeD->set('field_member_of', [$this->nodeC->id()]);
     $this->nodeD->save();
-    
+
     $this->drupalPlaceBlock(
       'system_breadcrumb_block',
       [

--- a/src/Plugin/Condition/ContentEntityType.php
+++ b/src/Plugin/Condition/ContentEntityType.php
@@ -11,7 +11,7 @@ use Drupal\Core\Form\FormStateInterface;
  * @Condition(
  *   id = "content_entity_type",
  *   label = @Translation("Content Entity Type"),
- *   context = {
+ *   context_definitions = {
  *     "node" = @ContextDefinition("entity:node", required = FALSE, label = @Translation("Node")),
  *     "media" = @ContextDefinition("entity:media", required = FALSE, label = @Translation("Media")),
  *     "file" = @ContextDefinition("entity:file", required = FALSE, label = @Translation("File")),

--- a/src/Plugin/Condition/EntityBundle.php
+++ b/src/Plugin/Condition/EntityBundle.php
@@ -11,7 +11,7 @@ use Drupal\Core\Form\FormStateInterface;
  * @Condition(
  *   id = "entity_bundle",
  *   label = @Translation("Entity Bundle"),
- *   context = {
+ *   context_definitions = {
  *     "node" = @ContextDefinition("entity:node", required = FALSE, label = @Translation("Node")),
  *     "media" = @ContextDefinition("entity:media", required = FALSE, label = @Translation("Media")),
  *     "taxonomy_term" = @ContextDefinition("entity:taxonomy_term", required = FALSE, label = @Translation("Term"))

--- a/src/Plugin/Condition/FileUsesFilesystem.php
+++ b/src/Plugin/Condition/FileUsesFilesystem.php
@@ -16,7 +16,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * @Condition(
  *   id = "file_uses_filesystem",
  *   label = @Translation("File uses filesystem"),
- *   context = {
+ *   context_definitions = {
  *     "file" = @ContextDefinition("entity:file", required = TRUE , label = @Translation("file"))
  *   }
  * )

--- a/src/Plugin/Condition/MediaHasTerm.php
+++ b/src/Plugin/Condition/MediaHasTerm.php
@@ -8,7 +8,7 @@ namespace Drupal\islandora\Plugin\Condition;
  * @Condition(
  *   id = "media_has_term",
  *   label = @Translation("Media has term with URI"),
- *   context = {
+ *   context_definitions = {
  *     "media" = @ContextDefinition("entity:media", required = TRUE , label = @Translation("media"))
  *   }
  * )

--- a/src/Plugin/Condition/MediaUsesFilesystem.php
+++ b/src/Plugin/Condition/MediaUsesFilesystem.php
@@ -13,7 +13,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * @Condition(
  *   id = "media_uses_filesystem",
  *   label = @Translation("Media uses filesystem"),
- *   context = {
+ *   context_definitions = {
  *     "media" = @ContextDefinition("entity:media", required = TRUE , label = @Translation("media"))
  *   }
  * )

--- a/src/Plugin/Condition/NodeHadNamespace.php
+++ b/src/Plugin/Condition/NodeHadNamespace.php
@@ -16,7 +16,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * @Condition(
  *   id = "node_had_namespace",
  *   label = @Translation("Node had 7.x namespace"),
- *   context = {
+ *   context_definitions = {
  *     "node" = @ContextDefinition("entity:node", required = TRUE , label = @Translation("node"))
  *   }
  * )

--- a/src/Plugin/Condition/NodeHasParent.php
+++ b/src/Plugin/Condition/NodeHasParent.php
@@ -15,7 +15,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * @Condition(
  *   id = "node_has_parent",
  *   label = @Translation("Node has parent"),
- *   context = {
+ *   context_definitions = {
  *     "node" = @ContextDefinition("entity:node", required = TRUE , label = @Translation("node"))
  *   }
  * )

--- a/src/Plugin/Condition/NodeHasTerm.php
+++ b/src/Plugin/Condition/NodeHasTerm.php
@@ -16,7 +16,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * @Condition(
  *   id = "node_has_term",
  *   label = @Translation("Node has term with URI"),
- *   context = {
+ *   context_definitions = {
  *     "node" = @ContextDefinition("entity:node", required = TRUE , label = @Translation("node"))
  *   }
  * )

--- a/src/Plugin/Condition/NodeIsPublished.php
+++ b/src/Plugin/Condition/NodeIsPublished.php
@@ -13,7 +13,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * @Condition(
  *   id = "node_is_published",
  *   label = @Translation("Node is published"),
- *   context = {
+ *   context_definitions = {
  *     "node" = @ContextDefinition("entity:node", required = TRUE , label = @Translation("node"))
  *   }
  * )

--- a/src/Plugin/Condition/ParentNodeHasTerm.php
+++ b/src/Plugin/Condition/ParentNodeHasTerm.php
@@ -8,7 +8,7 @@ namespace Drupal\islandora\Plugin\Condition;
  * @Condition(
  *   id = "parent_node_has_term",
  *   label = @Translation("Parent node for media has term with URI"),
- *   context = {
+ *   context_definitions = {
  *     "media" = @ContextDefinition("entity:media", required = TRUE , label = @Translation("media"))
  *   }
  * )


### PR DESCRIPTION
…t annotation

**Github Issue**: Resolves https://github.com/Islandora/documentation/issues/1274

# What does this Pull Request do?

Replaces the deprecated `context` annotation with `context_definitions` in our plugins.  See https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Condition%21Annotation%21Condition.php/property/Condition%3A%3Acontext/8.7.x

# How should this be tested?

You shouldn't see a noticeable change.  So if you pull in this PR and nothing breaks, it's good!

# Interested parties
@Islandora/8-x-committers
