### PR TITLE
Removing isladora_version_count table

### DIFF
--- a/islandora.install
+++ b/islandora.install
@@ -6,42 +6,6 @@
  */
 
 /**
- * Implements hook_schema().
- */
-function islandora_schema() {
-  $schema = [];
-  $schema['islandora_version_count'] = [
-    'description' => 'Keeps track of the number of changes to an entity',
-    'fields' => [
-      'id' => [
-        'description' => 'Autoincrementing id for record',
-        'type' => 'serial',
-        'unsigned' => TRUE,
-        'not null' => TRUE,
-      ],
-      'uuid' => [
-        'description' => 'UUID for an entity',
-        'type' => 'varchar',
-        'length' => 128,
-        'not null' => TRUE,
-        'unique' => TRUE,
-      ],
-      'count' => [
-        'description' => 'Number of times an entity has been updated.',
-        'type' => 'int',
-        'unsigned' => TRUE,
-        'default' => 0,
-      ],
-    ],
-    'primary key' => ['id'],
-    'unique keys' => [
-      'uuid' => ['uuid'],
-    ],
-  ];
-  return $schema;
-}
-
-/**
  * Delete the 'delete_media' action we used to provide, if it exists.
  *
  * Use the core 'media_delete_action' instead.
@@ -79,4 +43,15 @@ function islandora_update_8002(&$sandbox) {
 
   // Force drupal to reload the config.
   \Drupal::service('plugin.manager.condition')->clearCachedDefinitions();
+}
+
+/**
+ * Deletes the islandora_version_count table.
+ *
+ * We never implemented the functionality.
+ */
+function islandora_update_8003(&$sandbox) {
+  \Drupal::service('database')
+    ->schema()
+    ->dropTable('islandora_version_count');
 }


### PR DESCRIPTION
**Github Issue**: Resolves https://github.com/Islandora/documentation/issues/1528

# What does this Pull Request do?

Gets rid of the `islandora_version_count` table, b/c we never implemented the two-way sync.

# What's new?
I removed `hook_schema` and added an update hook to remove the table. :fire: :fire: :fire:

# How should this be tested?

- Pull down this pr
- `drush updb`
` `drush sql:cli` and then `show tables`
- `islandora_version_count` should not be in the list.

# Interested parties
@Islandora/8-x-committers
