### PR TITLE
Add null check prior to using object.

### DIFF
--- a/modules/islandora_text_extraction/islandora_text_extraction.module
+++ b/modules/islandora_text_extraction/islandora_text_extraction.module
@@ -36,11 +36,18 @@ function islandora_text_extraction_media_presave(MediaInterface $media) {
   $text = $media->get('field_edited_text')->getValue();
   if (!$text) {
     $file_id = $media->get('field_media_file')->getValue()[0]['target_id'];
-    $file = File::load($file_id);
-    $data = file_get_contents($file->getFileUri());
-    $data = nl2br($data);
-    $media->set('field_edited_text', $data);
-    $media->field_edited_text->format = 'basic_html';
+    if ($file_id) {
+      $file = File::load($file_id);
+      if ($file) {
+        $data = file_get_contents($file->getFileUri());
+        $data = nl2br($data);
+        $media->set('field_edited_text', $data);
+        $media->field_edited_text->format = 'basic_html';
+      }
+    }
+    else {
+      \Drupal::logger('islandora_text_extraction')->warning("No file associated with media entity.");
+    }
   }
 }
 


### PR DESCRIPTION
# What does this Pull Request do?

Checks if an entity is null before de-referencing it. 

# What's new?

Prevents the following error: 

```
Error: Call to a member function getFileUri() on null in islandora_text_extraction_media_presave() (line 40 of /var/www/drupal/web/modules/contrib/islandora/modules/islandora_text_extraction/islandora_text_extraction.module
```

# How should this be tested?

Small change doesn't really require testing.

# Interested parties
@Islandora/8-x-committers
