### PR TITLE
Switch to using PHPUnit directly and splitting into testsuites.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@ php:
   - 7.2
   - 7.3
 
+env:
+  - TESTSUITE=kernel
+  - TESTSUITE=functional
+  - TESTSUITE=functional-javascript
+
 matrix:
     fast_finish: true
     allow_failures:
@@ -20,7 +25,9 @@ branches:
 before_install:
   - export SCRIPT_DIR=$HOME/islandora/.scripts
   - export DRUPAL_DIR=/opt/drupal
+  - export PHPUNIT_FILE=$TRAVIS_BUILD_DIR/phpunit.xml
   - export COMPOSER_PATH="/home/travis/.phpenv/versions/$TRAVIS_PHP_VERSION/bin/composer"
+  - phpenv config-rm xdebug.ini
 
 install:
   - git clone https://github.com/Islandora/documentation.git $HOME/islandora
@@ -33,18 +40,13 @@ install:
   - cd web
   - drush --uri=127.0.0.1:8282 en -y islandora_audio islandora_breadcrumbs islandora_iiif islandora_image islandora_video islandora_text_extraction_defaults
   - drush --uri=127.0.0.1:8282 fim -y islandora_core_feature,islandora_text_extraction_defaults
+  - mkdir -p $DRUPAL_DIR/web/sites/simpletest/browser_output
+  - cp $PHPUNIT_FILE $DRUPAL_DIR/web/core/phpunit.xml
 
 script:
   - $SCRIPT_DIR/travis_scripts.sh
-  - $SCRIPT_DIR/run-tests.sh "islandora"
-  - $SCRIPT_DIR/run-tests.sh "islandora_breadcrumbs"
-  - $SCRIPT_DIR/run-tests.sh "islandora_image"
-  - $SCRIPT_DIR/run-tests.sh "islandora_audio"
-  - $SCRIPT_DIR/run-tests.sh "islandora_video"
-  - $SCRIPT_DIR/run-tests.sh "islandora_text_extraction"
-
-after_success:
-  - bash <(curl -s https://codecov.io/bash)
+  - cd $DRUPAL_DIR/web/core
+  - $DRUPAL_DIR/vendor/bin/phpunit --verbose --testsuite "$TESTSUITE"
 
 notifications:
   slack:

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- TODO set checkForUnintentionallyCoveredCode="true" once https://www.drupal.org/node/2626832 is resolved. -->
+<!-- PHPUnit expects functional tests to be run with either a privileged user
+ or your current system user. See core/tests/README.md and
+ https://www.drupal.org/node/2116263 for details.
+-->
+<phpunit bootstrap="tests/bootstrap.php" colors="true"
+         beStrictAboutTestsThatDoNotTestAnything="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutChangesToGlobalState="true"
+         printerClass="\Drupal\Tests\Listeners\HtmlOutputPrinter">
+  <php>
+    <!-- Set error reporting to E_ALL. -->
+    <ini name="error_reporting" value="32767"/>
+    <!-- Do not limit the amount of memory tests take to run. -->
+    <ini name="memory_limit" value="-1"/>
+    <!-- Example SIMPLETEST_BASE_URL value: http://localhost -->
+    <env name="SIMPLETEST_BASE_URL" value="http://127.0.0.1:8282"/>
+    <!-- Example SIMPLETEST_DB value: mysql://username:password@localhost/databasename#table_prefix -->
+    <env name="SIMPLETEST_DB" value="mysql://drupal:drupal@127.0.0.1/drupal"/>
+    <!-- Example BROWSERTEST_OUTPUT_DIRECTORY value: /path/to/webroot/sites/simpletest/browser_output -->
+    <env name="BROWSERTEST_OUTPUT_DIRECTORY" value="../sites/simpletest/browser_output"/>
+    <!-- To have browsertest output use an alternative base URL. For example if
+     SIMPLETEST_BASE_URL is an internal DDEV URL, you can set this to the
+     external DDev URL so you can follow the links directly.
+    -->
+    <env name="BROWSERTEST_OUTPUT_BASE_URL" value=""/>
+    <!-- To disable deprecation testing completely uncomment the next line. -->
+    <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/>
+    <!-- Example for changing the driver class for mink tests MINK_DRIVER_CLASS value: 'Drupal\FunctionalJavascriptTests\DrupalSelenium2Driver' -->
+    <env name="MINK_DRIVER_CLASS" value=''/>
+    <!-- Example for changing the driver args to mink tests MINK_DRIVER_ARGS value: '["http://127.0.0.1:8510"]' -->
+    <env name="MINK_DRIVER_ARGS" value=''/>
+    <!-- Example for changing the driver args to phantomjs tests MINK_DRIVER_ARGS_PHANTOMJS value: '["http://127.0.0.1:8510"]' -->
+    <env name="MINK_DRIVER_ARGS_PHANTOMJS" value=''/>
+    <!-- Example for changing the driver args to webdriver tests MINK_DRIVER_ARGS_WEBDRIVER value: '["chrome", { "chromeOptions": { "w3c": false } }, "http://localhost:4444/wd/hub"]' For using the Firefox browser, replace "chrome" with "firefox" -->
+    <env name="MINK_DRIVER_ARGS_WEBDRIVER" value=''/>
+  </php>
+  <testsuites>
+    <testsuite name="unit">
+    </testsuite>
+    <testsuite name="kernel">
+      <directory>../modules/contrib/islandora/tests/src/Kernel</directory>
+      <directory>../modules/contrib/islandora/modules/*/tests/src/Kernel</directory>
+    </testsuite>
+    <testsuite name="functional">
+      <directory>../modules/contrib/islandora/tests/src/Functional</directory>
+      <directory>../modules/contrib/isladnora/modules/*/tests/src/Functional</directory>
+    </testsuite>
+    <testsuite name="functional-javascript">
+      <directory>../modules/contrib/islandora/tests/src/FunctionalJavascript</directory>
+      <directory>../modules/contrib/islandora/modules/*/tests/src/FunctionalJavascript</directory>
+    </testsuite>
+    <testsuite name="build">
+    </testsuite>
+  </testsuites>
+  <listeners>
+    <listener class="\Drupal\Tests\Listeners\DrupalListener">
+    </listener>
+    <!-- The Symfony deprecation listener has to come after the Drupal listener -->
+    <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener">
+    </listener>
+  </listeners>
+  <!-- Filter for coverage reports. -->
+  <filter>
+    <whitelist>
+      <directory>./includes</directory>
+      <directory>./lib</directory>
+      <!-- Extensions can have their own test directories, so exclude those. -->
+      <directory>./modules</directory>
+      <exclude>
+        <directory>./modules/*/src/Tests</directory>
+        <directory>./modules/*/tests</directory>
+      </exclude>
+      <directory>../modules</directory>
+      <exclude>
+        <directory>../modules/*/src/Tests</directory>
+        <directory>../modules/*/tests</directory>
+        <directory>../modules/*/*/src/Tests</directory>
+        <directory>../modules/*/*/tests</directory>
+      </exclude>
+      <directory>../sites</directory>
+     </whitelist>
+  </filter>
+</phpunit>

--- a/tests/src/Functional/IslandoraFunctionalTestBase.php
+++ b/tests/src/Functional/IslandoraFunctionalTestBase.php
@@ -23,7 +23,12 @@ class IslandoraFunctionalTestBase extends BrowserTestBase {
   /**
    * {@inheritdoc}
    */
-  protected static $modules = ['context_ui', 'field_ui', 'islandora'];
+  protected static $modules = [
+    'context_ui',
+    'field_ui',
+    'islandora',
+    'menu_link_content',
+  ];
 
   /**
    * {@inheritdoc}


### PR DESCRIPTION
**JIRA Ticket**: n/a

# What does this Pull Request do?

Switches up our travis testing to use PHPUnit directly instead of the Drupal `run-tests` script. This allows us to define testsuites and break up the actual testing into smaller chunks.

It also disables xdebug as we are not tracking code coverage in the Drupal modules so this should make it a little faster.

# What's new?
A new custom `phpunit.xml` which is copied to Drupal root and then PHPUnit is run calling one of the "testsuite" names defined inside.

# How should this be tested?

Travis will be 
![Super green](https://www.neatorama.com/images/2014-04/SUPER-GREEN-l.jpg)

# Interested parties
@Islandora/7-x-1-x-committers specifically @rosiel and @dannylamb 
