### PR TITLE
Ran into issues with `node_has_term` condition from the Islandora mod…

### DIFF
--- a/src/Plugin/Condition/NodeHasTerm.php
+++ b/src/Plugin/Condition/NodeHasTerm.php
@@ -84,7 +84,10 @@ class NodeHasTerm extends ConditionPluginBase implements ContainerFactoryPluginI
    */
   public function defaultConfiguration() {
     return array_merge(
-      ['logic' => 'and'],
+      [
+        'logic' => 'and',
+        'uri' => NULL,
+      ],
       parent::defaultConfiguration()
     );
   }


### PR DESCRIPTION
…ule. It

always saves to the block and fails to evaluate to false. It should not save if
no value has been specified for term URI.

Found the following in `web/core/lib/Drupal/Core/Condition/ConditionPluginCollection.php`.

```php
// In order to determine if a plugin is configured, we must compare it to
// its default configuration. The default configuration of a plugin does
// not contain context_mapping and it is not used when the plugin is not
// configured, so remove the context_mapping from the instance config to
// compare the remaining values.
unset($instance_config['context_mapping']);
if ($default_config === $instance_config) {
  unset($configuration[$instance_id]);
}
```

When doing the comparison we have.

```php
$default_config = [
  "id" => "node_has_term",
  "logic" => "and",
  "negate" => false
];
$instance_config = [
  "id" => "node_has_term",
  "logic" => "and",
  "negate" => false,
  "uri" => NULL,
];
```

So the comparison fails and the configuration is stored and evaluated later
causing issues since it fails to pass evaluation.

Hence we need to change the default config to match the submitted values.

# What does this Pull Request do?

Changes the defaults for `NodeHasTerm` to reflect the submitted values.

# What's new?

Example:
* Configuration will not persist if matches defaults

# How should this be tested?

A description of what steps someone could take to:
* Submit a form where the configuration is present without changing values in the form
* View the entity with `devel`
* Note that configuration is persisted although was not set by the user

After change is applied the configuration is not persisted.

# Additional Notes:

This will not remove persisted configuration that already exists without a value as `===` is used in core for the comparison of the configuration, and that takes the order of values into account, and that configuration will not match the defaults as `uri` was appended to the structure afterwards.
