### PR TITLE
Add configuration for a user and password to the broker.

### DIFF
--- a/src/Form/IslandoraSettingsForm.php
+++ b/src/Form/IslandoraSettingsForm.php
@@ -22,6 +22,8 @@ class IslandoraSettingsForm extends ConfigFormBase {
 
   const CONFIG_NAME = 'islandora.settings';
   const BROKER_URL = 'broker_url';
+  const BROKER_USER = 'broker_user';
+  const BROKER_PASSWORD = 'broker_password';
   const JWT_EXPIRY = 'jwt_expiry';
   const GEMINI_URL = 'gemini_url';
   const GEMINI_PSEUDO = 'gemini_pseudo_bundles';
@@ -35,6 +37,12 @@ class IslandoraSettingsForm extends ConfigFormBase {
   private $entityTypeBundleInfo;
 
   /**
+   * The saved password (if set).
+   * @var string
+   */
+  private $brokerPassword;
+
+  /**
    * Constructs a \Drupal\system\ConfigFormBase object.
    *
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
@@ -45,6 +53,7 @@ class IslandoraSettingsForm extends ConfigFormBase {
   public function __construct(ConfigFactoryInterface $config_factory, EntityTypeBundleInfoInterface $entity_type_bundle_info) {
     $this->setConfigFactory($config_factory);
     $this->entityTypeBundleInfo = $entity_type_bundle_info;
+    $this->brokerPassword = $this->config(self::CONFIG_NAME)->get(self::BROKER_PASSWORD);
   }
 
   /**
@@ -79,12 +88,46 @@ class IslandoraSettingsForm extends ConfigFormBase {
   public function buildForm(array $form, FormStateInterface $form_state) {
     $config = $this->config(self::CONFIG_NAME);
 
-    $form[self::BROKER_URL] = [
+    $form['broker_info'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Broker'),
+      '#open' => TRUE,
+    ];
+    $form['broker_info'][self::BROKER_URL] = [
       '#type' => 'textfield',
-      '#title' => $this->t('Broker URL'),
+      '#title' => $this->t('URL'),
       '#default_value' => $config->get(self::BROKER_URL),
     ];
-
+    $broker_user = $config->get(self::BROKER_USER);
+    $form['broker_info']['provide_user_creds'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Provide user identification'),
+      '#default_value' => $broker_user ? TRUE : FALSE,
+    ];
+    $state_selector = 'input[name="provide_user_creds"]';
+    $form['broker_info'][self::BROKER_USER] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('User'),
+      '#default_value' => $broker_user,
+      '#states' => [
+        'visible' => [
+          $state_selector => ['checked' => TRUE],
+        ],
+        'required' => [
+          $state_selector => ['checked' => TRUE],
+	]
+      ],
+    ];
+    $form['broker_info'][self::BROKER_PASSWORD] = [
+      '#type' => 'password',
+      '#title' => $this->t('Password'),
+      '#description' => $this->t('If this field is left blank and the user is filled out, the current password will not be changed.'),
+      '#states' => [
+        'visible' => [
+          $state_selector => ['checked' => TRUE],
+        ],
+      ],
+    ];
     $form[self::JWT_EXPIRY] = [
       '#type' => 'textfield',
       '#title' => $this->t('JWT Expiry'),
@@ -142,14 +185,22 @@ class IslandoraSettingsForm extends ConfigFormBase {
   public function validateForm(array &$form, FormStateInterface $form_state) {
     // Validate broker url by actually connecting with a stomp client.
     $brokerUrl = $form_state->getValue(self::BROKER_URL);
-
     // Attempt to subscribe to a dummy queue.
     try {
-      $stomp = new StatefulStomp(
-        new Client(
-          $brokerUrl
-        )
-      );
+      $client = new Client($brokerUrl);
+      if ($form_state->getValue('provide_user_creds')) {
+        $broker_password = $form_state->getValue(self::BROKER_PASSWORD);
+	  if (!$broker_password) {
+	    if (!$this->brokerPassword) {
+	      $form_state->setErrorByName(self::BROKER_PASSWORD, $this->t('A password must be supplied'));
+	    }
+	    else {
+              $broker_password = $this->brokerPassword;
+	    }
+	  }
+	 $client->setLogin($form_state->getValue(self::BROKER_USER), $broker_password);
+      }
+      $stomp = new StatefulStomp($client);
       $stomp->subscribe('dummy-queue-for-validation');
       $stomp->unsubscribe();
     }
@@ -223,6 +274,21 @@ class IslandoraSettingsForm extends ConfigFormBase {
     $config = $this->configFactory->getEditable(self::CONFIG_NAME);
 
     $pseudo_types = array_filter($form_state->getValue(self::GEMINI_PSEUDO));
+
+    $broker_password = $form_state->getValue(self::BROKER_PASSWORD);
+
+    // If there's no user set delete what may have been here before as password fields will also be blank when default valuing.
+    if (!$form_state->getValue('provide_user_creds')) {
+      $config->delete(self::BROKER_USER);
+      $config->delete(self::BROKER_PASSWORD);
+    }
+    else {
+      $config->set(self::BROKER_USER, $form_state->getValue(self::BROKER_USER));
+      // If the password has changed update it as well.
+      if ($broker_password && $broker_password != $this->brokerPassword) {
+        $config->set(self::BROKER_PASSWORD, $broker_password);
+      }
+    }
 
     $config
       ->set(self::BROKER_URL, $form_state->getValue(self::BROKER_URL))

--- a/src/StompFactory.php
+++ b/src/StompFactory.php
@@ -25,13 +25,16 @@ class StompFactory {
     // Get broker url from config.
     $settings = $config->get(IslandoraSettingsForm::CONFIG_NAME);
     $brokerUrl = $settings->get(IslandoraSettingsForm::BROKER_URL);
-
+    $brokerUser = $settings->get(IslandoraSettingsForm::BROKER_USER);
     // Try a sensible default if one hasn't been configured.
     if (empty($brokerUrl)) {
       $brokerUrl = "tcp://localhost:61613";
     }
 
     $client = new Client($brokerUrl);
+    if ($brokerUser) {
+      $client->setLogin($brokerUser, $settings->get(IslandoraSettingsForm::BROKER_PASSWORD));
+    }
     return new StatefulStomp($client);
   }
 


### PR DESCRIPTION
**JIRA Ticket**: https://github.com/Islandora/documentation/issues/1454

# What does this Pull Request do?
Adds user/password configuration for the broker such that non-anonymous connections can be made.

# What's new?
Configuration form settings and passing down the credentials to the `islandora.stomp` service.

# How should this be tested?
Configure ActiveMQ to require authentication.
Add those credentials to the form.
Things operate as expected.

# Interested parties
@Islandora/8-x-committers 
