### PR TITLE
Update field.field.media.extracted_text.field_mime_type.yml

### DIFF
--- a/modules/islandora_text_extraction_defaults/config/install/field.field.media.extracted_text.field_mime_type.yml
+++ b/modules/islandora_text_extraction_defaults/config/install/field.field.media.extracted_text.field_mime_type.yml
@@ -11,7 +11,7 @@ bundle: extracted_text
 label: 'MIME type'
 description: ''
 required: false
-translatable: true
+translatable: false
 default_value:
   -
     value: text/plain


### PR DESCRIPTION
**Github Issue**: https://github.com/Islandora/documentation/issues/1496

# What does this Pull Request do?

Sets the mime type field for `Extracted Text` to not be translatable.  This lets its RDF get flushed to Fedora.

# How should this be tested?

- Make a Digital Document node
- Give it an Original File
- Extracted text will be generated, but none of its metadata will make it to Fedora
  - There will be a 400 error in the milliner logs that looks something like this: `(RuntimeException(code: 400): Client error: `PUT http://future.islan
dora.ca:8080/fcrepo/rest/78/23/d2/2a/7823d22a-ba4d-4415-8328-1b8252b99463/fcr:metadata` resulted in a `400 Bad Request` respo
nse: Invalid value for 'http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasMimeType' encountered : \"text/plain\"@en at
 /var/www/html/Crayfish/Milliner/src/Service/MillinerService.php:280)`
- Pull in this PR
- `drush -y fim islandora_text_extraction_defaults`
- Repeat the process for another PDF
- Now there should be no errors in Milliner's log and if you set up the Fedora URI pseudo field for Extracted Text, you should see it.

# Interested parties
@Islandora/8-x-committers 
