### PR TITLE
Make rdf namespaces configurable (Issue 1520)

### DIFF
--- a/config/install/islandora.settings.yml
+++ b/config/install/islandora.settings.yml
@@ -5,52 +5,52 @@ gemini_pseudo_bundles: []
 rdf_namespaces:
     -
         prefix: 'ldp'
-        namespace: 'http://www.w3.org/ns/ldp#',
+        namespace: 'http://www.w3.org/ns/ldp#'
     -
         prefix: 'dc11'
-        namespace: 'http://purl.org/dc/elements/1.1/',
+        namespace: 'http://purl.org/dc/elements/1.1/'
     -
         prefix: 'dcterms'
-        namespace: 'http://purl.org/dc/terms/',
+        namespace: 'http://purl.org/dc/terms/'
     -
         prefix: 'nfo'
-        namespace: 'http://www.semanticdesktop.org/ontologies/2007/03/22/nfo/v1.1/',
+        namespace: 'http://www.semanticdesktop.org/ontologies/2007/03/22/nfo/v1.1/'
     -
         prefix: 'ebucore'
-        namespace: 'http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#',
+        namespace: 'http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#'
     -
         prefix: 'fedora'
-        namespace: 'http://fedora.info/definitions/v4/repository#',
+        namespace: 'http://fedora.info/definitions/v4/repository#'
     -
         prefix: 'owl'
-        namespace: 'http://www.w3.org/2002/07/owl#',
+        namespace: 'http://www.w3.org/2002/07/owl#'
     -
         prefix: 'ore'
-        namespace: 'http://www.openarchives.org/ore/terms/',
+        namespace: 'http://www.openarchives.org/ore/terms/'
     -
         prefix: 'rdf'
-        namespace: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
+        namespace: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#'
     -
         prefix: 'rdau'
         namespace: 'http://rdaregistry.info/Elements/u/'
     -
         prefix: 'islandora'
-        namespace: 'http://islandora.ca/',
+        namespace: 'http://islandora.ca/'
     -
         prefix: 'pcdm'
-        namespace: 'http://pcdm.org/models#',
+        namespace: 'http://pcdm.org/models#'
     -
         prefix: 'use'
-        namespace: 'http://pcdm.org/use#',
+        namespace: 'http://pcdm.org/use#'
     -
         prefix: 'iana'
-        namespace: 'http://www.iana.org/assignments/relation/',
+        namespace: 'http://www.iana.org/assignments/relation/'
     -
         prefix: 'premis'
-        namespace: 'http://www.loc.gov/premis/rdf/v1#',
+        namespace: 'http://www.loc.gov/premis/rdf/v1#'
     -
         prefix: 'premis3'
-        namespace: 'http://www.loc.gov/premis/rdf/v3/',
+        namespace: 'http://www.loc.gov/premis/rdf/v3/'
     -
         prefix: 'co'
-        namespace: 'http://purl.org/co/',
+        namespace: 'http://purl.org/co/'

--- a/config/install/islandora.settings.yml
+++ b/config/install/islandora.settings.yml
@@ -2,3 +2,55 @@ broker_url: 'tcp://localhost:61613'
 jwt_expiry: '+2 hour'
 gemini_url: ''
 gemini_pseudo_bundles: []
+rdf_namespaces:
+    -
+        prefix: 'ldp'
+        namespace: 'http://www.w3.org/ns/ldp#',
+    -
+        prefix: 'dc11'
+        namespace: 'http://purl.org/dc/elements/1.1/',
+    -
+        prefix: 'dcterms'
+        namespace: 'http://purl.org/dc/terms/',
+    -
+        prefix: 'nfo'
+        namespace: 'http://www.semanticdesktop.org/ontologies/2007/03/22/nfo/v1.1/',
+    -
+        prefix: 'ebucore'
+        namespace: 'http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#',
+    -
+        prefix: 'fedora'
+        namespace: 'http://fedora.info/definitions/v4/repository#',
+    -
+        prefix: 'owl'
+        namespace: 'http://www.w3.org/2002/07/owl#',
+    -
+        prefix: 'ore'
+        namespace: 'http://www.openarchives.org/ore/terms/',
+    -
+        prefix: 'rdf'
+        namespace: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
+    -
+        prefix: 'rdau'
+        namespace: 'http://rdaregistry.info/Elements/u/'
+    -
+        prefix: 'islandora'
+        namespace: 'http://islandora.ca/',
+    -
+        prefix: 'pcdm'
+        namespace: 'http://pcdm.org/models#',
+    -
+        prefix: 'use'
+        namespace: 'http://pcdm.org/use#',
+    -
+        prefix: 'iana'
+        namespace: 'http://www.iana.org/assignments/relation/',
+    -
+        prefix: 'premis'
+        namespace: 'http://www.loc.gov/premis/rdf/v1#',
+    -
+        prefix: 'premis3'
+        namespace: 'http://www.loc.gov/premis/rdf/v3/',
+    -
+        prefix: 'co'
+        namespace: 'http://purl.org/co/',

--- a/config/schema/islandora.schema.yml
+++ b/config/schema/islandora.schema.yml
@@ -22,6 +22,18 @@ islandora.settings:
       label: 'List of node, media and taxonomy terms that should include the linked Fedora URI'
       sequence:
         type: string
+    rdf_namespaces:
+        type: sequence
+        label: 'RDF Namespaces'
+        sequence:
+            type: mapping
+            mapping:
+                prefix: 
+                    type: string
+                    label: 'RDF Prefix'
+                namespace:
+                    type: string
+                    label: 'Fully Qualified RDF Namespace'
 
 
 action.configuration.emit_node_event:

--- a/islandora.install
+++ b/islandora.install
@@ -90,3 +90,69 @@ function islandora_update_8005() {
     }
   }
 }
+
+/**
+ * Adds initial namespace configurations.
+ */
+function islandora_update_8006() {
+  $namespaces = [
+    [
+      'prefix' => 'ldp',
+      'namespace' => 'http://www.w3.org/ns/ldp#',
+    ], [
+      'prefix' => 'dc11',
+      'namespace' => 'http://purl.org/dc/elements/1.1/',
+    ], [
+      'prefix' => 'dcterms',
+      'namespace' => 'http://purl.org/dc/terms/',
+    ], [
+      'prefix' => 'nfo',
+      'namespace' => 'http://www.semanticdesktop.org/ontologies/2007/03/22/nfo/v1.1/',
+    ], [
+      'prefix' => 'ebucore',
+      'namespace' => 'http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#',
+    ], [
+      'prefix' => 'fedora',
+      'namespace' => 'http://fedora.info/definitions/v4/repository#',
+    ], [
+      'prefix' => 'owl',
+      'namespace' => 'http://www.w3.org/2002/07/owl#',
+    ], [
+      'prefix' => 'ore',
+      'namespace' => 'http://www.openarchives.org/ore/terms/',
+    ], [
+      'prefix' => 'rdf',
+      'namespace' => 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
+    ], [
+      'prefix' => 'rdau',
+      'namespace' => 'http://rdaregistry.info/Elements/u/',
+    ], [
+      'prefix' => 'islandora',
+      'namespace' => 'http://islandora.ca/',
+    ], [
+      'prefix' => 'pcdm',
+      'namespace' => 'http://pcdm.org/models#',
+    ], [
+      'prefix' => 'use',
+      'namespace' => 'http://pcdm.org/use#',
+    ], [
+      'prefix' => 'iana',
+      'namespace' => 'http://www.iana.org/assignments/relation/',
+    ], [
+      'prefix' => 'premis',
+      'namespace' => 'http://www.loc.gov/premis/rdf/v1#',
+    ], [
+      'prefix' => 'premis3',
+      'namespace' => 'http://www.loc.gov/premis/rdf/v3/',
+    ], [
+      'prefix' => 'co',
+      'namespace' => 'http://purl.org/co/',
+    ],
+  ];
+
+  $config = \Drupal::configFactory()->getEditable('islandora.settings');
+  if ($config && !is_array($config->get('rdf_namespaces'))) {
+    $config->set('rdf_namespaces', $namespaces);
+    $config->save(TRUE);
+  }
+}

--- a/islandora.module
+++ b/islandora.module
@@ -47,25 +47,16 @@ function islandora_help($route_name, RouteMatchInterface $route_match) {
  * Implements hook_rdf_namespaces().
  */
 function islandora_rdf_namespaces() {
-  // Yes, it's amazing, rdf is not registered by default!
-  return [
-    'ldp'  => 'http://www.w3.org/ns/ldp#',
-    'dc11' => 'http://purl.org/dc/elements/1.1/',
-    'dcterms' => 'http://purl.org/dc/terms/',
-    'nfo' => 'http://www.semanticdesktop.org/ontologies/2007/03/22/nfo/v1.1/',
-    'ebucore' => 'http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#',
-    'fedora' => 'http://fedora.info/definitions/v4/repository#',
-    'owl' => 'http://www.w3.org/2002/07/owl#',
-    'ore' => 'http://www.openarchives.org/ore/terms/',
-    'rdf' => 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
-    'islandora' => 'http://islandora.ca/',
-    'pcdm' => 'http://pcdm.org/models#',
-    'use' => 'http://pcdm.org/use#',
-    'iana' => 'http://www.iana.org/assignments/relation/',
-    'premis' => 'http://www.loc.gov/premis/rdf/v1#',
-    'premis3' => 'http://www.loc.gov/premis/rdf/v3/',
-    'co' => 'http://purl.org/co/',
-  ];
+  $config = \Drupal::config('islandora.settings');
+  $namespace_config = $config->get('rdf_namespaces');
+  if (!is_array($namespace_config)) {
+    \Drupal::logger('islandora')->warning("RDF Map config is not an array. Please check your RDF namespaces configuration in islandora core settings.");
+  }
+  $namespaces = [];
+  foreach ($namespace_config as $namespace) {
+    $namespaces[$namespace['prefix']] = $namespace['namespace'];
+  }
+  return $namespaces;
 }
 
 /**

--- a/src/Form/IslandoraSettingsForm.php
+++ b/src/Form/IslandoraSettingsForm.php
@@ -34,6 +34,7 @@ class IslandoraSettingsForm extends ConfigFormBase {
     'month',
     'year',
   ];
+  const RDF_NAMESPACES = 'rdf_namespaces';
 
   /**
    * To list the available bundle types.
@@ -184,6 +185,17 @@ class IslandoraSettingsForm extends ConfigFormBase {
         '#default_value' => $selected_bundles,
       ],
     ];
+
+    $rdf_namespaces = '';
+    foreach ($config->get('rdf_namespaces') as $namespace) {
+      $rdf_namespaces .= $namespace['prefix'] . '|' . $namespace['namespace'] . "\n";
+    }
+    $form[self::RDF_NAMESPACES] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('RDF Namespaces'),
+      '#default_value' => $rdf_namespaces,
+    ];
+
     return parent::buildForm($form, $form_state);
   }
 
@@ -259,6 +271,22 @@ class IslandoraSettingsForm extends ConfigFormBase {
         );
       }
     }
+
+    // Validate RDF Namespaces.
+    foreach (preg_split("/[\r\n]+/", $form_state->getValue(self::RDF_NAMESPACES)) as $line) {
+      if (empty($line)) {
+        continue;
+      }
+      $namespace = explode("|", trim($line));
+      if (empty($namespace[0]) || empty($namespace[1])) {
+        $form_state->setErrorByName(
+          self::RDF_NAMESPACES,
+          $this->t("RDF Namespace form is malformed on line '@line'",
+            ['@line' => trim($line)]
+          )
+        );
+      }
+    }
   }
 
   /**
@@ -285,10 +313,25 @@ class IslandoraSettingsForm extends ConfigFormBase {
       }
     }
 
+    $namespaces_array = [];
+    foreach (preg_split("/[\r\n]+/", $form_state->getValue(self::RDF_NAMESPACES)) as $line) {
+      if (empty($line)) {
+        continue;
+      }
+      $namespace = explode("|", trim($line));
+      if (!empty($namespace[0]) && !empty($namespace[1])) {
+        $namespaces_array[] = [
+          'prefix' => trim($namespace[0]),
+          'namespace' => trim($namespace[1]),
+        ];
+      }
+    }
+
     $config
       ->set(self::BROKER_URL, $form_state->getValue(self::BROKER_URL))
       ->set(self::JWT_EXPIRY, $form_state->getValue(self::JWT_EXPIRY))
       ->set(self::GEMINI_PSEUDO, $pseudo_types)
+      ->set(self::RDF_NAMESPACES, $namespaces_array)
       ->save();
 
     parent::submitForm($form, $form_state);


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1520

Supersedes https://github.com/Islandora-CLAW/islandora/pull/78

# What does this Pull Request do?

Takes the hard-coded namespaces in islandora.module and instead loads them from configuration.

# What's new?

* Moved namespaces from islandora.module into islandora.settings.yml
* Updated islandora.module to pull namespaces from config instead of being hardcoded
* Updated schema to add rdf_namespaces
* Updated islandora core settings form to update rdf_namespaces config

# How should this be tested?

* Create some records and make sure the JSON-LD looks fine
* Apply the PR
* Run drupal updates (`drush updb -y`)
* Clear cache
* Make sure the JSON-LD looks the same
* Go to the core settings form ('/admin/config/islandora/core') and change one of the namespaces used in the JSON-LD you tested.
* Clear cache again
* View the JSON-LD and see the modified namespace in use.

# Additional Notes:

Namespaces hardcoded by other modules in their namespace hooks may or may not be overridden by your values in this config. It depends on the processing order of your modules, which can be changed. The [Drupal 7 docs on this topic](https://www.drupal.org/docs/7/creating-custom-modules/howtos/how-to-update-a-modules-weight) still apply.

# Interested parties
@Islandora/8-x-committers