### PR TITLE
{WIP} Move entity_bundle condition plugin to islandora_entity_bundle to avoid ctools

### DIFF
--- a/src/Plugin/Action/AbstractGenerateDerivative.php
+++ b/src/Plugin/Action/AbstractGenerateDerivative.php
@@ -160,7 +160,7 @@ class AbstractGenerateDerivative extends EmitEvent {
     // Find the term for the derivative and use it to set the destination url
     // in the data array.
     $derivative_term = $this->utils->getTermForUri($this->configuration['derivative_term_uri']);
-    if (!$source_term) {
+    if (!$derivative_term) {
       throw new \RuntimeException("Could not locate derivative term with uri" . $this->configuration['derivative_term_uri'], 500);
     }
 

--- a/src/Plugin/Condition/EntityBundle.php
+++ b/src/Plugin/Condition/EntityBundle.php
@@ -8,8 +8,10 @@ use Drupal\Core\Form\FormStateInterface;
 /**
  * Provides a 'Entity Bundle' condition.
  *
+ * Namespaced to avoid conflict with ctools entity_bundle plugin.
+ *
  * @Condition(
- *   id = "entity_bundle",
+ *   id = "islandora_entity_bundle",
  *   label = @Translation("Entity Bundle"),
  *   context_definitions = {
  *     "node" = @ContextDefinition("entity:node", required = FALSE, label = @Translation("Node")),
@@ -18,7 +20,7 @@ use Drupal\Core\Form\FormStateInterface;
  *   }
  * )
  */
-class EntityBundle extends ConditionPluginBase {
+class IslandoraEntityBundle extends ConditionPluginBase {
 
   /**
    * {@inheritdoc}

--- a/tests/src/Functional/EntityBundleTest.php
+++ b/tests/src/Functional/EntityBundleTest.php
@@ -7,12 +7,12 @@ namespace Drupal\Tests\islandora\Functional;
  *
  * @group islandora
  */
-class EntityBundleTest extends IslandoraFunctionalTestBase {
+class IslandoraEntityBundleTest extends IslandoraFunctionalTestBase {
 
   /**
-   * @covers \Drupal\islandora\Plugin\Condition\EntityBundle::buildConfigurationForm
-   * @covers \Drupal\islandora\Plugin\Condition\EntityBundle::submitConfigurationForm
-   * @covers \Drupal\islandora\Plugin\Condition\EntityBundle::evaluate
+   * @covers \Drupal\islandora\Plugin\Condition\IslandoraEntityBundle::buildConfigurationForm
+   * @covers \Drupal\islandora\Plugin\Condition\IslandoraEntityBundle::submitConfigurationForm
+   * @covers \Drupal\islandora\Plugin\Condition\IslandoraEntityBundle::evaluate
    */
   public function testEntityBundleType() {
     // Create a test user.
@@ -24,7 +24,7 @@ class EntityBundleTest extends IslandoraFunctionalTestBase {
     $this->drupalLogin($account);
 
     $this->createContext('Test', 'test');
-    $this->addCondition('test', 'entity_bundle');
+    $this->addCondition('test', 'islandora_entity_bundle');
     $this->getSession()->getPage()->checkField("edit-conditions-entity-bundle-bundles-test-type");
     $this->getSession()->getPage()->findById("edit-conditions-entity-bundle-context-mapping-node")->selectOption("@node.node_route_context:node");
     $this->getSession()->getPage()->pressButton(t('Save and continue'));

--- a/tests/src/Functional/JsonldTypeAlterReactionTest.php
+++ b/tests/src/Functional/JsonldTypeAlterReactionTest.php
@@ -70,7 +70,7 @@ class JsonldTypeAlterReactionTest extends JsonldSelfReferenceReactionTest {
     $this->assertSession()
       ->pageTextContains("The context $context_name has been saved");
 
-    $this->addCondition('test', 'entity_bundle');
+    $this->addCondition('test', 'islandora_entity_bundle');
     $this->getSession()->getPage()->checkField("edit-conditions-entity-bundle-bundles-test-type");
     $this->getSession()->getPage()->findById("edit-conditions-entity-bundle-context-mapping-node")->selectOption("@node.node_route_context:node");
     $this->getSession()->getPage()->pressButton(t('Save and continue'));


### PR DESCRIPTION
**Github Ticket**: (link)
#1470 Bug: Can't specify pathauto pattern for corporate body terms #1470

* Other Relevant Links (Google Groups discussion, related pull requests, Release pull requests, etc.)
N/A

# What does this Pull Request do?
Changes the machine name and class for the Islandora context condition plugin from `entity_bundle` to `islandora_entity_bundle` to avoid a name collision with ctools `entity_bundle` plugin.

When this patch is applied, it should be possible to install pathauto and ctools and generate url aliases for taxonomy terms in the corporate_body vocabulary.

# What's new?
Will also need a matching change in the context definition in `islandora_defaults`.

# How should this be tested?

1. On a base Islandora, download & enable pathauto (also brings ctools).
1. Visit /admin/config/search/path/patterns/add and try and specify a pathauto pattern for a corporate_body term, e.g. pattern=`/agent/[term:name]`. Observe "The website encountered an unexpected error. Please try again later." or "Drupal\Component\Plugin\Exception\PluginNotFoundException: The "entity_bundle:taxonomy_term" plugin does not exist." errors.
1. Apply patch, clear cache.
1. Re-try defining pathauto pattern. This time creating a pathauto pattern should succeed.

# Additional Notes:
Note this requires matching name change in the context 'All media' in `islandora_defaults` 

# Interested parties
@seth-shaw-unlv @dannylamb 
