### PR TITLE
Handling case where IIIF manifest generation fails if cantaloupe is down

### DIFF
--- a/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
+++ b/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
@@ -184,7 +184,6 @@ class IIIFManifest extends StylePluginBase {
           $canvas_id = $iiif_base_id . '/canvas/' . $entity->id();
           $annotation_id = $iiif_base_id . '/annotation/' . $entity->id();
 
-	  dsm("BEFORE REQUEST");
           // Try to fetch the IIIF metadata for the image.
           try {
             $info_json = $this->httpClient->get($iiif_url)->getBody();


### PR DESCRIPTION
**Github Issue**: https://github.com/Islandora/documentation/issues/1568

# What does this Pull Request do?

Adds `ConnectException` to the list of exceptions we try to catch when calling out to Cantaloupe to make a IIIF manifest.

# What's new?
Just another exception in the try/catch.  I combined all the `catch`es and also nested the fallback code within the catch block for cleanliness.

# How should this be tested?

- Shut down cantaloupe
- Try to view a IIIIF manifest for a piece of paged content
- You should get a WSOD
- Apply this PR
- `drush cr`
- Try to view a IIIIF manifest for a piece of paged content again
- No whitescreen.  We fall back to pulling info out of Drupal metadata.

# Interested parties
@Islandora/8-x-committers @DonRichards @nigelgbanks 
