### PR TITLE
Issue 1491: Add default values for name (and alt text for images) in add media form

### DIFF
--- a/islandora.libraries.yml
+++ b/islandora.libraries.yml
@@ -1,0 +1,7 @@
+image_media_form_defaults:
+  version: 1.x
+  js:
+    js/image_media_form_defaults.js: {}
+  dependencies:
+    - core/jquery
+    - core/jquery.once

--- a/islandora.module
+++ b/islandora.module
@@ -317,6 +317,23 @@ function islandora_preprocess_node(&$variables) {
 }
 
 /**
+ * Implements hook_form_alter().
+ */
+function islandora_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  $media_add_forms = ['media_audio_add_form', 'media_document_add_form',
+    'media_extracted_text_add_form', 'media_file_add_form', 'media_image_add_form',
+    'media_fits_technical_metadata_add_form', 'media_video_add_form'];
+
+  if (in_array($form['#form_id'], $media_add_forms)) {
+    $params = \Drupal::request()->query->all();
+    $media_of_nid = $params['edit']['field_media_of']['widget'][0]['target_id'];
+    $node = \Drupal::entityTypeManager()->getStorage('node')->load($media_of_nid);
+    $title = $node->getTitle();
+    $form['name']['widget'][0]['value']['#default_value'] = $title;
+  }
+}
+
+/**
  * Implements hook_entity_form_display_alter().
  */
 function islandora_entity_form_display_alter(&$form_display, $context) {
@@ -466,5 +483,18 @@ function islandora_preprocess_views_view_table(&$variables) {
       ];
       drupal_attach_tabledrag($variables, $options);
     }
+  }
+}
+
+/**
+ * Implements hook_page_attachments().
+ */
+function islandora_page_attachments(array &$attachments) {
+  $current_path = \Drupal::service('path.current')->getPath();
+  $path_args = explode('/', ltrim($current_path, '/'));
+  // Need to populate the "Alt text" field using JavaScript since it is not part of
+  // the rendered form, it is added via Ajax on file upload.
+  if (count($path_args) >= 3 && $path_args[0] == 'media' && $path_args[1] == 'add' && $path_args[2] == 'image') {
+    $attachments['#attached']['library'][] = 'islandora/image_media_form_defaults';
   }
 }

--- a/islandora.module
+++ b/islandora.module
@@ -322,7 +322,8 @@ function islandora_preprocess_node(&$variables) {
 function islandora_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   $media_add_forms = ['media_audio_add_form', 'media_document_add_form',
     'media_extracted_text_add_form', 'media_file_add_form', 'media_image_add_form',
-    'media_fits_technical_metadata_add_form', 'media_video_add_form'];
+    'media_fits_technical_metadata_add_form', 'media_video_add_form',
+  ];
 
   if (in_array($form['#form_id'], $media_add_forms)) {
     $params = \Drupal::request()->query->all();
@@ -492,8 +493,8 @@ function islandora_preprocess_views_view_table(&$variables) {
 function islandora_page_attachments(array &$attachments) {
   $current_path = \Drupal::service('path.current')->getPath();
   $path_args = explode('/', ltrim($current_path, '/'));
-  // Need to populate the "Alt text" field using JavaScript since it is not part of
-  // the rendered form, it is added via Ajax on file upload.
+  // Need to populate the "Alt text" field using JavaScript since it is
+  // not part of the rendered form, it is added via Ajax on file upload.
   if (count($path_args) >= 3 && $path_args[0] == 'media' && $path_args[1] == 'add' && $path_args[2] == 'image') {
     $attachments['#attached']['library'][] = 'islandora/image_media_form_defaults';
   }

--- a/js/image_media_form_defaults.js
+++ b/js/image_media_form_defaults.js
@@ -1,0 +1,8 @@
+(function (Drupal, $) {
+  "use strict";
+  var ImageName = $('input[id=edit-name-0-value]').val();
+  $(document).ajaxSuccess(function() {
+    $('input[data-drupal-selector=edit-field-media-image-0-alt]').val(ImageName);
+  });
+}) (Drupal, jQuery);
+

--- a/js/image_media_form_defaults.js
+++ b/js/image_media_form_defaults.js
@@ -1,8 +1,6 @@
 (function (Drupal, $) {
-  "use strict";
   var ImageName = $('input[id=edit-name-0-value]').val();
-  $(document).ajaxSuccess(function() {
+  $(document).ajaxSuccess(function () {
     $('input[data-drupal-selector=edit-field-media-image-0-alt]').val(ImageName);
   });
-}) (Drupal, jQuery);
-
+})(Drupal, jQuery);


### PR DESCRIPTION
> Note: Do not merge. This PR has been replaced by https://github.com/Islandora/islandora/pull/783 (same code changes, but I deleted the source repo since opening this PR).

**Github Issue**: https://github.com/Islandora/documentation/issues/1491

# What does this Pull Request do?

Provides default values for the media name field, and for Image media, a default value for the Alt text field.

# What's new?

Implementation of `hook_form_alter()` to populate the media name field, and an implementation of `hook_page_attachments()` + the addition of a Javascript file to populate the image Alt text field.

# How should this be tested?

1. Check out this branch.
1. Clear your cache (e.g. `drush cr`)
1. Create a new Islandora object with the model "image" and add an image media. The image Name and Alt text fields should be automatically populated with the parent node's title.
1. Create a new Islandora object with a model different than "image" and add a media. The media's Name field should be automatically populated with the parent node's title.


# Additional Notes:

* Does this change the interface, add a new feature, or otherwise change behaviours that would require updating documentation?  Yes, improves the UX by providing sensible default values in form fields.
* Does this change add any new dependencies? No.
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? No
* Could this change impact execution of existing code? Yes.

# Interested parties

@Islandora/8-x-committers 
