### PR TITLE
Fix for media_source_mimetype

### DIFF
--- a/src/Plugin/Condition/MediaSourceHasMimetype.php
+++ b/src/Plugin/Condition/MediaSourceHasMimetype.php
@@ -44,20 +44,24 @@ class MediaSourceHasMimetype extends ConditionPluginBase {
    * {@inheritdoc}
    */
   public function evaluate() {
-    foreach ($this->getContexts() as $context) {
-      if ($context->hasContextValue()) {
-        $entity = $context->getContextValue();
-        $mid = $entity->id();
-        if ($mid && !empty($this->configuration['mimetype'])) {
-          $source = $entity->getSource();
+    if (empty($this->configuration['mimetype']) && !$this->isNegated()) {
+      return TRUE;
+    }
+    $media = $this->getContext('media');
+    if ($media->hasContextValue()) {
+      $entity = $media->getContextValue();
+      $mid = $entity->id();
+      if ($mid) {
+        $source = $entity->getSource();
+        if ($source) {
           $source_file = File::load($source->getSourceFieldValue($entity));
           if ($this->configuration['mimetype'] == $source_file->getMimeType()) {
-            return !$this->isNegated();
+            return TRUE;
           }
         }
       }
     }
-    return $this->isNegated();
+    return FALSE;
   }
 
   /**


### PR DESCRIPTION
Fix for `media_source_mimetype` to allow entities to display when not specified.

# What does this Pull Request do?

Allows entities which do not specify any `media_source_mimetype` to continue to be accessible.

# What's new?

Changes the `media_source_mimetype` so that double negation does not occur. Checks for `isNegated` should not be used in `ConditionPlugins` as it causes a double negation, since the `ConditionManager` does the negation. With the exception of the first check in the case where no value has been specified for the plugin.

See: 
https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Condition%21ConditionManager.php/8.9.x

```php
public function execute(ExecutableInterface $condition) {
    if ($condition instanceof ConditionInterface) {
      $result = $condition
        ->evaluate();
      return $condition
        ->isNegated() ? !$result : $result;
    }
    throw new ExecutableException("This manager object can only execute condition plugins");
  }
```
# How should this be tested?

Use the latest 8.x-1.x commit ([ca73b271fd928364ff06e2765401747c17f30b4a](https://github.com/Islandora/islandora/commit/ca73b271fd928364ff06e2765401747c17f30b4a) at time of writing).

* Create a custom block
* Place on front page without any restrictions
* Clear cache
* Note that it does not display

Change to this branch and repeat the steps, note that the block now displays.

# Interested parties
@Islandora/7-x-1-x-committers
