### PR TITLE
ensure weights in integer weight select

### DIFF
--- a/src/Plugin/views/field/IntegerWeightSelector.php
+++ b/src/Plugin/views/field/IntegerWeightSelector.php
@@ -46,18 +46,16 @@ class IntegerWeightSelector extends FieldPluginBase {
       $options[$this->getValue($row)] = $this->getValue($row);
     }
 
-    // If we were given some blank values we need to fill
-    // out the option list from 1 through the result count
-    // to make sure we have enough. (Blanks should only appear
-    // at the beginning of the results list.)
-    // Also, blank values will break the selector, remove it.
+    // Blank values will break the selector, so remove one if found.
     if (array_key_exists('', $options)) {
       unset($options['']);
-      for ($i = 1; $i <= $this->view->total_rows; $i++) {
-        $options[$i] = $i;
-      }
-      ksort($options);
     }
+    // Add in values from the list of rows, starting at 0, to ensure we have
+    // numbers matching each possible row.
+    for ($i = 0; $i < $this->view->total_rows; $i++) {
+      $options[$i] = $i;
+    }
+    ksort($options);
 
     // Now that we have all the available weight values, populate the forms.
     foreach ($this->view->result as $row_index => $row) {


### PR DESCRIPTION
# What does this Pull Request do?

Fixes an issue where the integer weight selector can be made impossible to correctly re-weight things using the select menus.

The issue can be seen if you take the steps under "How should this be tested" below.

You'll see (in the current codebase) that performing the steps in the test case makes it so that you cannot change the weight values of the child members using the select fields.

This is happening because those select menus are populated by first populating options for each current weight value for each member, then if any weights are currently an empty string, running through and adding a number for each row, starting from 1.

It breaks because of two things:

* View rows actually start from 0, whereas the options are populated from 1, so there will always be one fewer number in the select menu than the total rows in the view
* After the first time you reorder things, and until you add a new member, there will not be an empty string triggering the second condition, so the only numbers in the list will be used as options for weights.

This is kind of compounded by the fact that if you do indeed allow someone to modify weights as part of the Repository Item creation form, they can put any number they'd like in there, so once you attempt reordering, there's no guarantee you'll have numbers in the select field you can use to reorder weights.

# What's new?

The form now creates weight select fields that contain all existing values as options, plus one guaranteed option for each possible row number.

# How should this be tested?

* Create a collection
* Add two repository items to that collection
* Use the "Reorder members" view to give one of the members a weight of 2 using the select drop-downs (might have to "Show row weights" first), then save the order
* Use the "Reorder members" view to then give the member you previously set at 2 a weight of 1
* Visit the "Reorder members" view again, and observe that both select fields allow you to reorder the items

# Additional Notes:

This might not be the best solution to the issue ... weight fields in forms use the 'number' type form element, so would it be better to do so here as well? That would also ensure that any arbitrary number is still valid, works with `#default_value`, and doesn't create a massive select field. 

# Interested parties
@Islandora/8-x-committers 
