### PR TITLE
Use islandora_ci for scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
   - cd $DRUPAL_DIR;
   - chmod -R u+w web/sites/default
   - COMPOSER_MEMORY_LIMIT=-1 php -d memory_limit=-1 $COMPOSER_PATH config repositories.local path "$TRAVIS_BUILD_DIR"
-  - COMPOSER_MEMORY_LIMIT=-1 php -d memory_limit=-1 $COMPOSER_PATH require "islandora/islandora:dev-travis-testing as dev-8.x-1.x" --prefer-source --update-with-dependencies
+  - COMPOSER_MEMORY_LIMIT=-1 php -d memory_limit=-1 $COMPOSER_PATH require "islandora/islandora:dev-travis-testing as dev-8.x-1.x" --prefer-source --update-with-all-dependencies
   - cd web
   - drush --uri=127.0.0.1:8282 en -y islandora_audio islandora_breadcrumbs islandora_iiif islandora_image islandora_video islandora_text_extraction_defaults
   - drush --uri=127.0.0.1:8282 fim -y islandora_core_feature,islandora_text_extraction_defaults

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,14 +23,14 @@ branches:
     - /master/
 
 before_install:
-  - export SCRIPT_DIR=$HOME/islandora/.scripts
+  - export SCRIPT_DIR=$HOME/islandora_ci
   - export DRUPAL_DIR=/opt/drupal
   - export PHPUNIT_FILE=$TRAVIS_BUILD_DIR/phpunit.xml
   - export COMPOSER_PATH="/home/travis/.phpenv/versions/$TRAVIS_PHP_VERSION/bin/composer"
   - phpenv config-rm xdebug.ini
 
 install:
-  - git clone https://github.com/Islandora/documentation.git $HOME/islandora
+  - git clone https://github.com/Islandora/islandora_ci.git $HOME/islandora_ci
   - $SCRIPT_DIR/travis_setup_drupal.sh
   - git -C "$TRAVIS_BUILD_DIR" checkout -b travis-testing
   - cd $DRUPAL_DIR;


### PR DESCRIPTION
**JIRA Ticket**: Part of https://github.com/Islandora/documentation/pull/1672, which is meant to clear out Islandora/documenation so that it can have looser merging privileges

# What does this Pull Request do?

Uses the newly extracted Islandora/islandora_ci for travis scripts instead of Islandora/documentation.

# How should this be tested?

Travis should be green.

# Interested parties
@Islandora/8-x-committers
