### PR TITLE
#1475 Check derivative_term instead of source_term

### DIFF
--- a/src/Plugin/Action/AbstractGenerateDerivative.php
+++ b/src/Plugin/Action/AbstractGenerateDerivative.php
@@ -160,7 +160,7 @@ class AbstractGenerateDerivative extends EmitEvent {
     // Find the term for the derivative and use it to set the destination url
     // in the data array.
     $derivative_term = $this->utils->getTermForUri($this->configuration['derivative_term_uri']);
-    if (!$source_term) {
+    if (!$derivative_term) {
       throw new \RuntimeException("Could not locate derivative term with uri" . $this->configuration['derivative_term_uri'], 500);
     }
 


### PR DESCRIPTION
**GitHub Issue**: (link)
https://github.com/Islandora/documentation/issues/1475
Supercedes withdrawn PR https://github.com/Islandora-CLAW/islandora/pull/181

# What does this Pull Request do?

Fixes a check for `$derivative_term` after it has been fetched by URI.

# What's new?
Should trap cases where a derivative term can't be located by URI.

# How should this be tested?

* Add a Repository Item with Model=Image
* Add media, type=Image, Use=Original Term
* When media is submitted, and derivatives generated, you might see an error message "Error generating event: Could not locate derivative term with urihttps://projects.iq.harvard.edu/fits"

# Interested parties
@Islandora-CLAW/committers
