### PR TITLE
Increase size of media.field_file_size

### DIFF
--- a/modules/islandora_core_feature/config/install/field.storage.media.field_file_size.yml
+++ b/modules/islandora_core_feature/config/install/field.storage.media.field_file_size.yml
@@ -11,8 +11,8 @@ field_name: field_file_size
 entity_type: media
 type: integer
 settings:
-  unsigned: false
-  size: normal
+  unsigned: true
+  size: big
 module: core
 locked: false
 cardinality: 1

--- a/modules/islandora_core_feature/islandora_core_feature.install
+++ b/modules/islandora_core_feature/islandora_core_feature.install
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * @file
+ * Update Hooks.
+ */
+
+use Drupal\field\Entity\FieldStorageConfig;
+
+/**
+ * Updates Media file size field storage for larger files.
+ */
+function islandora_core_feature_update_8001() {
+
+  $entity_type = 'media';
+  $field_name = 'field_file_size';
+
+  $database = \Drupal::database();
+  $data = [];
+  $storage_key = $entity_type . '.field_schema_data.' . $field_name;
+  $storage_schema = \Drupal::keyValue('entity.storage_schema.sql');
+  $field_schema = $storage_schema->get($storage_key);
+
+  foreach (["{$entity_type}__{$field_name}", "{$entity_type}_revision__{$field_name}"] as $table) {
+    // Squirrel away the data.
+    $data[$table] = $database->select($table, 'n')
+      ->fields('n')
+      ->execute()
+      ->fetchAll();
+
+    // Clean it out for resizing.
+    $database->truncate($table)->execute();
+    $database->schema()->dropPrimaryKey($table);
+
+    // Resize the main field data table.
+    $database->query("ALTER TABLE $table MODIFY {$field_name}_value BIGINT(11) unsigned NOT NULL");
+
+    // Update storage schema.
+    $field_schema[$table]['fields'][$field_name . '_value']['type'] = "bigint";
+    $field_schema[$table]['fields'][$field_name . '_value']['unsigned'] = "true";
+  }
+  $storage_schema->set($storage_key, $field_schema);
+
+  // Update field storage configuration.
+  $config = \Drupal::configFactory()
+    ->getEditable("field.storage.{$entity_type}.{$field_name}");
+  $config->set('settings.size', 'big');
+  $config->set('settings.unsigned', TRUE);
+  $config->save(TRUE);
+
+  // Make sure the new config persists.
+  FieldStorageConfig::loadByName($entity_type, $field_name)->save();
+
+  // Reload the data.
+  foreach ($data as $table => $rows) {
+    foreach ($rows as $row) {
+      $database->insert($table)
+        ->fields((array) $row)
+        ->execute();
+    }
+  }
+
+  return t('Length of @entity-type.@field-name updated to an unsigned big int', [
+    '@entity-type' => $entity_type,
+    '@field-name' => $field_name,
+  ]);
+}

--- a/modules/islandora_core_feature/islandora_core_feature.install
+++ b/modules/islandora_core_feature/islandora_core_feature.install
@@ -10,9 +10,10 @@ use Drupal\field\Entity\FieldStorageConfig;
 /**
  * Updates Media file size field storage for larger files.
  */
-function islandora_core_feature_update_8001() {
+function islandora_core_feature_update_8001(&$sandbox) {
 
   $entity_type = 'media';
+
   $field_name = 'field_file_size';
 
   $database = \Drupal::database();
@@ -21,82 +22,113 @@ function islandora_core_feature_update_8001() {
     "{$entity_type}_revision__{$field_name}",
   ];
 
-  foreach ($tables as $table) {
+  if (!isset($sandbox['progress'])) {
+    $sandbox['upper_limit'] = 0;
+    foreach ($tables as $table) {
 
-    // Move the existing data out of the way.
-    $database->schema()->renameTable($table, $table . '_o');
+      // Record size of the table for future use.
+      $sandbox[$table]['size'] = $database->select($table)
+        ->countQuery()
+        ->execute()
+        ->fetchField();
+      if ($sandbox[$table]['size'] > $sandbox['upper_limit']) {
+        $sandbox['upper_limit'] = $sandbox[$table]['size'];
+      }
+      // Move the existing data out of the way.
+      $database->schema()->renameTable($table, $table . '_o');
 
-    // Create replacement tables.
-    $database->schema()->createTable($table, [
-      'fields' => [
-        'bundle' => [
-          'type' => 'varchar',
-          'not null' => TRUE,
-          'length' => 128,
-          'default' => ' ',
-        ],
-        'deleted' => [
-          'type' => 'int',
-          'size' => 'tiny',
-          'not null' => TRUE,
-          'default' => 0,
-        ],
-        'entity_id' => [
-          'type' => 'int',
-          'unsigned' => TRUE,
-          'not null' => TRUE,
-          'length' => 10,
+      // Create replacement tables.
+      $database->schema()->createTable($table, [
+        'fields' => [
+          'bundle' => [
+            'type' => 'varchar',
+            'not null' => TRUE,
+            'length' => 128,
+            'default' => ' ',
+          ],
+          'deleted' => [
+            'type' => 'int',
+            'size' => 'tiny',
+            'not null' => TRUE,
+            'default' => 0,
+          ],
+          'entity_id' => [
+            'type' => 'int',
+            'unsigned' => TRUE,
+            'not null' => TRUE,
+            'length' => 10,
 
+          ],
+          'revision_id' => [
+            'type' => 'int',
+            'unsigned' => TRUE,
+            'not null' => TRUE,
+            'length' => 10,
+          ],
+          'langcode' => [
+            'type' => 'varchar',
+            'not null' => TRUE,
+            'length' => 32,
+            'default' => ' ',
+          ],
+          'delta' => [
+            'type' => 'int',
+            'unsigned' => TRUE,
+            'not null' => TRUE,
+            'length' => 10,
+          ],
+          'field_file_size_value' => [
+            'type' => 'int',
+            'size' => 'big',
+            'unsigned' => TRUE,
+            'not null' => TRUE,
+          ],
         ],
-        'revision_id' => [
-          'type' => 'int',
-          'unsigned' => TRUE,
-          'not null' => TRUE,
-          'length' => 10,
-        ],
-        'langcode' => [
-          'type' => 'varchar',
-          'not null' => TRUE,
-          'length' => 32,
-          'default' => ' ',
-        ],
-        'delta' => [
-          'type' => 'int',
-          'unsigned' => TRUE,
-          'not null' => TRUE,
-          'length' => 10,
-        ],
-        'field_file_size_value' => [
-          'type' => 'int',
-          'size' => 'big',
-          'unsigned' => TRUE,
-          'not null' => TRUE,
-        ],
-      ],
-      'primary key' => ['entity_id', 'deleted', 'delta', 'langcode'],
-      'indexes' => ['bundle' => ['bundle'], 'revision_id' => ['revision_id']],
-    ]);
+        'primary key' => ['entity_id', 'deleted', 'delta', 'langcode'],
+        'indexes' => ['bundle' => ['bundle'], 'revision_id' => ['revision_id']],
+      ]);
+
+    }
+
+    // Update field storage configuration.
+    $config = \Drupal::configFactory()
+      ->getEditable("field.storage.{$entity_type}.{$field_name}");
+    $config->set('settings.size', 'big');
+    $config->set('settings.unsigned', TRUE);
+    $config->save(TRUE);
+
+    // Make sure the new config persists.
+    FieldStorageConfig::loadByName($entity_type, $field_name)->save();
+
+    // Track batch reload progress.
+    $sandbox['progress'] = 0;
   }
 
-  // Update field storage configuration.
-  $config = \Drupal::configFactory()
-    ->getEditable("field.storage.{$entity_type}.{$field_name}");
-  $config->set('settings.size', 'big');
-  $config->set('settings.unsigned', TRUE);
-  $config->save(TRUE);
-
-  // Make sure the new config persists.
-  FieldStorageConfig::loadByName($entity_type, $field_name)->save();
+  // Arbitrary, hopefully reasonable, batch size per table.
+  $limit = 500;
 
   // Reload the data and clean up.
   foreach ($tables as $table) {
-    $query = $database->select($table . '_o', 'o')->fields('o');
-    $database->insert($table)->from($query)->execute();
-    $database->schema()->dropTable($table . '_o');
+    if (!isset($sandbox[$table]['done'])) {
+      $query = $database->select($table . '_o', 'o')->fields('o')
+        ->orderBy('o.entity_id', 'ASC')
+        ->orderBy('o.revision_id', 'ASC')
+        ->orderBy('o.delta', 'ASC')
+        ->range($sandbox['progress'], $sandbox['progress'] + $limit);
+      $database->insert($table)->from($query)->execute();
+      $database->schema()->dropTable($table . '_o');
+      if ($sandbox['progress'] + $limit >= $progress[$table]['size']) {
+        $sandbox[$table]['done'] = TRUE;
+      }
+    }
   }
 
-  return t('Length of @entity-type.@field-name updated to an unsigned big int', [
-    '@entity-type' => $entity_type,
-    '@field-name' => $field_name,
-  ]);
+  $sandbox['progress'] = $sandbox['progress'] + $limit;
+  $sandbox['#finished'] = $sandbox['progress'] >= $sandbox['upper_limit'] ? 1 : $sandbox['progress'] / $sandbox['upper_limit'];
+  if ($sandbox['#finished'] == 1) {
+    return t('Length of @entity-type.@field-name updated to an unsigned big int', [
+      '@entity-type' => $entity_type,
+      '@field-name' => $field_name,
+    ]);
+  }
 }

--- a/modules/islandora_core_feature/islandora_core_feature.install
+++ b/modules/islandora_core_feature/islandora_core_feature.install
@@ -21,7 +21,10 @@ function islandora_core_feature_update_8001() {
   $storage_schema = \Drupal::keyValue('entity.storage_schema.sql');
   $field_schema = $storage_schema->get($storage_key);
 
-  foreach (["{$entity_type}__{$field_name}", "{$entity_type}_revision__{$field_name}"] as $table) {
+  foreach ([
+    "{$entity_type}__{$field_name}",
+    "{$entity_type}_revision__{$field_name}",
+  ] as $table) {
     // Squirrel away the data.
     $data[$table] = $database->select($table, 'n')
       ->fields('n')

--- a/modules/islandora_core_feature/islandora_core_feature.install
+++ b/modules/islandora_core_feature/islandora_core_feature.install
@@ -23,23 +23,59 @@ function islandora_core_feature_update_8001() {
 
   foreach ($tables as $table) {
 
-    // Squirrel away the data.
-    $table_file_path = "public://islandora_core_feature_update_8001_{$table}.json";
-    if (!file_exists($table_file_path)) {
-      $table_data = $database->select($table, 'n')->fields('n')->execute()->fetchAll();
-      \Drupal::service('file_system')->saveData(json_encode($table_data), $table_file_path);
-    }
+    // Move the existing data out of the way.
+    $database->schema()->renameTable($table, $table . '_o');
 
-    // Clean it out for resizing.
-    $database->truncate($table)->execute();
+    // Create replacement tables.
+    $database->schema()->createTable($table, [
+      'fields' => [
+        'bundle' => [
+          'type' => 'varchar',
+          'not null' => TRUE,
+          'length' => 128,
+          'default' => ' ',
+        ],
+        'deleted' => [
+          'type' => 'int',
+          'size' => 'tiny',
+          'not null' => TRUE,
+          'default' => 0,
+        ],
+        'entity_id' => [
+          'type' => 'int',
+          'unsigned' => TRUE,
+          'not null' => TRUE,
+          'length' => 10,
 
-    $database->schema()->changeField($table, $field_name . '_value', $field_name . '_value', [
-      'type' => 'int',
-      'size' => 'big',
-      'unsigned' => TRUE,
-      'not null' => TRUE,
+        ],
+        'revision_id' => [
+          'type' => 'int',
+          'unsigned' => TRUE,
+          'not null' => TRUE,
+          'length' => 10,
+        ],
+        'langcode' => [
+          'type' => 'varchar',
+          'not null' => TRUE,
+          'length' => 32,
+          'default' => ' ',
+        ],
+        'delta' => [
+          'type' => 'int',
+          'unsigned' => TRUE,
+          'not null' => TRUE,
+          'length' => 10,
+        ],
+        'field_file_size_value' => [
+          'type' => 'int',
+          'size' => 'big',
+          'unsigned' => TRUE,
+          'not null' => TRUE,
+        ],
+      ],
+      'primary key' => ['entity_id', 'deleted', 'delta', 'langcode'],
+      'indexes' => ['bundle' => ['bundle'], 'revision_id' => ['revision_id']],
     ]);
-
   }
 
   // Update field storage configuration.
@@ -52,19 +88,11 @@ function islandora_core_feature_update_8001() {
   // Make sure the new config persists.
   FieldStorageConfig::loadByName($entity_type, $field_name)->save();
 
-  // Reload the data.
+  // Reload the data and clean up.
   foreach ($tables as $table) {
-    $table_file_path = "public://islandora_core_feature_update_8001_{$table}.json";
-    if (file_exists($table_file_path)) {
-      foreach (json_decode(file_get_contents($table_file_path), TRUE) as $row) {
-        $database->insert($table)
-          ->fields((array) $row)
-          ->execute();
-      }
-      // Clean up.
-      \Drupal::service('file_system')->delete($table_file_path);
-    }
-
+    $query = $database->select($table . '_o', 'o')->fields('o');
+    $database->insert($table)->from($query)->execute();
+    $database->schema()->dropTable($table . '_o');
   }
 
   return t('Length of @entity-type.@field-name updated to an unsigned big int', [

--- a/modules/islandora_core_feature/islandora_core_feature.install
+++ b/modules/islandora_core_feature/islandora_core_feature.install
@@ -107,7 +107,7 @@ function islandora_core_feature_update_8001(&$sandbox) {
   // Arbitrary, hopefully reasonable, batch size per table.
   $limit = 500;
 
-  // Reload the data and clean up.
+  // Reload the data.
   foreach ($tables as $table) {
     if (!isset($sandbox[$table]['done'])) {
       $query = $database->select($table . '_o', 'o')->fields('o')
@@ -116,16 +116,19 @@ function islandora_core_feature_update_8001(&$sandbox) {
         ->orderBy('o.delta', 'ASC')
         ->range($sandbox['progress'], $sandbox['progress'] + $limit);
       $database->insert($table)->from($query)->execute();
-      $database->schema()->dropTable($table . '_o');
-      if ($sandbox['progress'] + $limit >= $progress[$table]['size']) {
-        $sandbox[$table]['done'] = TRUE;
-      }
     }
   }
 
   $sandbox['progress'] = $sandbox['progress'] + $limit;
   $sandbox['#finished'] = $sandbox['progress'] >= $sandbox['upper_limit'] ? 1 : $sandbox['progress'] / $sandbox['upper_limit'];
   if ($sandbox['#finished'] == 1) {
+    // Clean up.
+    foreach ($tables as $table) {
+      $database->schema()->dropTable($table . '_o');
+      if ($sandbox['progress'] + $limit >= $progress[$table]['size']) {
+        $sandbox[$table]['done'] = TRUE;
+      }
+    }
     return t('Length of @entity-type.@field-name updated to an unsigned big int', [
       '@entity-type' => $entity_type,
       '@field-name' => $field_name,

--- a/modules/islandora_core_feature/islandora_core_feature.install
+++ b/modules/islandora_core_feature/islandora_core_feature.install
@@ -16,33 +16,31 @@ function islandora_core_feature_update_8001() {
   $field_name = 'field_file_size';
 
   $database = \Drupal::database();
-  $data = [];
-  $storage_key = $entity_type . '.field_schema_data.' . $field_name;
-  $storage_schema = \Drupal::keyValue('entity.storage_schema.sql');
-  $field_schema = $storage_schema->get($storage_key);
-
-  foreach ([
+  $tables = [
     "{$entity_type}__{$field_name}",
     "{$entity_type}_revision__{$field_name}",
-  ] as $table) {
+  ];
+
+  foreach ($tables as $table) {
+
     // Squirrel away the data.
-    $data[$table] = $database->select($table, 'n')
-      ->fields('n')
-      ->execute()
-      ->fetchAll();
+    $table_file_path = "public://islandora_core_feature_update_8001_{$table}.json";
+    if (!file_exists($table_file_path)) {
+      $table_data = $database->select($table, 'n')->fields('n')->execute()->fetchAll();
+      \Drupal::service('file_system')->saveData(json_encode($table_data), $table_file_path);
+    }
 
     // Clean it out for resizing.
     $database->truncate($table)->execute();
-    $database->schema()->dropPrimaryKey($table);
 
-    // Resize the main field data table.
-    $database->query("ALTER TABLE $table MODIFY {$field_name}_value BIGINT(11) unsigned NOT NULL");
+    $database->schema()->changeField($table, $field_name . '_value', $field_name . '_value', [
+      'type' => 'int',
+      'size' => 'big',
+      'unsigned' => TRUE,
+      'not null' => TRUE,
+    ]);
 
-    // Update storage schema.
-    $field_schema[$table]['fields'][$field_name . '_value']['type'] = "bigint";
-    $field_schema[$table]['fields'][$field_name . '_value']['unsigned'] = "true";
   }
-  $storage_schema->set($storage_key, $field_schema);
 
   // Update field storage configuration.
   $config = \Drupal::configFactory()
@@ -55,12 +53,18 @@ function islandora_core_feature_update_8001() {
   FieldStorageConfig::loadByName($entity_type, $field_name)->save();
 
   // Reload the data.
-  foreach ($data as $table => $rows) {
-    foreach ($rows as $row) {
-      $database->insert($table)
-        ->fields((array) $row)
-        ->execute();
+  foreach ($tables as $table) {
+    $table_file_path = "public://islandora_core_feature_update_8001_{$table}.json";
+    if (file_exists($table_file_path)) {
+      foreach (json_decode(file_get_contents($table_file_path), TRUE) as $row) {
+        $database->insert($table)
+          ->fields((array) $row)
+          ->execute();
+      }
+      // Clean up.
+      \Drupal::service('file_system')->delete($table_file_path);
     }
+
   }
 
   return t('Length of @entity-type.@field-name updated to an unsigned big int', [


### PR DESCRIPTION
**GitHub Ticket**: https://github.com/Islandora/documentation/issues/1771

# What does this Pull Request do?

Increases the size and signed state of media.field_file_size to support files larger than 2.2GB.

# What's new?

* Changes field.storage.media.field_file_size to be big and unsigned.
* Added islandora_core_feature.install hook 8001 to resize the field without losing existing data.

# How should this be tested?

* Create a media
* Attempt to save a large file size value on a media. E.g. `drush eval "\Drupal::entityTypeManager()->getStorage('media')->load(1)->set('field_file_size', 2400000000000)->save();"` This will throw an error.
* Apply the PR
* Run updates `drush updb -y`
* Clear cache `drush cr`
* Attempt to save the large file size value again: `drush eval "\Drupal::entityTypeManager()->getStorage('media')->load(1)->set('field_file_size', 2400000000000)->save();"` will return successfully.


# Additional Notes:
This PR does **not** include the [bigint module](https://www.drupal.org/project/bigint). I can update the PR to include it if folks want it, but it does take some work. It requires updating composer.json and finding all the relevant field configs to update them.

# Interested parties
@Islandora/8-x-committers
