### PR TITLE
Migrate fix

### DIFF
--- a/islandora.install
+++ b/islandora.install
@@ -74,7 +74,7 @@ function islandora_update_8004() {
 /**
  * Makes migrate_tags an array.
  */
-function islandora_update_8007() {
+function islandora_update_8005() {
   $config_factory = \Drupal::configFactory();
   $config_factory->getEditable('migrate_plus.migration.islandora__tags')->delete();
   $config = $config_factory->getEditable('migrate_plus.migration.islandora_tags');

--- a/islandora.install
+++ b/islandora.install
@@ -70,3 +70,28 @@ function islandora_update_8004() {
     }
   }
 }
+
+/**
+ * Makes migrate_tags an array.
+ */
+function islandora_update_8005() {
+  $config_factory = \Drupal::configFactory();
+  $config = $config_factory->getEditable('migrate_plus.migration.islandora_tags');
+  if ($config) {
+    if (!$config->get('migrate_tags')) {
+      $config->set('migrate_tags', [$config->get('migrate_tags')]);
+      $config->save(TRUE);
+    }
+  }
+  // This is what 8004 was supposed to do.
+  $config = $config_factory->getEditable('migrate_plus.migration.islandora_tags');
+  if ($config) {
+    if (!$config->get('source.ids')) {
+      $config->set('source.ids', $config->get('source.keys'));
+      $config->clear('source.keys');
+      $config->save(TRUE);
+    }
+  }
+  // This was added by mistake in 8004.
+  $config->delete('migrate_plus.migration.islandora__tags');
+}

--- a/islandora.install
+++ b/islandora.install
@@ -92,6 +92,12 @@ function islandora_update_8005() {
       $config->save(TRUE);
     }
   }
+}
+
+/**
+ * Remove config added by mistake.
+ */
+function islandora_update_8006() {
   // This was added by mistake in 8004.
-  $config->delete('migrate_plus.migration.islandora__tags');
+  $config_factory->getEditable('migrate_plus.migration.islandora__tags')->delete();
 }

--- a/islandora.install
+++ b/islandora.install
@@ -89,3 +89,4 @@ function islandora_update_8007() {
       $config->save(TRUE);
     }
   }
+}

--- a/islandora.install
+++ b/islandora.install
@@ -74,30 +74,18 @@ function islandora_update_8004() {
 /**
  * Makes migrate_tags an array.
  */
-function islandora_update_8005() {
+function islandora_update_8007() {
   $config_factory = \Drupal::configFactory();
+  $config_factory->getEditable('migrate_plus.migration.islandora__tags')->delete();
   $config = $config_factory->getEditable('migrate_plus.migration.islandora_tags');
   if ($config) {
-    if (!$config->get('migrate_tags')) {
-      $config->set('migrate_tags', [$config->get('migrate_tags')]);
+    if (!$config->get('migration_tags')) {
+      $config->set('migration_tags', [$config->get('migration_tags')]);
       $config->save(TRUE);
     }
-  }
-  // This is what 8004 was supposed to do.
-  $config = $config_factory->getEditable('migrate_plus.migration.islandora_tags');
-  if ($config) {
     if (!$config->get('source.ids')) {
       $config->set('source.ids', $config->get('source.keys'));
       $config->clear('source.keys');
       $config->save(TRUE);
     }
   }
-}
-
-/**
- * Remove config added by mistake.
- */
-function islandora_update_8006() {
-  // This was added by mistake in 8004.
-  $config_factory->getEditable('migrate_plus.migration.islandora__tags')->delete();
-}

--- a/islandora.install
+++ b/islandora.install
@@ -79,7 +79,7 @@ function islandora_update_8005() {
   $config_factory->getEditable('migrate_plus.migration.islandora__tags')->delete();
   $config = $config_factory->getEditable('migrate_plus.migration.islandora_tags');
   if ($config) {
-    if (!$config->get('migration_tags')) {
+    if (!is_array($config->get('migration_tags'))) {
       $config->set('migration_tags', [$config->get('migration_tags')]);
       $config->save(TRUE);
     }

--- a/modules/islandora_core_feature/config/install/migrate_plus.migration.islandora_tags.yml
+++ b/modules/islandora_core_feature/config/install/migrate_plus.migration.islandora_tags.yml
@@ -8,7 +8,8 @@ id: islandora_tags
 class: null
 field_plugin_method: null
 cck_plugin_method: null
-migration_tags: islandora_tags
+migration_tags:
+  - islandora_tags
 migration_group: islandora
 label: 'Tags migration from CSV'
 source:


### PR DESCRIPTION
**GitHub Issue**: (https://github.com/Islandora/documentation/issues/1741)


# What does this Pull Request do?
Updates migration_tags to be an array

# What's new?
* Change to the migration configuration to make migration_tags an array
* Update hook to update existing configuration
* Removes messed up config that I accidentally added in the previous update hook 8004 with the name `islandora__tags` instead of `islandora_tags`


# How should this be tested?
* See migration_tags as a string
* Pull in PR, run update
* Verify migration_tags is an array now
* Verify migrate_plus.migration.islandora__tags does not exist
* Verify the presence of source:ids and not source:keys in islandora_tags 


# Interested parties
 @Islandora/8-x-committers
