### PR TITLE
#1534 Change config permission to 'administer site configuration'

### DIFF
--- a/modules/islandora_iiif/islandora_iiif.routing.yml
+++ b/modules/islandora_iiif/islandora_iiif.routing.yml
@@ -4,6 +4,6 @@ islandora_iiif.islandora_iiif_config_form:
     _form: '\Drupal\islandora_iiif\Form\IslandoraIIIFConfigForm'
     _title: 'IslandoraIIIFConfigForm'
   requirements:
-    _permission: 'access administration pages'
+    _permission: 'administer site configuration'
   options:
     _admin_route: TRUE


### PR DESCRIPTION
**Github Ticket**:
#1534 Tighten access to Islandora IIIF config form 
https://github.com/Islandora/documentation/issues/1534

# What does this Pull Request do?

Changes config permission for Islandora IIIF config form from 'access administration pages' to 'administer site configuration' so that some roles can have (say) content administration via administration pages without being able to alter key site configuration.

A brief description of what the intended result of the PR will be and/or what problem it solves.

# What's new?
Changed permission for `/admin/config/islandora/iiif`

# How should this be tested?

With a user role with 'access administration pages' permission note that /admin/config/islandora/iiif is accessible. With this patch they should get "You are not authorised to access this page.", and 'administer site configuration' is required instead.


# Interested parties
@Islandora/8-x-committers 
