### PR TITLE
Add Solr option for Orphaned Objects list

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -133,8 +133,8 @@ function islandora_repository_admin(array $form, array &$form_state) {
           '#description' => t('How the Orphaned Islandora Objects list is generated.'),
           '#default_value' => variable_get('islandora_orphaned_objects_backend', 'SPARQL'),
           '#options' => array(
-              'Solr' => t('Solr'),
-              'SPARQL' => t('SPARQL'),
+            'Solr' => t('Solr'),
+            'SPARQL' => t('SPARQL'),
           ),
         ),
         'islandora_risearch_use_itql_when_necessary' => array(

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -131,7 +131,7 @@ function islandora_repository_admin(array $form, array &$form_state) {
           '#type' => 'radios',
           '#title' => t('Orphaned Objects query'),
           '#description' => t('How the Orphaned Islandora Objects list is generated.'),
-          '#default_value' => variable_get('islandora_orphaned_objects_backend', 'Solr'),
+          '#default_value' => variable_get('islandora_orphaned_objects_backend', 'SPARQL'),
           '#options' => array(
               'Solr' => t('Solr'),
               'SPARQL' => t('SPARQL'),

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -127,6 +127,16 @@ function islandora_repository_admin(array $form, array &$form_state) {
             ),
           ),
         ),
+        'islandora_orphaned_objects_backend' => array(
+          '#type' => 'radios',
+          '#title' => t('Orphaned Objects query'),
+          '#description' => t('How the Orphaned Islandora Objects list is generated.'),
+          '#default_value' => variable_get('islandora_orphaned_objects_backend', 'Solr'),
+          '#options' => array(
+              'Solr' => t('Solr'),
+              'SPARQL' => t('SPARQL'),
+          ),
+        ),
         'islandora_risearch_use_itql_when_necessary' => array(
           '#type' => 'checkbox',
           '#title' => t('Use iTQL for particular queries'),

--- a/includes/orphaned_objects.inc
+++ b/includes/orphaned_objects.inc
@@ -195,26 +195,47 @@ function islandora_get_orphaned_objects() {
     }
 
     $orphaned_objects = array();
-
+    $already_checked = array();
+    $dead_parents = array();
     // Check all results for PIDs that don't exist.
     foreach ($results AS $result) {
       if (array_key_exists($collection_field, $result['solr_doc'])) {
         foreach ($result['solr_doc'][$collection_field] AS $collection) {
-          $test = islandora_object_load($collection);
-          if (!$test) {
-            $orphaned_objects[] = $result;
+          if (in_array($collection, $dead_parents)) {
+              $orphaned_objects[] = $result;
+          }
+          elseif (!in_array($collection, $already_checked)) {
+            $test = islandora_object_load($collection);
+            if (!$test) {
+              $orphaned_objects[] = $result;
+              $dead_parents[] = $collection;
+            }
+            $already_checked[] = $collection;
           }
         }
       }
       if (array_key_exists($member_field, $result['solr_doc'])) {
         foreach ($result['solr_doc'][$member_field] AS $membership) {
-          $test = islandora_object_load($membership);
-          if (!$test) {
-            $orphaned_objects[] = $result;
+          if (in_array($membership, $dead_parents)) {
+              $orphaned_objects[] = $result;
+          }
+          elseif (!in_array($membership, $already_checked)) {
+            $test = islandora_object_load($membership);
+            if (!$test) {
+              $orphaned_objects[] = $result;
+              $dead_parents[] = $membership;
+            }
+            $already_checked[] = $membership;
           }
         }
       }
-    }  
+    }
+dd("List of orphans");
+dd($orphaned_objects);
+dd("List of dead parents");
+dd($dead_parents);
+dd("List of checked parents");
+dd($already_checked);
   $results = $orphaned_objects;
   }
 

--- a/includes/orphaned_objects.inc
+++ b/includes/orphaned_objects.inc
@@ -193,7 +193,6 @@ function islandora_get_orphaned_objects() {
       watchdog_exception('Islandora', $e, 'Got an exception searching for parent objects .', array(), WATCHDOG_ERROR);
       $results = array();
     }
-
     $orphaned_objects = array();
     $already_checked = array();
     $dead_parents = array();

--- a/includes/orphaned_objects.inc
+++ b/includes/orphaned_objects.inc
@@ -194,9 +194,9 @@ function islandora_get_orphaned_objects() {
     $already_checked = array();
     $missing_parents = array();
     // Check all results for PIDs that don't exist.
-    foreach ($results AS $result) {
+    foreach ($results as $result) {
       if (array_key_exists($collection_field, $result['solr_doc'])) {
-        foreach ($result['solr_doc'][$collection_field] AS $collection) {
+        foreach ($result['solr_doc'][$collection_field] as $collection) {
           if (in_array($collection, $missing_parents)) {
             $orphaned_objects[] = $result;
           }
@@ -211,7 +211,7 @@ function islandora_get_orphaned_objects() {
         }
       }
       if (array_key_exists($member_field, $result['solr_doc'])) {
-        foreach ($result['solr_doc'][$member_field] AS $membership) {
+        foreach ($result['solr_doc'][$member_field] as $membership) {
           if (in_array($membership, $missing_parents)) {
             $orphaned_objects[] = $result;
           }

--- a/includes/orphaned_objects.inc
+++ b/includes/orphaned_objects.inc
@@ -204,7 +204,7 @@ function islandora_get_orphaned_objects() {
             $orphaned_objects[] = $result;
           }
           elseif (!in_array($collection, $already_checked)) {
-            $test = islandora_object_load($collection);
+            $test = islandora_identify_dead_parents($collection);
             if (!$test) {
               $orphaned_objects[] = $result;
               $dead_parents[] = $collection;
@@ -219,7 +219,8 @@ function islandora_get_orphaned_objects() {
             $orphaned_objects[] = $result;
           }
           elseif (!in_array($membership, $already_checked)) {
-            $test = islandora_object_load($membership);
+$test=islandora_object_load($membership);
+            $test = islandora_identify_dead_parents($membership);
             if (!$test) {
               $orphaned_objects[] = $result;
               $dead_parents[] = $membership;
@@ -292,6 +293,7 @@ EOQ;
     ));
     $results = $connection->repository->ri->sparqlQuery($sparql_query_objects);
   }
+dd($results);
   return $results;
 }
 
@@ -319,6 +321,30 @@ function islandora_delete_orphaned_objects_create_batch(array $pids) {
   );
   return $batch;
 }
+
+/**
+ * Solr query to check for deceased parents.
+ *
+ */
+function islandora_identify_dead_parents($parent) {
+            $parent_params = "PID";
+            $parent_test = substr($parent, strpos($parent, '/') +1);
+            $parent_query = 'PID:"' . $parent_test . '"';
+            $qp = new islandoraSolrQueryProcessor();
+            $qp->buildQuery($parent_query);
+            $qp->solrParams['fl'] = $parent_params;
+            $qp->solrLimit = 1000000000;
+            $qp->executeQuery(FALSE);
+            try {
+              $parent_results = $qp->islandoraSolrResult['response']['objects'];
+            }
+            catch (Exception $e) {
+              watchdog_exception('Islandora', $e, 'Got an exception searching for parent objects .', array(), WATCHDOG_ERROR);
+              $parent_results = array();
+            }
+  return($parent_results);
+}
+
 
 /**
  * Constructs and performs the deleting batch operation.

--- a/includes/orphaned_objects.inc
+++ b/includes/orphaned_objects.inc
@@ -169,7 +169,7 @@ function islandora_get_orphaned_objects() {
     $qp->solrParams['fl'] = $params;
     $qp->solrLimit = 1000000000;
 
-    // Check islandora_compound_object filters, include compound children if necessary.
+    // Check islandora_compound_object filters to include compound children.
     if (variable_get('islandora_compound_object_hide_child_objects_solr', TRUE)) {
       $fq = variable_get('islandora_compound_object_solr_fq', '-RELS_EXT_isConstituentOf_uri_mt:[* TO *]');
       if (!empty($fq)) {
@@ -319,11 +319,10 @@ function islandora_delete_orphaned_objects_create_batch(array $pids) {
 
 /**
  * Solr query to check for deceased parents.
- *
  */
 function islandora_identify_missing_parents($parent) {
   $parent_params = "PID";
-  $parent_test = substr($parent, strpos($parent, '/') +1);
+  $parent_test = substr($parent, strpos($parent, '/') + 1);
   $parent_query = 'PID:"' . $parent_test . '"';
   $qp = new islandoraSolrQueryProcessor();
   $qp->buildQuery($parent_query);
@@ -337,7 +336,7 @@ function islandora_identify_missing_parents($parent) {
     watchdog_exception('Islandora', $e, 'Got an exception searching for parent objects .', array(), WATCHDOG_ERROR);
     $parent_results = array();
   }
-  return($parent_results);
+  return ($parent_results);
 }
 
 

--- a/includes/orphaned_objects.inc
+++ b/includes/orphaned_objects.inc
@@ -54,23 +54,20 @@ function islandora_manage_orphaned_objects_form(array $form, array $form_state) 
     or a variety of other reasons. Some of these orphans may exist intentionally.
     Please be cautious when deleting, as this action is irreversible.'), 'warning');
     $orphaned_objects = islandora_get_orphaned_objects();
-    $query_method = variable_get('islandora_orphaned_objects_backend', 'Solr');
+    $query_method = variable_get('islandora_orphaned_objects_backend', 'SPARQL');
     module_load_include('inc', 'islandora', 'includes/utilities');
     $rows = array();
     foreach ($orphaned_objects as $orphaned_object) {
       if ($query_method == 'SPARQL') {
         $pid = $orphaned_object['object']['value'];
+        $title = $orphaned_object['title']['value'];
       }
       elseif ($query_method == 'Solr') {
         $pid = $orphaned_object['PID'];
+        $title = $orphaned_object['object_label'];
       }
       if (islandora_namespace_accessible($pid)) {
-        if ($query_method == 'SPARQL') {
-          $rows[$pid] = array(l($orphaned_object['title']['value'] . " (" . $pid . ")", "islandora/object/$pid"));
-        }
-        elseif ($query_method == 'Solr') {
-          $rows[$pid] = array(l($orphaned_object['object_label'] . " (" . $pid . ")", "islandora/object/$pid"));
-        }
+        $rows[$pid] = array(l($title . " (" . $pid . ")", "islandora/object/$pid"));
       }
     }
     ksort($rows);
@@ -156,7 +153,7 @@ function islandora_manage_orphaned_objects_confirm_submit(array $form, array &$f
  *   An array containing the results of the orphaned objects queries.
  */
 function islandora_get_orphaned_objects() {
-  $query_method = variable_get('islandora_orphaned_objects_backend', 'Solr');
+  $query_method = variable_get('islandora_orphaned_objects_backend', 'SPARQL');
 
   if ($query_method == 'Solr') {
     // Solr query for all objects.
@@ -195,19 +192,19 @@ function islandora_get_orphaned_objects() {
     }
     $orphaned_objects = array();
     $already_checked = array();
-    $dead_parents = array();
+    $missing_parents = array();
     // Check all results for PIDs that don't exist.
     foreach ($results AS $result) {
       if (array_key_exists($collection_field, $result['solr_doc'])) {
         foreach ($result['solr_doc'][$collection_field] AS $collection) {
-          if (in_array($collection, $dead_parents)) {
+          if (in_array($collection, $missing_parents)) {
             $orphaned_objects[] = $result;
           }
           elseif (!in_array($collection, $already_checked)) {
-            $test = islandora_identify_dead_parents($collection);
+            $test = islandora_identify_missing_parents($collection);
             if (!$test) {
               $orphaned_objects[] = $result;
-              $dead_parents[] = $collection;
+              $missing_parents[] = $collection;
             }
             $already_checked[] = $collection;
           }
@@ -215,14 +212,14 @@ function islandora_get_orphaned_objects() {
       }
       if (array_key_exists($member_field, $result['solr_doc'])) {
         foreach ($result['solr_doc'][$member_field] AS $membership) {
-          if (in_array($membership, $dead_parents)) {
+          if (in_array($membership, $missing_parents)) {
             $orphaned_objects[] = $result;
           }
           elseif (!in_array($membership, $already_checked)) {
-            $test = islandora_identify_dead_parents($membership);
+            $test = islandora_identify_missing_parents($membership);
             if (!$test) {
               $orphaned_objects[] = $result;
-              $dead_parents[] = $membership;
+              $missing_parents[] = $membership;
             }
             $already_checked[] = $membership;
           }
@@ -324,7 +321,7 @@ function islandora_delete_orphaned_objects_create_batch(array $pids) {
  * Solr query to check for deceased parents.
  *
  */
-function islandora_identify_dead_parents($parent) {
+function islandora_identify_missing_parents($parent) {
   $parent_params = "PID";
   $parent_test = substr($parent, strpos($parent, '/') +1);
   $parent_query = 'PID:"' . $parent_test . '"';

--- a/includes/orphaned_objects.inc
+++ b/includes/orphaned_objects.inc
@@ -159,7 +159,7 @@ function islandora_get_orphaned_objects() {
   $query_method = variable_get('islandora_orphaned_objects_backend', 'Solr');
 
   if ($query_method == 'Solr') {
-    // Step 1: Solr query for the RELS_EXTs
+    // Solr query for all objects.
     $collection_field = variable_get('islandora_solr_member_of_collection_field', 'RELS_EXT_isMemberOfCollection_uri_ms');
     $label_field = variable_get('islandora_solr_object_label_field', 'fgs_label_s');
     $member_field = variable_get('islandora_solr_member_of_field', 'RELS_EXT_isMemberOf_uri_ms');
@@ -171,6 +171,7 @@ function islandora_get_orphaned_objects() {
     $qp->buildQuery($query);
     $qp->solrParams['fl'] = $params;
     $qp->solrLimit = 1000000000;
+
     // Check islandora_compound_object settings and changes query filters to include compound children if necessary.
     if (variable_get('islandora_compound_object_hide_child_objects_solr', TRUE)) {
       $fq = variable_get('islandora_compound_object_solr_fq', '-RELS_EXT_isConstituentOf_uri_mt:[* TO *]');
@@ -195,9 +196,7 @@ function islandora_get_orphaned_objects() {
 
     $orphaned_objects = array();
 
-  // Now we have $results[key]['PID'] for the pid. sparql: [key][object][value] and [key][title][value]
-  // Step 2: Check all results for PIDs that don't exist
-
+    // Check all results for PIDs that don't exist.
     foreach ($results AS $result) {
       if (array_key_exists($collection_field, $result['solr_doc'])) {
         foreach ($result['solr_doc'][$collection_field] AS $collection) {

--- a/includes/orphaned_objects.inc
+++ b/includes/orphaned_objects.inc
@@ -54,11 +54,23 @@ function islandora_manage_orphaned_objects_form(array $form, array $form_state) 
     or a variety of other reasons. Some of these orphans may exist intentionally.
     Please be cautious when deleting, as this action is irreversible.'), 'warning');
     $orphaned_objects = islandora_get_orphaned_objects();
+    $query_method = variable_get('islandora_orphaned_objects_backend', 'Solr');
+
     $rows = array();
     foreach ($orphaned_objects as $orphaned_object) {
-      $pid = $orphaned_object['object']['value'];
+      if ($query_method == 'SPARQL') {
+        $pid = $orphaned_object['object']['value'];
+      }
+      elseif ($query_method == 'Solr') {
+        $pid = $orphaned_object['PID'];
+      }
       if (islandora_namespace_accessible($pid)) {
-        $rows[$pid] = array(l($orphaned_object['title']['value'] . " (" . $pid . ")", "islandora/object/$pid"));
+        if ($query_method == 'SPARQL') {
+          $rows[$pid] = array(l($orphaned_object['title']['value'] . " (" . $pid . ")", "islandora/object/$pid"));
+        }
+        elseif ($query_method == 'Solr') {
+          $rows[$pid] = array(l($orphaned_object['object_label'] . " (" . $pid . ")", "islandora/object/$pid"));
+        }
       }
     }
     ksort($rows);
@@ -144,9 +156,73 @@ function islandora_manage_orphaned_objects_confirm_submit(array $form, array &$f
  *   An array containing the results of the orphaned objects queries.
  */
 function islandora_get_orphaned_objects() {
-  $connection = islandora_get_tuque_connection();
-  // SPARQL: get orphaned objects, exclude any with a living parent.
-  $object_query = <<<EOQ
+  $query_method = variable_get('islandora_orphaned_objects_backend', 'Solr');
+
+  if ($query_method == 'Solr') {
+    // Step 1: Solr query for the RELS_EXTs
+    $collection_field = variable_get('islandora_solr_member_of_collection_field', 'RELS_EXT_isMemberOfCollection_uri_ms');
+    $label_field = variable_get('islandora_solr_object_label_field', 'fgs_label_s');
+    $member_field = variable_get('islandora_solr_member_of_field', 'RELS_EXT_isMemberOf_uri_ms');
+
+    $params = "PID, " . $label_field . ", " . $collection_field . ", " . $member_field;
+
+    $query = "PID:*";
+    $qp = new islandoraSolrQueryProcessor();
+    $qp->buildQuery($query);
+    $qp->solrParams['fl'] = $params;
+    $qp->solrLimit = 1000000000;
+    // Check islandora_compound_object settings and changes query filters to include compound children if necessary.
+    if (variable_get('islandora_compound_object_hide_child_objects_solr', TRUE)) {
+      $fq = variable_get('islandora_compound_object_solr_fq', '-RELS_EXT_isConstituentOf_uri_mt:[* TO *]');
+      if (!empty($fq)) {
+      // delete islandora_compound_object_solr_fq from the list of filters
+        $filters = $qp->solrParams['fq'];
+        if (($key = array_search($fq, $filters)) !== FALSE) {
+          unset($filters[$key]);
+          $qp->solrParams['fq'] = $filters;
+        }
+      }
+    }
+    $qp->executeQuery(FALSE);
+
+    try {
+      $results = $qp->islandoraSolrResult['response']['objects'];
+    }
+    catch (Exception $e) {
+      watchdog_exception('Islandora', $e, 'Got an exception searching for parent objects .', array(), WATCHDOG_ERROR);
+      $results = array();
+    }
+
+    $orphaned_objects = array();
+
+  // Now we have $results[key]['PID'] for the pid. sparql: [key][object][value] and [key][title][value]
+  // Step 2: Check all results for PIDs that don't exist
+
+    foreach ($results AS $result) {
+      if (array_key_exists($collection_field, $result['solr_doc'])) {
+        foreach ($result['solr_doc'][$collection_field] AS $collection) {
+          $test = islandora_object_load($collection);
+          if (!$test) {
+            $orphaned_objects[] = $result;
+          }
+        }
+      }
+      if (array_key_exists($member_field, $result['solr_doc'])) {
+        foreach ($result['solr_doc'][$member_field] AS $membership) {
+          $test = islandora_object_load($membership);
+          if (!$test) {
+            $orphaned_objects[] = $result;
+          }
+        }
+      }
+    }  
+  $results = $orphaned_objects;
+  }
+
+  elseif($query_method == "SPARQL") {
+    $connection = islandora_get_tuque_connection();
+    // SPARQL: get orphaned objects, exclude any with a living parent.
+    $object_query = <<<EOQ
 !prefix
 SELECT DISTINCT ?object ?title 
 WHERE {
@@ -171,37 +247,38 @@ WHERE {
   FILTER (!bound(?liveparent))
 } ORDER BY ?object
 EOQ;
-  $parent_relationships = module_invoke_all('islandora_solution_pack_child_relationships', 'all');
-  $parent_relationships['prefix'] = array_unique($parent_relationships['prefix']);
-  $parent_relationships['predicate'] = array_unique($parent_relationships['predicate']);
-  if (count($parent_relationships['predicate']) == 0) {
-    // No predicates to search for. Exit early.
-    return array();
+    $parent_relationships = module_invoke_all('islandora_solution_pack_child_relationships', 'all');
+    $parent_relationships['prefix'] = array_unique($parent_relationships['prefix']);
+    $parent_relationships['predicate'] = array_unique($parent_relationships['predicate']);
+    if (count($parent_relationships['predicate']) == 0) {
+      // No predicates to search for. Exit early.
+      return array();
+    }
+    $optionals = (array) module_invoke('islandora_xacml_api', 'islandora_basic_collection_get_query_optionals', 'view');
+    $filter_modules = array(
+      'islandora_xacml_api',
+      'islandora',
+    );
+    $filters = array();
+    foreach ($filter_modules as $module) {
+      $filters = array_merge_recursive($filters, (array) module_invoke($module, 'islandora_basic_collection_get_query_filters', 'view'));
+    }
+    $filter_map = function ($filter) {
+      return "FILTER($filter)";
+    };
+    $parent_map = function ($parent) {
+      return "?object $parent ?liveparent";
+    };
+    // Use separate queries for different object types.
+    $sparql_query_objects = format_string($object_query, array(
+      '!optionals' => !empty($optionals) ? ('OPTIONAL {{' . implode('} UNION {', $optionals) . '}}') : '',
+      '!filters' => !empty($filters) ? implode(' ', array_map($filter_map, $filters)) : '',
+      '!dead_parent_relationships' => '?p = ' . implode(' || ?p = ', $parent_relationships['predicate']),
+      '!live_parent_relationships' => '{' . implode(' } UNION { ', array_map($parent_map, $parent_relationships['predicate'])) . '}',
+      '!prefix' => implode("\n", $parent_relationships['prefix']),
+    ));
+    $results = $connection->repository->ri->sparqlQuery($sparql_query_objects);
   }
-  $optionals = (array) module_invoke('islandora_xacml_api', 'islandora_basic_collection_get_query_optionals', 'view');
-  $filter_modules = array(
-    'islandora_xacml_api',
-    'islandora',
-  );
-  $filters = array();
-  foreach ($filter_modules as $module) {
-    $filters = array_merge_recursive($filters, (array) module_invoke($module, 'islandora_basic_collection_get_query_filters', 'view'));
-  }
-  $filter_map = function ($filter) {
-    return "FILTER($filter)";
-  };
-  $parent_map = function ($parent) {
-    return "?object $parent ?liveparent";
-  };
-  // Use separate queries for different object types.
-  $sparql_query_objects = format_string($object_query, array(
-    '!optionals' => !empty($optionals) ? ('OPTIONAL {{' . implode('} UNION {', $optionals) . '}}') : '',
-    '!filters' => !empty($filters) ? implode(' ', array_map($filter_map, $filters)) : '',
-    '!dead_parent_relationships' => '?p = ' . implode(' || ?p = ', $parent_relationships['predicate']),
-    '!live_parent_relationships' => '{' . implode(' } UNION { ', array_map($parent_map, $parent_relationships['predicate'])) . '}',
-    '!prefix' => implode("\n", $parent_relationships['prefix']),
-  ));
-  $results = $connection->repository->ri->sparqlQuery($sparql_query_objects);
   return $results;
 }
 

--- a/includes/orphaned_objects.inc
+++ b/includes/orphaned_objects.inc
@@ -172,11 +172,11 @@ function islandora_get_orphaned_objects() {
     $qp->solrParams['fl'] = $params;
     $qp->solrLimit = 1000000000;
 
-    // Check islandora_compound_object settings and changes query filters to include compound children if necessary.
+    // Check islandora_compound_object filters, include compound children if necessary.
     if (variable_get('islandora_compound_object_hide_child_objects_solr', TRUE)) {
       $fq = variable_get('islandora_compound_object_solr_fq', '-RELS_EXT_isConstituentOf_uri_mt:[* TO *]');
       if (!empty($fq)) {
-      // delete islandora_compound_object_solr_fq from the list of filters
+        // Delete islandora_compound_object_solr_fq from the list of filters.
         $filters = $qp->solrParams['fq'];
         if (($key = array_search($fq, $filters)) !== FALSE) {
           unset($filters[$key]);
@@ -202,7 +202,7 @@ function islandora_get_orphaned_objects() {
       if (array_key_exists($collection_field, $result['solr_doc'])) {
         foreach ($result['solr_doc'][$collection_field] AS $collection) {
           if (in_array($collection, $dead_parents)) {
-              $orphaned_objects[] = $result;
+            $orphaned_objects[] = $result;
           }
           elseif (!in_array($collection, $already_checked)) {
             $test = islandora_object_load($collection);
@@ -217,7 +217,7 @@ function islandora_get_orphaned_objects() {
       if (array_key_exists($member_field, $result['solr_doc'])) {
         foreach ($result['solr_doc'][$member_field] AS $membership) {
           if (in_array($membership, $dead_parents)) {
-              $orphaned_objects[] = $result;
+            $orphaned_objects[] = $result;
           }
           elseif (!in_array($membership, $already_checked)) {
             $test = islandora_object_load($membership);
@@ -230,16 +230,10 @@ function islandora_get_orphaned_objects() {
         }
       }
     }
-dd("List of orphans");
-dd($orphaned_objects);
-dd("List of dead parents");
-dd($dead_parents);
-dd("List of checked parents");
-dd($already_checked);
-  $results = $orphaned_objects;
+    $results = $orphaned_objects;
   }
 
-  elseif($query_method == "SPARQL") {
+  elseif ($query_method == "SPARQL") {
     $connection = islandora_get_tuque_connection();
     // SPARQL: get orphaned objects, exclude any with a living parent.
     $object_query = <<<EOQ

--- a/includes/orphaned_objects.inc
+++ b/includes/orphaned_objects.inc
@@ -55,7 +55,7 @@ function islandora_manage_orphaned_objects_form(array $form, array $form_state) 
     Please be cautious when deleting, as this action is irreversible.'), 'warning');
     $orphaned_objects = islandora_get_orphaned_objects();
     $query_method = variable_get('islandora_orphaned_objects_backend', 'Solr');
-
+    module_load_include('inc', 'islandora', 'includes/utilities');
     $rows = array();
     foreach ($orphaned_objects as $orphaned_object) {
       if ($query_method == 'SPARQL') {
@@ -219,7 +219,6 @@ function islandora_get_orphaned_objects() {
             $orphaned_objects[] = $result;
           }
           elseif (!in_array($membership, $already_checked)) {
-$test=islandora_object_load($membership);
             $test = islandora_identify_dead_parents($membership);
             if (!$test) {
               $orphaned_objects[] = $result;
@@ -293,7 +292,6 @@ EOQ;
     ));
     $results = $connection->repository->ri->sparqlQuery($sparql_query_objects);
   }
-dd($results);
   return $results;
 }
 
@@ -327,21 +325,21 @@ function islandora_delete_orphaned_objects_create_batch(array $pids) {
  *
  */
 function islandora_identify_dead_parents($parent) {
-            $parent_params = "PID";
-            $parent_test = substr($parent, strpos($parent, '/') +1);
-            $parent_query = 'PID:"' . $parent_test . '"';
-            $qp = new islandoraSolrQueryProcessor();
-            $qp->buildQuery($parent_query);
-            $qp->solrParams['fl'] = $parent_params;
-            $qp->solrLimit = 1000000000;
-            $qp->executeQuery(FALSE);
-            try {
-              $parent_results = $qp->islandoraSolrResult['response']['objects'];
-            }
-            catch (Exception $e) {
-              watchdog_exception('Islandora', $e, 'Got an exception searching for parent objects .', array(), WATCHDOG_ERROR);
-              $parent_results = array();
-            }
+  $parent_params = "PID";
+  $parent_test = substr($parent, strpos($parent, '/') +1);
+  $parent_query = 'PID:"' . $parent_test . '"';
+  $qp = new islandoraSolrQueryProcessor();
+  $qp->buildQuery($parent_query);
+  $qp->solrParams['fl'] = $parent_params;
+  $qp->solrLimit = 1000000000;
+  $qp->executeQuery(FALSE);
+  try {
+    $parent_results = $qp->islandoraSolrResult['response']['objects'];
+  }
+  catch (Exception $e) {
+    watchdog_exception('Islandora', $e, 'Got an exception searching for parent objects .', array(), WATCHDOG_ERROR);
+    $parent_results = array();
+  }
   return($parent_results);
 }
 

--- a/islandora.install
+++ b/islandora.install
@@ -59,6 +59,7 @@ function islandora_uninstall() {
     'islandora_semaphore_period',
     'islandora_require_obj_upload',
     'islandora_breadcrumbs_backends',
+    'islandora_orphaned_objects_backend',
     'islandora_render_context_ingeststep',
     'islandora_deny_inactive_and_deleted',
   );

--- a/tests/datastream_validator_tests.test
+++ b/tests/datastream_validator_tests.test
@@ -224,7 +224,7 @@ class PrefixDatastreamValidatorTestCase extends IslandoraWebTestCase {
       'dsid' => $prefix,
       'path' => $this->path . $filename,
       'control_group' => 'M',
-    ),
+      ),
     );
     $object = $this->ingestConstructedObject(array(), $datastreams);
     return $object;

--- a/tests/scripts/travis_setup.sh
+++ b/tests/scripts/travis_setup.sh
@@ -42,7 +42,7 @@ if [ "$(phpenv version-name)" == "5.3.3" ]; then
   composer global require drupal/coder:7.*
 else
   composer global require drush/drush:7.*
-  composer global require drupal/coder
+  composer global require drupal/coder:7.*
 fi
 
 # Symlink the things


### PR DESCRIPTION
**JIRA Ticket**: (https://jira.lyrasis.org/browse/ISLANDORA-2520)

# What does this Pull Request do?

Allows you to query Solr instead of Fedora to generate the list of orphaned objects.

# What's new?
* New Islandora Config option (choose between SPARQL and Solr)
* Query for orphaned objects can use Solr now

In large repositories, querying the RI for the orphaned objects list is extremely resource-intensive and can cause timeouts and even crashes. This new approach allows you to get the same info from Solr, more quickly and less dangerously.

# How should this be tested?

1. Create some orphaned objects: delete a collection without deleting its children, and/or delete a newspaper without deleting issues. To do this, manage a parent collection, and use the Delete Child Objects option in the Collection tab to delete the child collection or newspaper.

2. Check the Orphaned Islandora Objects report (reports -> Orphaned Islandora Objects). You should see some orphans.

3. Check out this PR, set the query method to Solr in Islandora -> Configuration, and check the Orphaned Islandora Objects report again. You should see a functional list of Islandora objects. 

4. Switch to SPARQL and check again to make sure you aren't missing anything.

# Additional Notes:
I am not sure whether the `islandora_object_load` approach is the most efficient way to see whether a parent object exists. I am open to suggestions!

# Interested parties
@Islandora/7-x-1-x-committers, @whikloj @DiegoPino 
