### PR TITLE
Save document media files to fedora by default (Issue-1459)

### DIFF
--- a/modules/islandora_core_feature/config/install/field.storage.media.field_media_document.yml
+++ b/modules/islandora_core_feature/config/install/field.storage.media.field_media_document.yml
@@ -1,0 +1,25 @@
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - islandora_core_feature
+  module:
+    - file
+    - media
+id: media.field_media_document
+field_name: field_media_document
+entity_type: media
+type: file
+settings:
+  display_field: false
+  display_default: false
+  uri_scheme: fedora
+  target_type: file
+module: file
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
**GitHub Ticket**: https://github.com/Islandora/documentation/issues/1459

See also https://github.com/Islandora/islandora_defaults/pull/26

# What does this Pull Request do?

Makes the new Document media type default storage location set to Fedora as the other media type files are.

# What's new?

* Added field_media_document storage config

# How should this be tested?

*Test in conjunction with https://github.com/Islandora/islandora_defaults/pull/26*

- Create a new document media and upload a file. _Should upload to Drupal public._
- Apply the PR
- Import `islandora_core_feature` feature.
- Create a new document media and upload a file. _Should upload to Fedora via flysystem._

# Additional Notes:

* Does this change the interface, add a new feature, or otherwise change behaviours that would require updating documentation? Adds Document media files to Fedora as the other media types currently do. 
* Does this change add any new dependencies? No.
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? No.
* Could this change impact execution of existing code? No.

# Interested parties
@bseeger  and @Islandora/8-x-committers, esp @dannylamb 