### PR TITLE
Exclude configured root from orphans list

### DIFF
--- a/includes/orphaned_objects.inc
+++ b/includes/orphaned_objects.inc
@@ -198,7 +198,7 @@ function islandora_get_orphaned_objects() {
     foreach ($results as $result) {
       if (array_key_exists($collection_field, $result['solr_doc'])) {
         foreach ($result['solr_doc'][$collection_field] as $collection) {
-          if (($result['PID'] != $root_pid) && ($collection != $root_pid_check) ) {
+          if (($result['PID'] != $root_pid) && ($collection != $root_pid_check)) {
             if (in_array($collection, $missing_parents)) {
               $orphaned_objects[] = $result;
             }

--- a/includes/orphaned_objects.inc
+++ b/includes/orphaned_objects.inc
@@ -198,19 +198,17 @@ function islandora_get_orphaned_objects() {
     foreach ($results as $result) {
       if (array_key_exists($collection_field, $result['solr_doc'])) {
         foreach ($result['solr_doc'][$collection_field] as $collection) {
-          if($result['PID'] != $root_pid) {
-            if ($collection != $root_pid_check) {
-              if (in_array($collection, $missing_parents)) {
+          if (($result['PID'] != $root_pid) && ($collection != $root_pid_check) ) {
+            if (in_array($collection, $missing_parents)) {
+              $orphaned_objects[] = $result;
+            }
+            elseif (!in_array($collection, $already_checked)) {
+              $test = islandora_identify_missing_parents($collection);
+              if (!$test) {
                 $orphaned_objects[] = $result;
+                $missing_parents[] = $collection;
               }
-              elseif (!in_array($collection, $already_checked)) {
-                $test = islandora_identify_missing_parents($collection);
-                if (!$test) {
-                  $orphaned_objects[] = $result;
-                  $missing_parents[] = $collection;
-                }
-                $already_checked[] = $collection;
-              }
+              $already_checked[] = $collection;
             }
           }
         }

--- a/includes/orphaned_objects.inc
+++ b/includes/orphaned_objects.inc
@@ -155,7 +155,7 @@ function islandora_manage_orphaned_objects_confirm_submit(array $form, array &$f
 function islandora_get_orphaned_objects() {
   $query_method = variable_get('islandora_orphaned_objects_backend', 'SPARQL');
   $root_pid = variable_get('islandora_repository_pid', 'islandora:root');
-  $root_pid = "info:fedora/" . $root_pid;
+  $root_pid_check = "info:fedora/" . $root_pid;
   if ($query_method == 'Solr') {
     // Solr query for all objects.
     $collection_field = variable_get('islandora_solr_member_of_collection_field', 'RELS_EXT_isMemberOfCollection_uri_ms');
@@ -198,17 +198,19 @@ function islandora_get_orphaned_objects() {
     foreach ($results as $result) {
       if (array_key_exists($collection_field, $result['solr_doc'])) {
         foreach ($result['solr_doc'][$collection_field] as $collection) {
-          if ($collection != $root_pid) {
-            if (in_array($collection, $missing_parents)) {
-              $orphaned_objects[] = $result;
-            }
-            elseif (!in_array($collection, $already_checked)) {
-              $test = islandora_identify_missing_parents($collection);
-              if (!$test) {
+          if($result['PID'] != $root_pid) {
+            if ($collection != $root_pid_check) {
+              if (in_array($collection, $missing_parents)) {
+                $orphaned_objects[] = $result;
+              }
+              elseif (!in_array($collection, $already_checked)) {
+                $test = islandora_identify_missing_parents($collection);
+                if (!$test) {
                   $orphaned_objects[] = $result;
                   $missing_parents[] = $collection;
+                }
+                $already_checked[] = $collection;
               }
-              $already_checked[] = $collection;
             }
           }
         }

--- a/includes/orphaned_objects.inc
+++ b/includes/orphaned_objects.inc
@@ -154,7 +154,8 @@ function islandora_manage_orphaned_objects_confirm_submit(array $form, array &$f
  */
 function islandora_get_orphaned_objects() {
   $query_method = variable_get('islandora_orphaned_objects_backend', 'SPARQL');
-
+  $root_pid = variable_get('islandora_repository_pid', 'islandora:root');
+  $root_pid = "info:fedora/" . $root_pid;
   if ($query_method == 'Solr') {
     // Solr query for all objects.
     $collection_field = variable_get('islandora_solr_member_of_collection_field', 'RELS_EXT_isMemberOfCollection_uri_ms');
@@ -197,16 +198,18 @@ function islandora_get_orphaned_objects() {
     foreach ($results as $result) {
       if (array_key_exists($collection_field, $result['solr_doc'])) {
         foreach ($result['solr_doc'][$collection_field] as $collection) {
-          if (in_array($collection, $missing_parents)) {
-            $orphaned_objects[] = $result;
-          }
-          elseif (!in_array($collection, $already_checked)) {
-            $test = islandora_identify_missing_parents($collection);
-            if (!$test) {
+          if ($collection != $root_pid) {
+            if (in_array($collection, $missing_parents)) {
               $orphaned_objects[] = $result;
-              $missing_parents[] = $collection;
             }
-            $already_checked[] = $collection;
+            elseif (!in_array($collection, $already_checked)) {
+              $test = islandora_identify_missing_parents($collection);
+              if (!$test) {
+                  $orphaned_objects[] = $result;
+                  $missing_parents[] = $collection;
+              }
+              $already_checked[] = $collection;
+            }
           }
         }
       }


### PR DESCRIPTION
**JIRA Ticket**: (https://jira.lyrasis.org/browse/ISLANDORA-2520)

# What does this Pull Request do?

Patching #807 -- solves a problem where sites with namespace restrictions (esp. multisites) might end up with their top-level collections misidentified as orphans, because their Solr settings exclude the root's parent's namespace.

# What's new?

Fetches the root collection PID, and:

- Excludes the root collection from being checked as a "missing parent", as the root namespace might be excluded from Solr
- Excludes the root collection from being checked as an orphan, because its parent, in a multisite environment, might be excluded from Solr

# How should this be tested?

* Configure a subcollection with a different namespace as your root collection in Islandora -> Configure
* Restrict namespaces in Solr settings (Query Defaults) so that your root collection is not listed
* See Orphaned Objects list - your root collection will be present
* Check out this branch and re-view: Your root collection will not be present


# Interested parties
@bryjbrown @Islandora/7-x-1-x-committers
