### PR TITLE
audio captions part 2

### DIFF
--- a/modules/islandora_audio/islandora_audio.libraries.yml
+++ b/modules/islandora_audio/islandora_audio.libraries.yml
@@ -1,0 +1,7 @@
+audio:
+  version: 1.x
+  js:
+    js/audio.js: {preprocess: false}
+  dependencies:
+    - core/drupal
+    - core/drupalSettings

--- a/modules/islandora_audio/js/audio.js
+++ b/modules/islandora_audio/js/audio.js
@@ -1,0 +1,45 @@
+/*jslint browser: true*/
+/*global Audio, Drupal*/
+/**
+ * @file
+ * Displays Audio viewer.
+ */
+(function ($, Drupal) {
+    'use strict';
+
+    /**
+     * If initialized.
+     * @type {boolean}
+     */
+    var initialized;
+    /**
+     * Unique HTML id.
+     * @type {string}
+     */
+    var base;
+
+    function init(context,settings){
+        if (!initialized){
+            console.log("hello audio");
+            initialized = true;
+	    $('audio')[0].textTracks[0].oncuechange = function() {
+		console.log("changed");
+		var currentCue = this.activeCues[0].text;
+		$('#audioTrack').html(currentCue);
+	    }
+        }
+    }
+    Drupal.Audio = Drupal.Audio || {};
+
+    /**
+     * Initialize the Audio Viewer.
+     */
+    Drupal.behaviors.Audio = {
+        attach: function (context, settings) {
+            init(context,settings);
+        },
+        detach: function () {
+        }
+    };
+
+})(jQuery, Drupal);

--- a/modules/islandora_audio/js/audio.js
+++ b/modules/islandora_audio/js/audio.js
@@ -20,10 +20,8 @@
 
     function init(context,settings){
         if (!initialized){
-            console.log("hello audio");
             initialized = true;
 	    $('audio')[0].textTracks[0].oncuechange = function() {
-		console.log("changed");
 		var currentCue = this.activeCues[0].text;
 		$('#audioTrack').html(currentCue);
 	    }

--- a/modules/islandora_audio/templates/islandora-file-audio.html.twig
+++ b/modules/islandora_audio/templates/islandora-file-audio.html.twig
@@ -15,14 +15,18 @@
 * @ingroup themeable
 */
 #}
+<div id="audioTrack"></div>
+{#<video {{ attributes }} controls poster="http://localhost:8000/sites/default/files/2021-03/1-Service%20File.jpg">#}
 <audio {{ attributes }}>
   {% for file in files %}
     <source {{ file.source_attributes }} />
     {% if tracks %}
     {% for track in tracks %}
-      <track {{ track.track_attributes }}
+      <track {{ track.track_attributes }} default />
     {% endfor %}
     {% endif %}
   {% endfor %}
 </audio>
+
+{{ attach_library('islandora_audio/audio') }}
 

--- a/modules/islandora_audio/templates/islandora-file-audio.html.twig
+++ b/modules/islandora_audio/templates/islandora-file-audio.html.twig
@@ -16,7 +16,6 @@
 */
 #}
 <div id="audioTrack"></div>
-{#<video {{ attributes }} controls poster="http://localhost:8000/sites/default/files/2021-03/1-Service%20File.jpg">#}
 <audio {{ attributes }}>
   {% for file in files %}
     <source {{ file.source_attributes }} />

--- a/modules/islandora_audio/templates/islandora-file-audio.html.twig
+++ b/modules/islandora_audio/templates/islandora-file-audio.html.twig
@@ -21,7 +21,7 @@
     <source {{ file.source_attributes }} />
     {% if tracks %}
     {% for track in tracks %}
-      <track {{ track.track_attributes }} default />
+      <track {{ track.track_attributes }} />
     {% endfor %}
     {% endif %}
   {% endfor %}


### PR DESCRIPTION
# What does this Pull Request do?
Provides a solution to DISPLAY the captions for audio files

# What's new?
* a small amount of javascript to move the text out of the actual audio player
* a template change

# How should this be tested?
* spin up (or use an existing) islandora site
* pull in this PR
* add an audio file
* add captions to the service file for the audio (make sure its set as the default)
* view the node
* press play
* view captions with the audio file
* should be tested in as many browsers as you can find (i tested in chrome, firefox, and safari)

# Additional Notes:
This spawned out of conversation on https://github.com/Islandora/islandora/pull/826 with @kayakr 

You should see the text of the captions above the audio player like so:
<img width="368" alt="Screen Shot 2021-04-20 at 3 06 03 PM" src="https://user-images.githubusercontent.com/5439169/115469676-ef597000-a1e9-11eb-9efb-5c5e49aa0cd3.png">

# Interested parties

@Islandora/8-x-committers
