### PR TITLE
Validate JWT expiry

### DIFF
--- a/src/Form/IslandoraSettingsForm.php
+++ b/src/Form/IslandoraSettingsForm.php
@@ -66,7 +66,7 @@ class IslandoraSettingsForm extends ConfigFormBase {
     $this->entityTypeBundleInfo = $entity_type_bundle_info;
     $this->brokerPassword = $this->config(self::CONFIG_NAME)->get(self::BROKER_PASSWORD);
   }
-  
+
   /**
    * {@inheritdoc}
    */

--- a/src/Form/IslandoraSettingsForm.php
+++ b/src/Form/IslandoraSettingsForm.php
@@ -26,6 +26,16 @@ class IslandoraSettingsForm extends ConfigFormBase {
   const GEMINI_URL = 'gemini_url';
   const GEMINI_PSEUDO = 'gemini_pseudo_bundles';
   const FEDORA_URL = 'fedora_url';
+  const TIME_INTERVALS = [
+    'sec',
+    'second',
+    'min',
+    'minute',
+    'hour',
+    'week',
+    'month',
+    'year',
+  ];
 
   /**
    * To list the available bundle types.
@@ -89,7 +99,9 @@ class IslandoraSettingsForm extends ConfigFormBase {
       '#type' => 'textfield',
       '#title' => $this->t('JWT Expiry'),
       '#default_value' => $config->get(self::JWT_EXPIRY),
-      '#description' => 'Eg: 60, "2 days", "10h", "7d". A numeric value is interpreted as a seconds count. If you use a string be sure you provide the time units (days, hours, etc), otherwise milliseconds unit is used by default ("120" is equal to "120ms").',
+      '#description' => $this->t('A positive time interval expression. Eg: "60 secs", "2 days", "10 hours", "7 weeks". Be sure you provide the time units (@unit), plurals are accepted.',
+        ['@unit' => implode(self::TIME_INTERVALS, ", ")]
+      ),
     ];
 
     $form[self::GEMINI_URL] = [
@@ -165,7 +177,8 @@ class IslandoraSettingsForm extends ConfigFormBase {
     }
 
     // Validate jwt expiry as a valid time string.
-    $expiry = $form_state->getValue(self::JWT_EXPIRY);
+    $expiry = trim($form_state->getValue(self::JWT_EXPIRY));
+    $expiry = strtolower($expiry);
     if (strtotime($expiry) === FALSE) {
       $form_state->setErrorByName(
         self::JWT_EXPIRY,
@@ -174,6 +187,28 @@ class IslandoraSettingsForm extends ConfigFormBase {
           ['@expiry' => $expiry]
         )
       );
+    }
+    elseif (substr($expiry, 0, 1) == "-") {
+      $form_state->setErrorByName(
+        self::JWT_EXPIRY,
+        $this->t('Time or interval expression cannot be negative')
+          );
+    }
+    elseif (intval($expiry) === 0) {
+      $form_state->setErrorByName(
+        self::JWT_EXPIRY,
+        $this->t('No numeric interval specified, for example "1 day"')
+          );
+    }
+    else {
+      if (!preg_match("/\b(" . implode(self::TIME_INTERVALS, "|") . ")s?\b/", $expiry)) {
+        $form_state->setErrorByName(
+          self::JWT_EXPIRY,
+          $this->t("No time interval found, please include one of (@int). Plurals are also accepted.",
+            ['@int' => implode(self::TIME_INTERVALS, ", ")]
+          )
+        );
+      }
     }
 
     // Needed for the elseif below.

--- a/src/Form/IslandoraSettingsForm.php
+++ b/src/Form/IslandoraSettingsForm.php
@@ -65,10 +65,8 @@ class IslandoraSettingsForm extends ConfigFormBase {
     $this->setConfigFactory($config_factory);
     $this->entityTypeBundleInfo = $entity_type_bundle_info;
     $this->brokerPassword = $this->config(self::CONFIG_NAME)->get(self::BROKER_PASSWORD);
-  }I've pulled this down and tested it pretty thoroughly.  Works as advertised.  Form fails if you don't add a password.  If you've already entered a password and don't enter one, it uses the old one.
-
-After setting up activemq to use basic auth, I could successfully connect to the broker and publish messages from Drupal.
-
+  }
+  
   /**
    * {@inheritdoc}
    */

--- a/tests/src/Functional/IslandoraSettingsFormTest.php
+++ b/tests/src/Functional/IslandoraSettingsFormTest.php
@@ -58,4 +58,30 @@ class IslandoraSettingsFormTest extends IslandoraFunctionalTestBase {
 
   }
 
+  /**
+   * Test form validation for JWT expiry.
+   */
+  public function testJwtExpiry() {
+    $this->drupalGet('/admin/config/islandora/core');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->pageTextContains("JWT Expiry");
+    $this->assertSession()->fieldValueEquals('edit-jwt-expiry', '+2 hour');
+    // Blank is not allowed.
+    $this->drupalPostForm('/admin/config/islandora/core', ['edit-jwt-expiry' => ""], t('Save configuration'));
+    $this->assertSession()->pageTextContainsOnce('"" is not a valid time or interval expression.');
+    // Negative is not allowed.
+    $this->drupalPostForm('/admin/config/islandora/core', ['edit-jwt-expiry' => "-2 hours"], t('Save configuration'));
+    $this->assertSession()->pageTextContainsOnce('Time or interval expression cannot be negative');
+    // Must include an integer value.
+    $this->drupalPostForm('/admin/config/islandora/core', ['edit-jwt-expiry' => "last hour"], t('Save configuration'));
+    $this->assertSession()->pageTextContainsOnce('No numeric interval specified, for example "1 day"');
+    // Must have an accepted interval.
+    $this->drupalPostForm('/admin/config/islandora/core', ['edit-jwt-expiry' => "1 fortnight"], t('Save configuration'));
+    $this->assertSession()->pageTextContainsOnce('No time interval found, please include one of');
+    // Test a valid setting.
+    $this->drupalPostForm('/admin/config/islandora/core', ['edit-jwt-expiry' => "2 weeks"], t('Save configuration'));
+    $this->assertSession()->pageTextContainsOnce('The configuration options have been saved.');
+
+  }
+
 }


### PR DESCRIPTION
**JIRA Ticket**: https://github.com/Islandora/documentation/issues/1498

# What does this Pull Request do?

Tightens allowed time intervals for JWT expiry.

# What's new?
You must have a positive integer, you must use one of the expected time intervals.

It is possible to create some weird strings, but I haven't really tested all the things that `strtotime()` might allow.

# How should this be tested?

Pull in this code and try adding some weird expiry intervals.

# Interested parties
@Islandora/7-x-1-x-committers
