### PR TITLE
Renames `entity_bundle` to `islandora_entity_bundle` to avoid name collision

### DIFF
--- a/islandora.install
+++ b/islandora.install
@@ -77,6 +77,6 @@ function islandora_update_8002(&$sandbox) {
     $config->save();
   }
 
-  // Force drupal to reload the config. 
+  // Force drupal to reload the config.
   \Drupal::service('plugin.manager.context')->clearCachedDefinitions();
 }

--- a/islandora.install
+++ b/islandora.install
@@ -78,5 +78,5 @@ function islandora_update_8002(&$sandbox) {
   }
 
   // Force drupal to reload the config.
-  \Drupal::service('plugin.manager.context')->clearCachedDefinitions();
+  \Drupal::service('plugin.manager.condition')->clearCachedDefinitions();
 }

--- a/islandora.install
+++ b/islandora.install
@@ -52,3 +52,31 @@ function islandora_update_8001(&$sandbox) {
     $action->delete();
   }
 }
+
+/**
+ * Replaces 'entity_bundle' conditions with 'islandora_entity_bundle'.
+ *
+ * This prevents plugin naming collisions between islandora and ctools.
+ */
+function islandora_update_8002(&$sandbox) {
+
+  // Find contexts that have the old 'entity_bundle' condition.
+  $results = \Drupal::entityQuery('context')->condition('conditions.entity_bundle.id', 'entity_bundle')->execute();
+
+  if (empty($results)) {
+    return;
+  }
+
+  // Set each context config to use 'islandora_entity_bundle' instead.
+  foreach ($results as $result) {
+    $config = \Drupal::configFactory()->getEditable("context.context.$result");
+    $condition = $config->get('conditions.entity_bundle');
+    $condition['id'] = 'islandora_entity_bundle';
+    $config->set('conditions.islandora_entity_bundle', $condition);
+    $config->clear('conditions.entity_bundle');
+    $config->save();
+  }
+
+  // Force drupal to reload the config. 
+  \Drupal::service('plugin.manager.context')->clearCachedDefinitions();
+}

--- a/src/Plugin/Condition/EntityBundle.php
+++ b/src/Plugin/Condition/EntityBundle.php
@@ -20,7 +20,7 @@ use Drupal\Core\Form\FormStateInterface;
  *   }
  * )
  */
-class IslandoraEntityBundle extends ConditionPluginBase {
+class EntityBundle extends ConditionPluginBase {
 
   /**
    * {@inheritdoc}

--- a/src/Plugin/Condition/EntityBundle.php
+++ b/src/Plugin/Condition/EntityBundle.php
@@ -8,8 +8,10 @@ use Drupal\Core\Form\FormStateInterface;
 /**
  * Provides a 'Entity Bundle' condition.
  *
+ * Namespaced to avoid conflict with ctools entity_bundle plugin.
+ *
  * @Condition(
- *   id = "entity_bundle",
+ *   id = "islandora_entity_bundle",
  *   label = @Translation("Entity Bundle"),
  *   context_definitions = {
  *     "node" = @ContextDefinition("entity:node", required = FALSE, label = @Translation("Node")),
@@ -18,7 +20,7 @@ use Drupal\Core\Form\FormStateInterface;
  *   }
  * )
  */
-class EntityBundle extends ConditionPluginBase {
+class IslandoraEntityBundle extends ConditionPluginBase {
 
   /**
    * {@inheritdoc}

--- a/tests/src/Functional/EntityBundleTest.php
+++ b/tests/src/Functional/EntityBundleTest.php
@@ -25,8 +25,8 @@ class EntityBundleTest extends IslandoraFunctionalTestBase {
 
     $this->createContext('Test', 'test');
     $this->addCondition('test', 'islandora_entity_bundle');
-    $this->getSession()->getPage()->checkField("edit-conditions-entity-bundle-bundles-test-type");
-    $this->getSession()->getPage()->findById("edit-conditions-entity-bundle-context-mapping-node")->selectOption("@node.node_route_context:node");
+    $this->getSession()->getPage()->checkField("edit-conditions-islandora-entity-bundle-bundles-test-type");
+    $this->getSession()->getPage()->findById("edit-conditions-islandora-entity-bundle-context-mapping-node")->selectOption("@node.node_route_context:node");
     $this->getSession()->getPage()->pressButton(t('Save and continue'));
     $this->addPresetReaction('test', 'index', 'hello_world');
 

--- a/tests/src/Functional/EntityBundleTest.php
+++ b/tests/src/Functional/EntityBundleTest.php
@@ -7,12 +7,12 @@ namespace Drupal\Tests\islandora\Functional;
  *
  * @group islandora
  */
-class EntityBundleTest extends IslandoraFunctionalTestBase {
+class IslandoraEntityBundleTest extends IslandoraFunctionalTestBase {
 
   /**
-   * @covers \Drupal\islandora\Plugin\Condition\EntityBundle::buildConfigurationForm
-   * @covers \Drupal\islandora\Plugin\Condition\EntityBundle::submitConfigurationForm
-   * @covers \Drupal\islandora\Plugin\Condition\EntityBundle::evaluate
+   * @covers \Drupal\islandora\Plugin\Condition\IslandoraEntityBundle::buildConfigurationForm
+   * @covers \Drupal\islandora\Plugin\Condition\IslandoraEntityBundle::submitConfigurationForm
+   * @covers \Drupal\islandora\Plugin\Condition\IslandoraEntityBundle::evaluate
    */
   public function testEntityBundleType() {
     // Create a test user.
@@ -24,7 +24,7 @@ class EntityBundleTest extends IslandoraFunctionalTestBase {
     $this->drupalLogin($account);
 
     $this->createContext('Test', 'test');
-    $this->addCondition('test', 'entity_bundle');
+    $this->addCondition('test', 'islandora_entity_bundle');
     $this->getSession()->getPage()->checkField("edit-conditions-entity-bundle-bundles-test-type");
     $this->getSession()->getPage()->findById("edit-conditions-entity-bundle-context-mapping-node")->selectOption("@node.node_route_context:node");
     $this->getSession()->getPage()->pressButton(t('Save and continue'));

--- a/tests/src/Functional/EntityBundleTest.php
+++ b/tests/src/Functional/EntityBundleTest.php
@@ -7,12 +7,12 @@ namespace Drupal\Tests\islandora\Functional;
  *
  * @group islandora
  */
-class IslandoraEntityBundleTest extends IslandoraFunctionalTestBase {
+class EntityBundleTest extends IslandoraFunctionalTestBase {
 
   /**
-   * @covers \Drupal\islandora\Plugin\Condition\IslandoraEntityBundle::buildConfigurationForm
-   * @covers \Drupal\islandora\Plugin\Condition\IslandoraEntityBundle::submitConfigurationForm
-   * @covers \Drupal\islandora\Plugin\Condition\IslandoraEntityBundle::evaluate
+   * @covers \Drupal\islandora\Plugin\Condition\EntityBundle::buildConfigurationForm
+   * @covers \Drupal\islandora\Plugin\Condition\EntityBundle::submitConfigurationForm
+   * @covers \Drupal\islandora\Plugin\Condition\EntityBundle::evaluate
    */
   public function testEntityBundleType() {
     // Create a test user.

--- a/tests/src/Functional/JsonldTypeAlterReactionTest.php
+++ b/tests/src/Functional/JsonldTypeAlterReactionTest.php
@@ -71,8 +71,8 @@ class JsonldTypeAlterReactionTest extends JsonldSelfReferenceReactionTest {
       ->pageTextContains("The context $context_name has been saved");
 
     $this->addCondition('test', 'islandora_entity_bundle');
-    $this->getSession()->getPage()->checkField("edit-conditions-entity-bundle-bundles-test-type");
-    $this->getSession()->getPage()->findById("edit-conditions-entity-bundle-context-mapping-node")->selectOption("@node.node_route_context:node");
+    $this->getSession()->getPage()->checkField("edit-conditions-islandora-entity-bundle-bundles-test-type");
+    $this->getSession()->getPage()->findById("edit-conditions-islandora-entity-bundle-context-mapping-node")->selectOption("@node.node_route_context:node");
     $this->getSession()->getPage()->pressButton(t('Save and continue'));
 
     // The first time a Context is saved, you need to clear the cache.

--- a/tests/src/Functional/JsonldTypeAlterReactionTest.php
+++ b/tests/src/Functional/JsonldTypeAlterReactionTest.php
@@ -70,7 +70,7 @@ class JsonldTypeAlterReactionTest extends JsonldSelfReferenceReactionTest {
     $this->assertSession()
       ->pageTextContains("The context $context_name has been saved");
 
-    $this->addCondition('test', 'entity_bundle');
+    $this->addCondition('test', 'islandora_entity_bundle');
     $this->getSession()->getPage()->checkField("edit-conditions-entity-bundle-bundles-test-type");
     $this->getSession()->getPage()->findById("edit-conditions-entity-bundle-context-mapping-node")->selectOption("@node.node_route_context:node");
     $this->getSession()->getPage()->pressButton(t('Save and continue'));


### PR DESCRIPTION
**JIRA Ticket**: Islandora/documentation#1470

Supersedes https://github.com/Islandora/islandora/pull/771

# What does this Pull Request do?

Changes the plugin_id for the entity_bundle Condition to islandora_entity_bundle to avoid a name collision with ctools entity_bundle plugin.

It also has an update hook to update any contexts that may be using the `entity_bundle` condition.

When this patch is applied, it should be possible to install pathauto and ctools and generate url aliases for taxonomy terms in the corporate_body vocabulary.

# How should this be tested?

1. On a fresh install, download & enable pathauto (also brings ctools).
1. Visit /admin/config/search/path/patterns/add and try and specify a pathauto pattern for a corporate_body term, e.g. pattern=`/agent/[term:name]`. Observe "The website encountered an unexpected error. Please try again later." or "Drupal\Component\Plugin\Exception\PluginNotFoundException: The "entity_bundle:taxonomy_term" plugin does not exist." errors.
1. Go visit `admin/structure/context` and get a whitescreen
1. Apply this PR.
1. Run the update hook by executing `drush updatedb` from the command line.
1. Re-try defining pathauto pattern. This time creating a pathauto pattern should succeed.
1. Go visit `admin/structure/context`.  You should not whitescreen

# Interested parties
@Islandora/8-x-committers
