### PR TITLE
Refactoring multi-file media to create files like we do for other der…

### DIFF
--- a/src/Controller/MediaSourceController.php
+++ b/src/Controller/MediaSourceController.php
@@ -230,23 +230,41 @@ class MediaSourceController extends ControllerBase {
   public function attachToMedia(
     Media $media,
     string $destination_field,
-    Request $request) {
+    Request $request
+  ) {
     $content_location = $request->headers->get('Content-Location', "");
-    $contents = $request->getContent();
-    if ($contents) {
-      $file = file_save_data($contents, $content_location, FILE_EXISTS_REPLACE);
-      if ($media->hasField($destination_field)) {
-        $media->{$destination_field}->setValue([
-          'target_id' => $file->id(),
-        ]);
-        $media->save();
-      }
-      else {
-        $this->getLogger('islandora')->warning("Field $destination_field is not defined in  Media Type {$media->bundle()}");
-      }
+    if (empty($content_location)) {
+      throw new BadRequestHttpException("Missing Content-Location header");
     }
-    // Should only see this with a GET request for testing.
-    return new Response("<h1>Complete</h1>");
+
+    $content_type = $request->headers->get('Content-Type', "");
+    if (empty($content_type)) {
+      throw new BadRequestHttpException("Missing Content-Type header");
+    }
+
+    // Since we create both a Media and its File,
+    // start a transaction.
+    $transaction = $this->database->startTransaction();
+
+    try {
+      $this->service->putToMedia(
+        $media,
+	$destination_field,
+        $request->getContent(TRUE),
+        $content_type,
+        $content_location
+      );
+      // Should only see this with a GET request for testing.
+      return new Response("<h1>Complete</h1>");
+    }
+    catch (HttpException $e) {
+      $transaction->rollBack();
+      throw $e;
+    }
+    catch (\Exception $e) {
+      $transaction->rollBack();
+      throw new HttpException(500, $e->getMessage());
+    }
   }
 
   /**

--- a/src/Controller/MediaSourceController.php
+++ b/src/Controller/MediaSourceController.php
@@ -249,7 +249,7 @@ class MediaSourceController extends ControllerBase {
     try {
       $this->service->putToMedia(
         $media,
-	$destination_field,
+        $destination_field,
         $request->getContent(TRUE),
         $content_type,
         $content_location

--- a/src/MediaSource/MediaSourceService.php
+++ b/src/MediaSource/MediaSourceService.php
@@ -366,7 +366,7 @@ class MediaSourceService {
 
       // Validate file extension.
       $bundle = $media->bundle();
-      $destination_field_config= $this->entityTypeManager->getStorage('field_config')->load("media.$bundle.$destination_field");
+      $destination_field_config = $this->entityTypeManager->getStorage('field_config')->load("media.$bundle.$destination_field");
       $valid_extensions = $destination_field_config->getSetting('file_extensions');
       $errors = file_validate_extensions($file, $valid_extensions);
 
@@ -383,7 +383,7 @@ class MediaSourceService {
       $this->updateFile($file, $resource, $mimetype);
       $file->save();
 
-      // Update the media
+      // Update the media.
       $media->{$destination_field}->setValue([
         'target_id' => $file->id(),
       ]);
@@ -393,4 +393,5 @@ class MediaSourceService {
       throw new BadRequestHttpException("Media does not have destination field $destination_field");
     }
   }
+
 }


### PR DESCRIPTION
…ivatives

**Related issue**: https://github.com/Islandora/documentation/issues/1731

* Stumbled onto this when testing https://github.com/Islandora/islandora/pull/815

# What does this Pull Request do?

Refactors to use the same method of creating files for "regular" derivatives when generating "multi-file media" derivatives.

# What's new?
Not much.  Just made another function in the service, copy/pasted from other bits, and call that function from controller.

# How should this be tested?

* Make a new media type and give it
    * A source field
    * Another file field to hold the derivative (I called mine `field_derivative_file`) and made sure it could accept xml files
    * The `media_of` field
* Make a new 'Generate a derivative file for Media Attachment' action. I configured mine to run FITS on the source field like so:
    * Queue Name -> `islandora-connector-fits`
    * Destination Field File Name -> `field_derivative_file`
    * Mimetype -> `application/xml`
    * File Path -> `[date:custom:Y]-[date:custom:m]/[media:mid]-fits.xml`
* Make a context to pull it all together
    * Condition -> Check for the new media type with the `entity_bundle` condition
    * Reaction -> Derive File for Existing Media with the new action you just made
* Make a repository item, give it a new media of the type you just created
* The `field_derivative_file` should be populated with FITS XML

# Interested parties
@ajstanley @Islandora/8-x-committers
