### PR TITLE
Fixes JSONLD endpoint fail for Extracted Text

### DIFF
--- a/modules/islandora_text_extraction_defaults/config/install/rdf.mapping.media.extracted_text.yml
+++ b/modules/islandora_text_extraction_defaults/config/install/rdf.mapping.media.extracted_text.yml
@@ -1,0 +1,51 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.extracted_text
+  enforced:
+    module:
+      - islandora_text_extraction_defaults
+  module:
+    - media
+id: media.extracted_text
+targetEntityType: media
+bundle: extracted_text 
+types:
+  - 'pcdm:File'
+fieldMappings:
+  name:
+    properties:
+      - 'dcterms:title'
+      - 'rdf:label'
+  created:
+    properties:
+      - 'schema:dateCreated'
+    datatype_callback:
+      callable: 'Drupal\rdf\CommonDataConverter::dateIso8601Value'
+  changed:
+    properties:
+      - 'schema:dateModified'
+    datatype_callback:
+      callable: 'Drupal\rdf\CommonDataConverter::dateIso8601Value'
+  uid:
+    properties:
+      - 'schema:author'
+    mapping_type: rel
+  field_mime_type:
+    properties:
+      - 'ebucore:hasMimeType'
+  field_media_of:
+    properties:
+      - 'pcdm:fileOf'
+    mapping_type: rel
+  field_original_name:
+    properties:
+      - 'premis3:originalName'
+  field_tags:
+    properties:
+      - 'schema:additionalType'
+    mapping_type: rel
+  field_file_size:
+    properties:
+      - 'premis:hasSize'

--- a/src/Plugin/ContextReaction/JsonldTypeAlterReaction.php
+++ b/src/Plugin/ContextReaction/JsonldTypeAlterReaction.php
@@ -44,6 +44,9 @@ class JsonldTypeAlterReaction extends NormalizerAlterReaction {
 
     // Search for the entity in the graph.
     foreach ($normalized['@graph'] as &$elem) {
+      if (!is_array($elem['@type'])) {
+        $elem['@type'] = [$elem['@type']];
+      }
       if ($elem['@id'] === $this->getSubjectUrl($entity)) {
         foreach ($entity->get($config['source_field'])->getValue() as $type) {
           // If the configured field is using an entity reference,

--- a/src/Plugin/ContextReaction/JsonldTypeAlterReaction.php
+++ b/src/Plugin/ContextReaction/JsonldTypeAlterReaction.php
@@ -44,11 +44,9 @@ class JsonldTypeAlterReaction extends NormalizerAlterReaction {
 
     // Search for the entity in the graph.
     foreach ($normalized['@graph'] as &$elem) {
-      
       if (!is_array($elem['@type'])) {
         $elem['@type'] = [$elem['@type']];
       }
-      
       if ($elem['@id'] === $this->getSubjectUrl($entity)) {
         foreach ($entity->get($config['source_field'])->getValue() as $type) {
           // If the configured field is using an entity reference,

--- a/src/Plugin/ContextReaction/JsonldTypeAlterReaction.php
+++ b/src/Plugin/ContextReaction/JsonldTypeAlterReaction.php
@@ -44,9 +44,11 @@ class JsonldTypeAlterReaction extends NormalizerAlterReaction {
 
     // Search for the entity in the graph.
     foreach ($normalized['@graph'] as &$elem) {
+      
       if (!is_array($elem['@type'])) {
         $elem['@type'] = [$elem['@type']];
       }
+      
       if ($elem['@id'] === $this->getSubjectUrl($entity)) {
         foreach ($entity->get($config['source_field'])->getValue() as $type) {
           // If the configured field is using an entity reference,


### PR DESCRIPTION
**JIRA Ticket**: Resolves https://github.com/Islandora/documentation/issues/1477

# What does this Pull Request do?

Adds an RDF mapping for extracted text media.  Also touches up the JsonldTypeAlterReaction so it doesn't WSOD if there's ever another missing RDF mapping.

# How should this be tested?

- Visit the `?_format=jsonld` endpoint for an extracted_text media.
- You'll WSOD
- Apply this PR
- `drush -y fim islandora_text_extraction_defaults`
- Visit the `?_format=jsonld` endpoint again
- No WSOD

# Interested parties
@Islandora/8-x-committers
