### PR TITLE
Fix stale field_edited_text (Issue 1479)

### DIFF
--- a/modules/islandora_text_extraction/islandora_text_extraction.module
+++ b/modules/islandora_text_extraction/islandora_text_extraction.module
@@ -34,11 +34,11 @@ function islandora_text_extraction_media_presave(MediaInterface $media) {
     return;
   }
   $text = $media->get('field_edited_text')->getValue();
-  if (!$text) {
-    $file_id = $media->get('field_media_file')->getValue()[0]['target_id'];
-    $file = File::load($file_id);
-    $data = file_get_contents($file->getFileUri());
-    $data = nl2br($data);
+  $file_id = $media->get('field_media_file')->getValue()[0]['target_id'];
+  $file = File::load($file_id);
+  $data = file_get_contents($file->getFileUri());
+  $data = nl2br($data);
+  if ($text !== $data) {
     $media->set('field_edited_text', $data);
     $media->field_edited_text->format = 'basic_html';
   }


### PR DESCRIPTION
**Github Issue**: https://github.com/Islandora/documentation/issues/1479

Slack: https://islandora.slack.com/archives/CM5PPAV28/p1585769436179000

# What does this Pull Request do?

When updating an Extracted Text, instead of checking for the existence of a value in `field_edited_text` it checks to see if it matches the contents of the file.

# What's new?

* Changes checking extracted text media from the existence of a value in `field_edited_text` to matching the contents of the file.

# How should this be tested?

- Replace the Original File of a Page (or Digital Document) node with text content with one with different text.
- Check the Extracted Text file to see the new text content and then see if the contents of `field_edited_text` matches. (It won't.)
- Apply the PR.
- Run the Extract Text action on the node again.
- The value of the Extracted Text media's `field_edited_text` should now match the contents of the associated file.

# Additional Notes:

* Does this change the interface, add a new feature, or otherwise change behaviours that would require updating documentation? No.
* Does this change add any new dependencies? No,
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? Only if you already have stale content in `field_edited_text`, then you will want to run the text extraction action again.
* Could this change impact execution of existing code? No.

# Interested parties
@Islandora/8-x-committers, esp @dannylamb
