### PR TITLE
Use continue 2 in switch inside for loop (for php 7.3)

### DIFF
--- a/src/EventSubscriber/LinkHeaderSubscriber.php
+++ b/src/EventSubscriber/LinkHeaderSubscriber.php
@@ -291,7 +291,7 @@ abstract class LinkHeaderSubscriber implements EventSubscriberInterface {
             break;
 
           default:
-            continue;
+            continue 2;
         }
 
         // Skip route if the user doesn't have access.


### PR DESCRIPTION

**Github Issue** Resolves https://github.com/Islandora/documentation/issues/1466

# What does this Pull Request do?

Uses `continue 2` in `LinkHeaderSubscriber` since we've got a `switch` in a `foreach`. It's for PHP 7.3 compatibility.

# How should this be tested?

* Travis's 7.3 tests shouldn't error on this anymore

OR

* Use isle-dc and `make dev`
* `docker exec -it isle-dc_drupal_1 drush cr`
    * You should see the warning about using `continue 2`
* `cd` into your codebase folder and pull this PR into your `islandora` module
* `docker exec -it isle-dc_drupal_1 drush cr`
  * You should _not_ see the warning about `continue 2`

# Interested parties
@Islandora/8-x-committers
