### PR TITLE
Issue 1521: Provide a way for repo admins to see RDF mappings

### DIFF
--- a/islandora.links.menu.yml
+++ b/islandora.links.menu.yml
@@ -11,3 +11,10 @@ system.islandora_settings:
   parent: system.admin_config_islandora
   route_name: system.islandora_settings 
   description: 'Confgure core Islandora settings'
+
+# Field to RDF property mappings
+system.islandora_rdf_mappings:
+  title: 'RDF field mappings'
+  parent: system.admin_reports
+  description: 'List of configured Drupal field to RDF property mappings.'
+  route_name: system.islandora_rdf_mappings

--- a/islandora.links.menu.yml
+++ b/islandora.links.menu.yml
@@ -12,9 +12,9 @@ system.islandora_settings:
   route_name: system.islandora_settings 
   description: 'Confgure core Islandora settings'
 
-# Field to RDF property mappings
+# RDF property mappings
 system.islandora_rdf_mappings:
-  title: 'RDF field mappings'
+  title: 'Field and term RDF mappings'
   parent: system.admin_reports
-  description: 'List of configured Drupal field to RDF property mappings.'
+  description: 'List of configured Drupal field to RDF property mappings and taxonomy term linked data URIs.'
   route_name: system.islandora_rdf_mappings

--- a/islandora.routing.yml
+++ b/islandora.routing.yml
@@ -16,6 +16,15 @@ system.islandora_settings:
   requirements:
     _permission: 'administer site configuration'
 
+# RDF mappings report
+system.islandora_rdf_mappings:
+  path: '/admin/reports/islandora/rdf_mappings'
+  defaults:
+    _controller: '\Drupal\islandora\Controller\RdfMappingsReportController::main'
+    _title: 'Drupal field to RDF property mappings'
+  requirements:
+    _permission: 'administer site configuration'
+
 islandora.add_member_to_node_page:
   path: '/node/{node}/members/add'
   defaults:

--- a/islandora.routing.yml
+++ b/islandora.routing.yml
@@ -16,12 +16,12 @@ system.islandora_settings:
   requirements:
     _permission: 'administer site configuration'
 
-# RDF mappings report
+# RDF properties report
 system.islandora_rdf_mappings:
   path: '/admin/reports/islandora/rdf_mappings'
   defaults:
     _controller: '\Drupal\islandora\Controller\RdfMappingsReportController::main'
-    _title: 'Drupal field to RDF property mappings'
+    _title: 'Field and term RDF mappings'
   requirements:
     _permission: 'administer site configuration'
 

--- a/src/Controller/RdfMappingsReportController.php
+++ b/src/Controller/RdfMappingsReportController.php
@@ -5,6 +5,8 @@ namespace Drupal\islandora\Controller;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\taxonomy\Entity\Vocabulary;
 use Drupal\taxonomy\Entity\Term;
+use Drupal\Core\Link;
+use Drupal\Core\Url;
 
 /**
  * RDF mappings report controller.
@@ -109,14 +111,16 @@ class RdfMappingsReportController extends ControllerBase {
             }
           }
           if (is_array($ld_uri) && array_key_exists('uri', $ld_uri)) {
+            $term_link = Link::fromTextAndUrl($term->getName(), Url::fromUri('internal:/taxonomy/term/' . $term->id()));
             $vocab_table_rows[] = [
-              $term->getName(),
+              $term_link,
               $term->id(),
               $ld_uri['uri'],
             ];
           }
           else {
-            $vocab_table_rows[] = [$term->getName(), $term->id(), t('None')];
+            $term_link = Link::fromTextAndUrl($term->getName(), Url::fromUri('internal:/taxonomy/term/' . $term->id()));
+            $vocab_table_rows[] = [$term_link, $term->id(), t('None')];
           }
         }
         $vocab_table = [

--- a/src/Controller/RdfMappingsReportController.php
+++ b/src/Controller/RdfMappingsReportController.php
@@ -18,10 +18,9 @@ class RdfMappingsReportController extends ControllerBase {
    *   Markup of the tables.
    */
   public function main() {
-
     $markup = '';
-    $entity_types = ['node', 'media'];
 
+    // Configured namespaces.
     $namespaces = rdf_get_namespaces();
     $namespaces_table_rows = [];
     foreach ($namespaces as $alias => $namespace_uri) {
@@ -38,6 +37,8 @@ class RdfMappingsReportController extends ControllerBase {
     $markup .= '<details><summary>' . t('RDF namespaces used in field mappings') .
       '</summary><div class="details-wrapper">' . $namespaces_table_markup . '</div></details>';
 
+    // Node and media field to RDF property mappings.
+    $entity_types = ['node', 'media'];
     $markup .= '<h2>' . t('Field mappings') . '</h2>';
     foreach ($entity_types as $entity_type) {
       $bundles = \Drupal::service('entity_type.bundle.info')->getBundleInfo($entity_type);
@@ -70,9 +71,11 @@ class RdfMappingsReportController extends ControllerBase {
       }
     }
 
-    // Taxonomy terms with external URIs.
-    $markup .= '<h2>' . t('Taxonomy terms with external URIs') . '</h2>';
+    // Taxonomy terms with external URIs or authority links.
+    $markup .= '<h2>' . t('Taxonomy terms with external URIs or authority links') . '</h2>';
     $utils = \Drupal::service('islandora.utils');
+    $uri_fields = $utils->getUriFieldNamesForTerms();
+
     $vocabs = Vocabulary::loadMultiple();
     foreach ($vocabs as $vid => $vocab) {
       $vocab_table_header = [];
@@ -90,16 +93,25 @@ class RdfMappingsReportController extends ControllerBase {
         $markup .= $vocab_table_markup;
       }
       else {
-        $vocab_table_header = [t('Term'), t('Term ID'), t('External URI')];
+        $vocab_table_header = [
+          t('Term'),
+          t('Term ID'),
+          t('External URI or Authority link'),
+        ];
         $vocab_table_rows = [];
         foreach ($terms as $t) {
           $term = Term::load($t->tid);
-          $uri = $utils->getUriForTerm($term);
-          if (is_null($uri)) {
-            $vocab_table_rows[] = [$term->getName(), $term->id(), t('None')];
+          foreach ($uri_fields as $uri_field) {
+            if ($term->hasField($uri_field) && !$term->get($uri_field)->isEmpty()) {
+              $uri = $term->get($uri_field)->first()->getValue();
+              continue;
+            }
+          }
+          if (isset($uri) && !is_null($uri) && array_key_exists('uri', $uri)) {
+            $vocab_table_rows[] = [$term->getName(), $term->id(), $uri['uri']];
           }
           else {
-            $vocab_table_rows[] = [$term->getName(), $term->id(), $uri];
+            $vocab_table_rows[] = [$term->getName(), $term->id(), t('None')];
           }
         }
         $vocab_table = [

--- a/src/Controller/RdfMappingsReportController.php
+++ b/src/Controller/RdfMappingsReportController.php
@@ -100,15 +100,20 @@ class RdfMappingsReportController extends ControllerBase {
         ];
         $vocab_table_rows = [];
         foreach ($terms as $t) {
+          $ld_uri = NULL;
           $term = Term::load($t->tid);
           foreach ($uri_fields as $uri_field) {
             if ($term->hasField($uri_field) && !$term->get($uri_field)->isEmpty()) {
-              $uri = $term->get($uri_field)->first()->getValue();
+              $ld_uri = $term->get($uri_field)->first()->getValue();
               continue;
             }
           }
-          if (isset($uri) && !is_null($uri) && array_key_exists('uri', $uri)) {
-            $vocab_table_rows[] = [$term->getName(), $term->id(), $uri['uri']];
+          if (is_array($ld_uri) && array_key_exists('uri', $ld_uri)) {
+            $vocab_table_rows[] = [
+              $term->getName(),
+              $term->id(),
+              $ld_uri['uri'],
+            ];
           }
           else {
             $vocab_table_rows[] = [$term->getName(), $term->id(), t('None')];

--- a/src/Controller/RdfMappingsReportController.php
+++ b/src/Controller/RdfMappingsReportController.php
@@ -3,6 +3,8 @@
 namespace Drupal\islandora\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\taxonomy\Entity\Vocabulary;
+use Drupal\taxonomy\Entity\Term;
 
 /**
  * RDF mappings report controller.
@@ -20,6 +22,23 @@ class RdfMappingsReportController extends ControllerBase {
     $markup = '';
     $entity_types = ['node', 'media'];
 
+    $namespaces = rdf_get_namespaces();
+    $namespaces_table_rows = [];
+    foreach ($namespaces as $alias => $namespace_uri) {
+      $namespaces_table_rows[] = [$alias, $namespace_uri];
+    }
+    $namespaces_table_header = [t('Namespace alias'), t('Namespace URI')];
+    $namespaces_table = [
+      '#theme' => 'table',
+      '#header' => $namespaces_table_header,
+      '#rows' => $namespaces_table_rows,
+    ];
+    $namespaces_table_markup = \Drupal::service('renderer')->render($namespaces_table);
+
+    $markup .= '<details><summary>' . t('RDF namespaces used in field mappings') .
+      '</summary><div class="details-wrapper">' . $namespaces_table_markup . '</div></details>';
+
+    $markup .= '<h2>' . t('Field mappings') . '</h2>';
     foreach ($entity_types as $entity_type) {
       $bundles = \Drupal::service('entity_type.bundle.info')->getBundleInfo($entity_type);
       foreach ($bundles as $name => $attr) {
@@ -51,21 +70,47 @@ class RdfMappingsReportController extends ControllerBase {
       }
     }
 
-    $markup .= '<h3>RDF namespaces</h3>';
-    $namespaces = rdf_get_namespaces();
-    $namespaces_table_rows = [];
-    foreach ($namespaces as $alias => $namespace_uri) {
-      $namespaces_table_rows[] = [$alias, $namespace_uri];
+    // Taxonomy terms with external URIs.
+    $markup .= '<h2>' . t('Taxonomy terms with external URIs') . '</h2>';
+    $utils = \Drupal::service('islandora.utils');
+    $vocabs = Vocabulary::loadMultiple();
+    foreach ($vocabs as $vid => $vocab) {
+      $vocab_table_header = [];
+      $vocab_table_rows = [];
+      $markup .= '<h3>' . $vocab->label() . ' (' . $vid . ')</h3>';
+      $terms = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->loadTree($vid);
+      if (count($terms) == 0) {
+        $vocab_table_rows[] = [t('No terms in this vocabulary.')];
+        $vocab_table = [
+          '#theme' => 'table',
+          '#header' => $vocab_table_header,
+          '#rows' => $vocab_table_rows,
+        ];
+        $vocab_table_markup = \Drupal::service('renderer')->render($vocab_table);
+        $markup .= $vocab_table_markup;
+      }
+      else {
+        $vocab_table_header = [t('Term'), t('Term ID'), t('External URI')];
+        $vocab_table_rows = [];
+        foreach ($terms as $t) {
+          $term = Term::load($t->tid);
+          $uri = $utils->getUriForTerm($term);
+          if (is_null($uri)) {
+            $vocab_table_rows[] = [$term->getName(), $term->id(), t('None')];
+          }
+          else {
+            $vocab_table_rows[] = [$term->getName(), $term->id(), $uri];
+          }
+        }
+        $vocab_table = [
+          '#theme' => 'table',
+          '#header' => $vocab_table_header,
+          '#rows' => $vocab_table_rows,
+        ];
+      }
+      $vocab_table_markup = \Drupal::service('renderer')->render($vocab_table);
+      $markup .= $vocab_table_markup;
     }
-    $namespaces_table_header = [t('Namespace alias'), t('Namespace URI')];
-    $namespaces_table = [
-      '#theme' => 'table',
-      '#header' => $namespaces_table_header,
-      '#rows' => $namespaces_table_rows,
-    ];
-    $namespaces_table_markup = \Drupal::service('renderer')->render($namespaces_table);
-
-    $markup .= $namespaces_table_markup;
 
     return ['#markup' => $markup];
   }

--- a/src/Controller/RdfMappingsReportController.php
+++ b/src/Controller/RdfMappingsReportController.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Drupal\islandora\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+
+/**
+ * RDF mappings report controller.
+ */
+class RdfMappingsReportController extends ControllerBase {
+
+  /**
+   * Output the RDF mappings report.
+   *
+   * @return string
+   *   Markup of the tables.
+   */
+  public function main() {
+
+    $markup = '';
+    $entity_types = ['node', 'media'];
+
+    foreach ($entity_types as $entity_type) {
+      $bundles = \Drupal::service('entity_type.bundle.info')->getBundleInfo($entity_type);
+      foreach ($bundles as $name => $attr) {
+        $markup .= '<h3>' . $attr['label'] . ' (' . $entity_type . ')' . '</h3>';
+        $rdf_mappings = rdf_get_mapping($entity_type, $name);
+        $fields = \Drupal::entityManager()->getFieldDefinitions($entity_type, $name);
+        $mappings_table_rows = [];
+        foreach ($fields as $field_name => $field_object) {
+          $field_mappings = $rdf_mappings->getPreparedFieldMapping($field_name);
+          if (array_key_exists('properties', $field_mappings)) {
+            $mappings_table_rows[] = [$field_object->getLabel() . ' (' . $field_name . ')', $field_mappings['properties'][0]];
+          }
+        }
+
+        $mappings_header = [t('Drupal field'), t('RDF property')];
+
+        if (count($mappings_table_rows) == 0) {
+          $mappings_header = [];
+          $mappings_table_rows[] = [t('No RDF mappings configured for @bundle.', ['@bundle' => $attr['label']])];
+        }
+
+        $mappings_table = [
+          '#theme' => 'table',
+          '#header' => $mappings_header,
+          '#rows' => $mappings_table_rows,
+        ];
+        $mappings_table_markup = \Drupal::service('renderer')->render($mappings_table);
+        $markup .= $mappings_table_markup;
+      }
+    }
+
+    $markup .= '<h3>RDF namespaces</h3>';
+    $namespaces = rdf_get_namespaces();
+    $namespaces_table_rows = [];
+    foreach ($namespaces as $alias => $namespace_uri) {
+      $namespaces_table_rows[] = [$alias, $namespace_uri];
+    }
+    $namespaces_table_header = [t('Namespace alias'), t('Namespace URI')];
+    $namespaces_table = [
+      '#theme' => 'table',
+      '#header' => $namespaces_table_header,
+      '#rows' => $namespaces_table_rows,
+    ];
+    $namespaces_table_markup = \Drupal::service('renderer')->render($namespaces_table);
+
+    $markup .= $namespaces_table_markup;
+
+    return ['#markup' => $markup];
+  }
+
+}

--- a/src/IslandoraUtils.php
+++ b/src/IslandoraUtils.php
@@ -302,7 +302,8 @@ class IslandoraUtils {
     $field_map = $this->entityFieldManager->getFieldMap();
     $fields = [];
     foreach ($field_map['taxonomy_term'] as $field_name => $field_data) {
-      if ($field_data['type'] == 'authority_link') {
+      $data_types = ['authority_link', 'field_external_authority_link'];
+      if (in_array($field_data['type'], $data_types)) {
         $fields[] = $field_name;
       }
     }

--- a/src/IslandoraUtils.php
+++ b/src/IslandoraUtils.php
@@ -265,7 +265,7 @@ class IslandoraUtils {
   }
 
   /**
-   * Gets the taxonomy term associated with an external uri.
+   * Gets the external uri associated with a taxonomy term.
    *
    * @param \Drupal\taxonomy\TermInterface $term
    *   Taxonomy term.


### PR DESCRIPTION
**Github issue**: https://github.com/Islandora/documentation/issues/1521

# What does this Pull Request do?

Adds a report listing all the 1) configured Drupal-field-to-RDF properties and 2) all of the external URIs associated with taxonomy terms.

# What's new?

* Adds a new controller at `admin/reports/islandora/rdf_mappings` that generates and renders the report
* Updates the `getUriFieldNamesForTerms()` function in the Islandora Utilities service

# How should this be tested?

1. Check out this branch. Within the `islandora` module directory:
   1. `git remote add mjordan https://github.com/mjordan/islandora.git`
   1. `git fetch mjordan`
   1. `git checkout issue-1521`
1. Clear your cache (`drush cr`)
1. Visit Admin > Reports > Field and term RDF mappings (refresh if you don't see this new item)
1. You should see the report listing fields and their RDF property mappings, and near the bottom, all taxonomies with terms that have external URIs / authority links. It's a long list.


# Additional Notes:

* Does this change the interface, add a new feature, or otherwise change behaviours that would require updating documentation? Yes, a new item, "Field and term RDF mappings", appears in Drupal's "Reports" menu.
* Does this change add any new dependencies? No.
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? No.
* Could this change impact execution of existing code? Yes.

# Interested parties
@Islandora/8-x-committers
