### PR TITLE
Issue 1367: Loosen Islandora Breadcrumbs applies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,12 @@ script:
   - $SCRIPT_DIR/run-tests.sh "islandora_video"
   - $SCRIPT_DIR/run-tests.sh "islandora_text_extraction"
 
+after_script:
+  - ps -ef
+
 after_success:
   - bash <(curl -s https://codecov.io/bash)
+  - ps -ef
 
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,12 +43,8 @@ script:
   - $SCRIPT_DIR/run-tests.sh "islandora_video"
   - $SCRIPT_DIR/run-tests.sh "islandora_text_extraction"
 
-after_script:
-  - ps -ef
-
 after_success:
   - bash <(curl -s https://codecov.io/bash)
-  - ps -ef
 
 notifications:
   slack:

--- a/modules/islandora_breadcrumbs/src/IslandoraBreadcrumbBuilder.php
+++ b/modules/islandora_breadcrumbs/src/IslandoraBreadcrumbBuilder.php
@@ -54,7 +54,7 @@ class IslandoraBreadcrumbBuilder implements BreadcrumbBuilderInterface {
     $nid = $attributes->getRawParameters()->get('node');
     if (!empty($nid)) {
       $node = $this->nodeStorage->load($nid);
-      return (!empty($node) && $node->hasField($this->config->get('referenceField')) && !$node->get($this->config->get('referenceField'))->isEmpty());
+      return (!empty($node) && $node->hasField($this->config->get('referenceField')));
     }
   }
 

--- a/modules/islandora_breadcrumbs/tests/src/Functional/BreadcrumbsTest.php
+++ b/modules/islandora_breadcrumbs/tests/src/Functional/BreadcrumbsTest.php
@@ -114,6 +114,18 @@ class BreadcrumbsTest extends IslandoraFunctionalTestBase {
 
     // We should still escape it and have the same trail as before.
     $this->assertBreadcrumb($this->nodeD->toUrl()->toString(), $breadcrumbs);
+
+    // Delete 'A', removing it from the chain.
+    $this->nodeA->delete();
+
+    // The new breadcrumb chain without 'A'.
+    $breadcrumbs = [
+      Url::fromRoute('<front>')->toString() => 'Home',
+      $this->nodeB->toUrl()->toString() => $this->nodeB->label(),
+      $this->nodeC->toUrl()->toString() => $this->nodeC->label(),
+    ];
+
+    $this->assertBreadcrumb($this->nodeD->toUrl()->toString(), $breadcrumbs);
   }
 
 }


### PR DESCRIPTION
**GitHub Ticket**: https://github.com/Islandora/documentation/issues/1367

# What does this Pull Request do?

Loosens the `applies` on islandora breadcrumbs so that it no longer requires a value in the configured reference field (member_of by default). This allows Islandora Objects with the Collection model (that won't have a value in member_of unless they are sub-collections) to use this breadcrumb builder instead of defaulting to the system provided breadcrumbs.

# What's new?

Simply removed the `!empty` condition from applies.

# How should this be tested?

- Create an Islandora object without completing the member_of field.
- It will use the system breadcrumbs, although it looks like Carapace doesn't show the 'node' parent for these 🤷‍♂️. (If you want to be sure, add a `dsm` to the breadcrumb builder's `build` function. It won't fire when the system one does.)
- Apply the PR
- Clear caches
- View the item again. (If you added the `dsm` function it should fire now.)

# Additional Notes:
If you want to be extra sure it is working, you can edit the islandora.breadcrumbs config file's 'includeSelf' setting to 'TRUE' and clear caches again. You should now see the current node's title in the breadcrumbs. (Sorry, we don't have a form for this yet, so you need to use one of the system-supplied config editing methods. We should probably make an issue for that... or maybe I should just do that now...)

~~This PR is untested since my VM is still tied up testing other stuff...~~ *Finally tested and ready for review.*

Also, I haven't put it through @qadan's test from the ticket.... but my wife is kicking me off the computer right now.

# Interested parties
@qadan and @jordandukart 
