### PR TITLE
Spaces needed in error messages.

### DIFF
--- a/src/Plugin/Action/AbstractGenerateDerivative.php
+++ b/src/Plugin/Action/AbstractGenerateDerivative.php
@@ -142,7 +142,7 @@ class AbstractGenerateDerivative extends EmitEvent {
     // url in the data array.
     $source_term = $this->utils->getTermForUri($this->configuration['source_term_uri']);
     if (!$source_term) {
-      throw new \RuntimeException("Could not locate source term with uri" . $this->configuration['source_term_uri'], 500);
+      throw new \RuntimeException("Could not locate source term with uri: " . $this->configuration['source_term_uri'], 500);
     }
 
     $source_media = $this->utils->getMediaWithTerm($entity, $source_term);
@@ -161,7 +161,7 @@ class AbstractGenerateDerivative extends EmitEvent {
     // in the data array.
     $derivative_term = $this->utils->getTermForUri($this->configuration['derivative_term_uri']);
     if (!$derivative_term) {
-      throw new \RuntimeException("Could not locate derivative term with uri" . $this->configuration['derivative_term_uri'], 500);
+      throw new \RuntimeException("Could not locate taxonomy term with uri: " . $this->configuration['derivative_term_uri'], 500);
     }
 
     $route_params = [


### PR DESCRIPTION
https://github.com/Islandora/documentation/issues/1637

* Other Relevant Links 
    * mentioned in https://github.com/Islandora-Devops/isle-dc/issues/117

# What does this Pull Request do?

Adds spaces, changes wording. 

# What's new?
 
Improved error messages, I hope?

# How should this be tested?

Does this make clearer error messages?


# Additional Notes:

* Maybe we should put some delimiters around the inserted text, such as:

`Error generating event: Could not locate taxonomy term with uri [https://projects.iq.harvard.edu/fits].`

That would be a coding style change, and could be implemented more broadly...

* I only got that one message, but I don't know if that means I should expect my derivative (without a  term) or not expect a derivative. Since it says "Error generating event" I'm guessing the former. Would it be bad form to add "Derivative generation for [FITS] could not proceed." or something? 

# Interested parties

@Islandora/8-x-committers 
