### PR TITLE
manually implementing postsave

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
     "drupal/token" : "^1.3",
     "drupal/flysystem" : "^1.0",
     "islandora/crayfish-commons": "dev-dev",
-    "drupal/hook_post_action" : "^1.0",
     "drupal/file_replace": "^1.1"
 
   },

--- a/islandora.info.yml
+++ b/islandora.info.yml
@@ -31,5 +31,4 @@ dependencies:
   - content_translation
   - flysystem
   - token
-  - hook_post_action
   - file_replace

--- a/islandora.module
+++ b/islandora.module
@@ -179,10 +179,10 @@ function islandora_media_delete(MediaInterface $media) {
  * behaviour will eventually be replaced by event listeners once these are
  * implemented in Drupal 9.
  *
- * @see https://www.drupal.org/project/drupal/issues/2551893
- *
  * @param \Drupal\Core\Media\MediaInterface $media
  *   The media that was just inserted.
+ *
+ * @see https://www.drupal.org/project/drupal/issues/2551893
  */
 function _islandora_fire_media_file_derivative_reaction(MediaInterface $media) {
   $utils = \Drupal::service('islandora.utils');

--- a/islandora.module
+++ b/islandora.module
@@ -120,6 +120,8 @@ function islandora_media_insert(MediaInterface $media) {
       $media
     );
   }
+  // Wait until the media insert is complete, then fire file derivatives.
+  drupal_register_shutdown_function('_islandora_fire_media_file_derivative_reaction', $media);
 }
 
 /**
@@ -170,16 +172,22 @@ function islandora_media_delete(MediaInterface $media) {
 }
 
 /**
- * Implements hook_ENTITYTYPE_postsave().
+ * Helper to fire media derivative file reactions after a media 'insert'.
+ *
+ * This function should not be called on its own; it exists as a workaround to
+ * being unable to fire media events after a media insert operation. This
+ * behaviour will eventually be replaced by event listeners once these are
+ * implemented in Drupal 9.
+ *
+ * @see https://www.drupal.org/project/drupal/issues/2551893
+ *
+ * @param \Drupal\Core\Media\MediaInterface $media
+ *   The media that was just inserted.
  */
-function islandora_media_postsave(EntityInterface $media, $op) {
-
+function _islandora_fire_media_file_derivative_reaction(MediaInterface $media) {
   $utils = \Drupal::service('islandora.utils');
-  // Add derived file to the media.
-  if ($op == 'insert') {
-    $utils->executeMediaReactions('\Drupal\islandora\Plugin\ContextReaction\DerivativeFileReaction', $media);
-  }
-
+  // Execute derivative file reactions.
+  $utils->executeMediaReactions('\Drupal\islandora\Plugin\ContextReaction\DerivativeFileReaction', $media);
 }
 
 /**


### PR DESCRIPTION
Related issue: https://github.com/Islandora/documentation/issues/1731

# What does this Pull Request do?

Removes `hook_post_action` as a dependency, and manually implements the functionality it was providing.

The `hook_post_action` module likely won't be ported to Drupal 9. The functionality it provides is also being implemented in Drupal 9 at a later date. The intention of this pull request is to provide a stopgap between the loss of support for `hook_post_action` in Drupal 9 and our eventual ability to recreate this functionality when it's added into core in Drupal 9.1 or later.

# What's new?

After an `insert` operation is taken for a Media, a registered shutdown function fires off file derivative actions for that Media.

# How should this be tested?

We only need to ensure that there is no regression from https://github.com/Islandora/islandora/pull/756, so the test case there will suffice.

# Additional Notes:
The recommendation in this PR is to wait for entity events to be implemented in D9, but also, if we did the work to implement actions as mentioned in [this comment](https://github.com/Islandora/islandora/pull/756#pullrequestreview-458452305), said future work would likely be enough to delay us having to migrate completely to entity events. But I think those entity events should be considered the ideal endgame.

# Interested parties
@dannylamb likely as part of the ongoing D9 sprint https://github.com/orgs/Islandora/projects/3
