### PR TITLE
getFilename as function instead of property

### DIFF
--- a/src/MediaSource/MediaSourceService.php
+++ b/src/MediaSource/MediaSourceService.php
@@ -320,7 +320,7 @@ class MediaSourceService {
 
       // Set alt text.
       if ($source_field_config->getSetting('alt_field') && $source_field_config->getSetting('alt_field_required')) {
-        $media_struct[$source_field]['alt'] = $file->getFilename;
+        $media_struct[$source_field]['alt'] = $file->getFilename();
       }
 
       $media = $this->entityTypeManager->getStorage('media')->create($media_struct);


### PR DESCRIPTION
# What does this Pull Request do?

Something trivial that came up when poring through the derivatives stuff for WCAG compliance - when image derivatives are created, it looks like they're supposed to be asking `getFilename()` for alt text, but instead, it's pulling the `getFilename` property, which doesn't exist.

`ContentEntityBase` is so very kind enough to [instantiate the variable as NULL](https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Entity%21ContentEntityBase.php/function/ContentEntityBase%3A%3A__get/8.7.x) when it doesn't exist, instead of throwing a warning like one would certainly expect PHP to do. This certainly gives me squinty eyes about the fact that typos can just float through the codebase without so much as a warning, but c'est la vie.

# What's new?
Image derivatives gain the expected alt text of the filename instead of `NULL`.

# How should this be tested?

* Ensure alt text is required for image media. You can do this by navigating to `admin/structure/media/manage/image/fields/media.image.field_media_image` and ensuring that "Enable alt field" and "Alt field required" are checked off.
* Create a Repository Item node using the 'Image' model
* Attach an Original File media to that node. Upload, we'll say, a PNG file, give that file a name, and make sure the alt text is filled out.
* You should be able to check the thumbnail and service file derivatives that are created, and see that they have the image alt text field filled out. The contents of the alt text field should be the filename of the derivative.

# Interested parties
@Islandora/8-x-committers 
