### PR TITLE
Issue-1559: Fix breadcrumbs error when part is deleted

### DIFF
--- a/modules/islandora_breadcrumbs/src/IslandoraBreadcrumbBuilder.php
+++ b/modules/islandora_breadcrumbs/src/IslandoraBreadcrumbBuilder.php
@@ -107,7 +107,8 @@ class IslandoraBreadcrumbBuilder implements BreadcrumbBuilderInterface {
 
     // Find the next in the chain, if there are any.
     if ($entity->hasField($this->config->get('referenceField')) &&
-      !$entity->get($this->config->get('referenceField'))->isEmpty()) {
+      !$entity->get($this->config->get('referenceField'))->isEmpty() &&
+      $entity->get($this->config->get('referenceField'))->entity instanceof EntityInterface) {
       $this->walkMembership($entity->get($this->config->get('referenceField'))->entity, $crumbs);
     }
   }


### PR DESCRIPTION
**Github Ticket**: https://github.com/Islandora/documentation/issues/1559

# What does this Pull Request do?

Resolves an issue where deleting an item in the member_of chain throws an Exception with a WSOD when attempting to view a child of that chain.

# What's new?

Adds a check to the islandora breadcrumbs builder to ensure the next step in the member_of chain _is_ actually an entity (e.g. wasn't deleted).

# How should this be tested?

- Create a collection with a child object.
- View the child and clear the cache to ensure the breadcrumbs appear.
- Delete the parent collection.
- Revisiting the child shows a WSOD.
- **Apply the PR**
- View the child object (no WSOD). 
- _You can also recreate the collection, add the child, and delete the collection again if you want to double-check._


# Additional Notes:

Credit for this fix goes to @ainsofs who [posted the patch to the original ticket](https://github.com/Islandora/documentation/issues/1559#issuecomment-654486343).

# Interested parties
@ainsofs, @Islandora/8-x-committers 