### PR TITLE
Skip link headers for non-canonicalizable entities

### DIFF
--- a/src/EventSubscriber/LinkHeaderSubscriber.php
+++ b/src/EventSubscriber/LinkHeaderSubscriber.php
@@ -9,6 +9,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\islandora\IslandoraUtils;
+use Drupal\Core\Entity\Exception\UndefinedLinkTemplateException;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
@@ -205,7 +206,14 @@ abstract class LinkHeaderSubscriber implements EventSubscriberInterface {
         // Headers are subject to an access check.
         if ($referencedEntity->access('view')) {
 
-          $entity_url = $this->utils->getEntityUrl($referencedEntity);
+          try {
+            $entity_url = $this->utils->getEntityUrl($referencedEntity);
+          }
+          catcH (UndefinedLinkTemplateException $e) {
+            // Not all referencable entities can generate canonical URLs, for
+            // example: block entities.
+            continue;
+          }
 
           // Taxonomy terms are written out as
           // <url>; rel="tag"; title="Tag Name"

--- a/src/EventSubscriber/LinkHeaderSubscriber.php
+++ b/src/EventSubscriber/LinkHeaderSubscriber.php
@@ -209,7 +209,7 @@ abstract class LinkHeaderSubscriber implements EventSubscriberInterface {
           try {
             $entity_url = $this->utils->getEntityUrl($referencedEntity);
           }
-          catcH (UndefinedLinkTemplateException $e) {
+          catch (UndefinedLinkTemplateException $e) {
             // Not all referencable entities can generate canonical URLs, for
             // example: block entities.
             continue;

--- a/src/IslandoraUtils.php
+++ b/src/IslandoraUtils.php
@@ -565,7 +565,7 @@ class IslandoraUtils {
    *   The entity URL.
    *
    * @throws \Drupal\Core\Entity\Exception\UndefinedLinkTemplateException
-   *   Should the given entity not specify a "canonical" template.
+   *   Thrown if the given entity does not specify a "canonical" template.
    * @throws \Drupal\Core\Entity\EntityMalformedException
    */
   public function getEntityUrl(EntityInterface $entity) {

--- a/src/IslandoraUtils.php
+++ b/src/IslandoraUtils.php
@@ -563,15 +563,17 @@ class IslandoraUtils {
    *
    * @return string
    *   The entity URL.
+   *
+   * @throws \Drupal\Core\Entity\Exception\UndefinedLinkTemplateException
+   *   Should the given entity not specify a "canonical" template.
    */
   public function getEntityUrl(EntityInterface $entity) {
     $undefined = $this->languageManager->getLanguage('und');
-    $entity_type = $entity->getEntityTypeId();
-    return Url::fromRoute(
-      "entity.$entity_type.canonical",
-      [$entity_type => $entity->id()],
-      ['absolute' => TRUE, 'language' => $undefined]
-    )->toString();
+    return $entity->toUrl('canonical', [
+        'absolute' => TRUE,
+        'language' => $undefined,
+      ])
+      ->toString();
   }
 
   /**

--- a/src/IslandoraUtils.php
+++ b/src/IslandoraUtils.php
@@ -566,14 +566,14 @@ class IslandoraUtils {
    *
    * @throws \Drupal\Core\Entity\Exception\UndefinedLinkTemplateException
    *   Should the given entity not specify a "canonical" template.
+   * @throws \Drupal\Core\Entity\EntityMalformedException
    */
   public function getEntityUrl(EntityInterface $entity) {
     $undefined = $this->languageManager->getLanguage('und');
     return $entity->toUrl('canonical', [
-        'absolute' => TRUE,
-        'language' => $undefined,
-      ])
-      ->toString();
+      'absolute' => TRUE,
+      'language' => $undefined,
+    ])->toString();
   }
 
   /**


### PR DESCRIPTION
# What does this Pull Request do?

Addresses https://github.com/Islandora/documentation/issues/1551, allowing for content making reference to non-canonicalizable entities (such as blocks) to be manipulated and viewed.

# What's new?

We use `Entity::toUrl()` to generate the URL, and catch its `UndefinedLinkTemplateException` exception.

# How should this be tested?

* Create a node bundle which can make references to blocks with an entity reference field
* Make a node with a reference to a block

In 1.1.1--prior to this change--you might experience uncaught exceptions, such as:
```
Symfony\Component\Routing\Exception\RouteNotFoundException: Route "entity.block.canonical" does not exist. in Drupal\Core\Routing\RouteProvider->getRouteByName() (line 208 of /opt/www/drupal/core/lib/Drupal/Core/Routing/RouteProvider.php).
```
With the new URL generation, we catch the more-specific `UndefinedLinkTemplateException` exception, and skip attempting to create a link entry for it.

# Additional Notes:

The [docs on `EntityInterface::toUrl()`](https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Entity%21EntityInterface.php/function/EntityInterface%3A%3AtoUrl/8.8.x) indicate:

> If the path is not set in the links array, the uri_callback function is used for setting the path. If this does not exist and the link relationship type is canonical, the path is set using the default template: entity/entityType/id.

... This does not appear to happen, with the [exception being thrown](https://git.drupalcode.org/project/drupal/-/blob/978e4b5219eeff545acf6a41fb19d60239caf8d5/core/lib/Drupal/Core/Entity/EntityBase.php#L226-228) instead of whatever "default template" being used, despite the [nearby inline documentation](https://git.drupalcode.org/project/drupal/-/blob/978e4b5219eeff545acf6a41fb19d60239caf8d5/core/lib/Drupal/Core/Entity/EntityBase.php#L221-222).

# Interested parties

@Islandora/8-x-committers 
