### PR TITLE
Add "islandora_models" terms for Compound and Newspaper

### DIFF
--- a/migrate/tags.csv
+++ b/migrate/tags.csv
@@ -15,3 +15,5 @@ islandora_models,"Digital Document","An electronic file or document.",https://sc
 islandora_models,"Paged Content","An Electronic Book, object with pages",https://schema.org/Book
 islandora_models,"Page","A page in an Electronic Paged Content Object",http://id.loc.gov/ontologies/bibframe/part
 islandora_models,"Publication Issue","A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.",https://schema.org/PublicationIssue
+islandora_models,"Compound Object","A special type of collection where the parent item may also have complex metadata",http://purl.org/coar/resource_type/c_1843
+islandora_models,"Newspaper","A special type of collection which only has Newspaper Issues for children.",https://schema.org/Newspaper

--- a/migrate/tags.csv
+++ b/migrate/tags.csv
@@ -15,5 +15,5 @@ islandora_models,"Digital Document","An electronic file or document.",https://sc
 islandora_models,"Paged Content","An Electronic Book, object with pages",https://schema.org/Book
 islandora_models,"Page","A page in an Electronic Paged Content Object",http://id.loc.gov/ontologies/bibframe/part
 islandora_models,"Publication Issue","A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.",https://schema.org/PublicationIssue
-islandora_models,"Compound Object","A special type of collection where the parent item may also have complex metadata",http://purl.org/coar/resource_type/c_1843
+islandora_models,"Compound Object","A special type of collection where the parent item may also have complex metadata",http://vocab.getty.edu/aat/300242735
 islandora_models,"Newspaper","A special type of collection which only has Newspaper Issues for children.",https://schema.org/Newspaper


### PR DESCRIPTION
Related to ongoing conversations about the need for System Models for both Compound Objects and Newspaper (parent objects, not issues. This PR contains two new entries for these types, but I expect others may have better URLs than I was able to come up with.