### PR TITLE
Issue 1694: node_referenced_by_field condition plugin

### DIFF
--- a/islandora.module
+++ b/islandora.module
@@ -414,16 +414,17 @@ function islandora_form_block_form_alter(&$form, FormStateInterface $form_state,
   // /admin/structure/context instead if you want to use these conditions
   // to alter block layout.
   unset($form['visibility']['content_entity_type']);
-  unset($form['visibility']['parent_node_has_term']);
-  unset($form['visibility']['node_had_namespace']);
-  unset($form['visibility']['media_has_term']);
   unset($form['visibility']['file_uses_filesystem']);
-  unset($form['visibility']['node_has_term']);
-  unset($form['visibility']['node_has_parent']);
-  unset($form['visibility']['media_uses_filesystem']);
   unset($form['visibility']['media_has_mimetype']);
-  unset($form['visibility']['node_is_islandora_object']);
+  unset($form['visibility']['media_has_term']);
   unset($form['visibility']['media_is_islandora_media']);
+  unset($form['visibility']['media_uses_filesystem']);
+  unset($form['visibility']['node_had_namespace']);
+  unset($form['visibility']['node_has_parent']);
+  unset($form['visibility']['node_has_term']);
+  unset($form['visibility']['node_is_islandora_object']);
+  unset($form['visibility']['node_referenced_by_node']);
+  unset($form['visibility']['parent_node_has_term']);
 }
 
 /**

--- a/src/Plugin/Condition/NodeReferencedByField.php
+++ b/src/Plugin/Condition/NodeReferencedByField.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Drupal\islandora\Plugin\Condition;
+
+use Drupal\Core\Condition\ConditionPluginBase;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\field\Entity\FieldStorageConfig;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Condition to detect if is a node is referenced by a configured field.
+ *
+ * @Condition(
+ *   id = "node_referenced_by_field",
+ *   label = @Translation("Node referenced by field"),
+ *   context = {
+ *     "node" = @ContextDefinition("entity:node", required = TRUE , label = @Translation("node"))
+ *   }
+ * )
+ */
+class NodeReferencedByField extends ConditionPluginBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * Node storage.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Constructor.
+   *
+   * @param array $configuration
+   *   The plugin configuration, i.e. an array with configuration values keyed
+   *   by configuration option name. The special key 'context' may be used to
+   *   initialize the defined contexts by setting it to an array of context
+   *   values keyed by context names.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   Entity type manager.
+   */
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    EntityTypeManagerInterface $entity_type_manager
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration() {
+    return parent::defaultConfiguration() + [
+      'reference_field' => 'field_member_of',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
+    $field_map = \Drupal::service('entity_field.manager')->getFieldMapByFieldType('entity_reference');
+    $node_fields = array_keys($field_map['node']);
+    $options = array_combine($node_fields, $node_fields);
+    $form['reference_field'] = [
+      '#type' => 'select',
+      '#title' => t('Field to check for reference to this node'),
+      '#options' => $options,
+      '#default_value' => $this->configuration['reference_field'],
+      '#required' => TRUE,
+      '#description' => t("Machine name of field that should be checked for references to this node."),
+    ];
+
+    return parent::buildConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
+    $this->configuration['reference_field'] = $form_state->getValue('reference_field');
+    parent::submitConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function evaluate() {
+    $node = $this->getContextValue('node');
+    if (!$node) {
+      return FALSE;
+    }
+    return $this->evaluateEntity($node);
+  }
+
+  /**
+   * Evaluates if an entity is referenced in the configured node field.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity to evaluate.
+   *
+   * @return bool
+   *   TRUE if entity is referenced..
+   */
+  protected function evaluateEntity(EntityInterface $entity) {
+    $reference_field = $this->configuration['reference_field'];
+    $config = FieldStorageConfig::loadByName('node', $reference_field);
+    if ($config) {
+      $id_count = \Drupal::entityQuery('node')
+        ->condition($reference_field, $entity->id())
+        ->count()
+        ->execute();
+      return ($id_count > 0);
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function summary() {
+    if (!empty($this->configuration['negate'])) {
+      return $this->t('The node is not referenced in the field @field.', ['@field' => $this->configuration['reference_field']]);
+    }
+    else {
+      return $this->t('The node is referenced in the field @field.', ['@field' => $this->configuration['reference_field']]);
+    }
+  }
+
+}

--- a/src/Plugin/Condition/NodeReferencedByNode.php
+++ b/src/Plugin/Condition/NodeReferencedByNode.php
@@ -11,7 +11,7 @@ use Drupal\field\Entity\FieldStorageConfig;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Condition to detect if is a node is referenced by another node using the configured field.
+ * Condition for a node referenced by another node using the configured field.
  *
  * @Condition(
  *   id = "node_referenced_by_node",
@@ -140,10 +140,10 @@ class NodeReferencedByNode extends ConditionPluginBase implements ContainerFacto
    */
   public function summary() {
     if (!empty($this->configuration['negate'])) {
-      return $this->t('The node is not referenced in another node\'s field `@field`.', ['@field' => $this->configuration['reference_field']]);
+      return $this->t("The node is not referenced in another node's field `@field`.", ['@field' => $this->configuration['reference_field']]);
     }
     else {
-      return $this->t('The node is referenced in another node\'s field `@field`.', ['@field' => $this->configuration['reference_field']]);
+      return $this->t("The node is referenced in another node's field `@field`.", ['@field' => $this->configuration['reference_field']]);
     }
   }
 

--- a/src/Plugin/Condition/NodeReferencedByNode.php
+++ b/src/Plugin/Condition/NodeReferencedByNode.php
@@ -11,17 +11,17 @@ use Drupal\field\Entity\FieldStorageConfig;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Condition to detect if is a node is referenced by a configured field.
+ * Condition to detect if is a node is referenced by another node using the configured field.
  *
  * @Condition(
- *   id = "node_referenced_by_field",
- *   label = @Translation("Node referenced by field"),
+ *   id = "node_referenced_by_node",
+ *   label = @Translation("Node is referenced by other nodes"),
  *   context = {
  *     "node" = @ContextDefinition("entity:node", required = TRUE , label = @Translation("node"))
  *   }
  * )
  */
-class NodeReferencedByField extends ConditionPluginBase implements ContainerFactoryPluginInterface {
+class NodeReferencedByNode extends ConditionPluginBase implements ContainerFactoryPluginInterface {
 
   /**
    * Node storage.
@@ -140,10 +140,10 @@ class NodeReferencedByField extends ConditionPluginBase implements ContainerFact
    */
   public function summary() {
     if (!empty($this->configuration['negate'])) {
-      return $this->t('The node is not referenced in the field @field.', ['@field' => $this->configuration['reference_field']]);
+      return $this->t('The node is not referenced in another node\'s field `@field`.', ['@field' => $this->configuration['reference_field']]);
     }
     else {
-      return $this->t('The node is referenced in the field @field.', ['@field' => $this->configuration['reference_field']]);
+      return $this->t('The node is referenced in another node\'s field `@field`.', ['@field' => $this->configuration['reference_field']]);
     }
   }
 


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1694

# What does this Pull Request do?

Adds a context condition plugin to detect if is a node is referenced by the configured field. It can be used, for example, to determine if a node is referenced by field_member_of, useful for complex objects. It isn't currently *used* by any islandora contexts in islandora_defaults, but is being made available as a potentially useful condition.

**Sidenote: this plugin could be fairly easily modified to also include a count threshold, e.g. is referenced by at least *n* nodes... but that is a PR for another day.**

# What's new?

* Added the aforementioned context plugin.

# How should this be tested?

* Apply the PR
* clear the cache
* either modify the collection context to use this new condition with field_member_of, instead of the term-based one, or create a new complex object condition that does something (such as changing the theme).
* Create a node referenced another node (e.g. "Node A" referenced by "Node B").
* Visit the referenced node (e.g. "Node A" from before) and observe the configured condition take effect.

_Addendum:_
* _Visit the block placement UI to ensure it doesn't show up there._

# Interested parties
@Islandora/8-x-committers, esp @rosiel.