### PR TITLE
Multi Drupal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,12 @@ php:
   - 7.4
 
 env:
-  - TESTSUITE=kernel
-  - TESTSUITE=functional
-  - TESTSUITE=functional-javascript
+  - TESTSUITE=kernel DRUPAL_VERSION=8.9.11
+  - TESTSUITE=functional DRUPAL_VERSION=8.9.11
+  - TESTSUITE=functional-javascript DRUPAL_VERSION=8.9.11
+  - TESTSUITE=kernel DRUPAL_VERSION=9.1.1
+  - TESTSUITE=functional DRUPAL_VERSION=9.1.1
+  - TESTSUITE=functional-javascript DRUPAL_VERSION=9.1.1
 
 matrix:
     fast_finish: true

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     "sebastian/phpcpd": "*"
   },
   "suggest": {
-    "drupal/transliterate_filenames": "Sanitizes filenames when they are uploaded so they don't break your repository." 
+    "drupal/transliterate_filenames": "Sanitizes filenames when they are uploaded so they don't break your repository."
   },
   "license": "GPL-2.0+",
   "authors": [


### PR DESCRIPTION
**JIRA Ticket**: n/a

# What does this Pull Request do?

Updates the travis setup to test both Drupal 8.9.11 and 9.1.1 requires https://github.com/Islandora/islandora_ci/pull/6

# What's new?

Defines new environment variable DRUPAL_VERSION in the build matrix.

# How should this be tested?

Once https://github.com/Islandora/islandora_ci/pull/6 is merged, I'll make this live and it should both pass and test both Drupal 8 and 9.

# Interested parties
@Islandora/8-x-committers 
