### PR TITLE
Move rdf namespaces into jsonld config (Issue-1520)

### DIFF
--- a/islandora.install
+++ b/islandora.install
@@ -6,6 +6,13 @@
  */
 
 /**
+ * Adds common namespaces to jsonld.settings.
+ */
+function islandora_install() {
+  update_jsonld_included_namespaces();
+}
+
+/**
  * Delete the 'delete_media' action we used to provide, if it exists.
  *
  * Use the core 'media_delete_action' instead.
@@ -88,5 +95,82 @@ function islandora_update_8005() {
       $config->clear('source.keys');
       $config->save(TRUE);
     }
+  }
+}
+
+/**
+ * Adds adds previously hardcoded namespaces to configuration.
+ */
+function islandora_update_8006() {
+  update_jsonld_included_namespaces();
+}
+
+/**
+ * Used by install and update_8006 to add namespaces to jsonld.settings.yml.
+ */
+function update_jsonld_included_namespaces() {
+  $namespaces = [
+    [
+      'prefix' => 'ldp',
+      'namespace' => 'http://www.w3.org/ns/ldp#',
+    ], [
+      'prefix' => 'dc11',
+      'namespace' => 'http://purl.org/dc/elements/1.1/',
+    ], [
+      'prefix' => 'dcterms',
+      'namespace' => 'http://purl.org/dc/terms/',
+    ], [
+      'prefix' => 'nfo',
+      'namespace' => 'http://www.semanticdesktop.org/ontologies/2007/03/22/nfo/v1.1/',
+    ], [
+      'prefix' => 'ebucore',
+      'namespace' => 'http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#',
+    ], [
+      'prefix' => 'fedora',
+      'namespace' => 'http://fedora.info/definitions/v4/repository#',
+    ], [
+      'prefix' => 'owl',
+      'namespace' => 'http://www.w3.org/2002/07/owl#',
+    ], [
+      'prefix' => 'ore',
+      'namespace' => 'http://www.openarchives.org/ore/terms/',
+    ], [
+      'prefix' => 'rdf',
+      'namespace' => 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
+    ], [
+      'prefix' => 'rdau',
+      'namespace' => 'http://rdaregistry.info/Elements/u/',
+    ], [
+      'prefix' => 'islandora',
+      'namespace' => 'http://islandora.ca/',
+    ], [
+      'prefix' => 'pcdm',
+      'namespace' => 'http://pcdm.org/models#',
+    ], [
+      'prefix' => 'use',
+      'namespace' => 'http://pcdm.org/use#',
+    ], [
+      'prefix' => 'iana',
+      'namespace' => 'http://www.iana.org/assignments/relation/',
+    ], [
+      'prefix' => 'premis',
+      'namespace' => 'http://www.loc.gov/premis/rdf/v1#',
+    ], [
+      'prefix' => 'premis3',
+      'namespace' => 'http://www.loc.gov/premis/rdf/v3/',
+    ], [
+      'prefix' => 'co',
+      'namespace' => 'http://purl.org/co/',
+    ],
+  ];
+
+  $config = \Drupal::configFactory()->getEditable('jsonld.settings');
+  if ($config && !is_array($config->get('rdf_namespaces'))) {
+    $config->set('rdf_namespaces', $namespaces);
+    $config->save(TRUE);
+  }
+  else {
+    \Drupal::logger('islandora')
+      ->warning("Could not find required jsonld.settings to add default RDF namespaces.");
   }
 }

--- a/islandora.module
+++ b/islandora.module
@@ -44,31 +44,6 @@ function islandora_help($route_name, RouteMatchInterface $route_match) {
 }
 
 /**
- * Implements hook_rdf_namespaces().
- */
-function islandora_rdf_namespaces() {
-  // Yes, it's amazing, rdf is not registered by default!
-  return [
-    'ldp'  => 'http://www.w3.org/ns/ldp#',
-    'dc11' => 'http://purl.org/dc/elements/1.1/',
-    'dcterms' => 'http://purl.org/dc/terms/',
-    'nfo' => 'http://www.semanticdesktop.org/ontologies/2007/03/22/nfo/v1.1/',
-    'ebucore' => 'http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#',
-    'fedora' => 'http://fedora.info/definitions/v4/repository#',
-    'owl' => 'http://www.w3.org/2002/07/owl#',
-    'ore' => 'http://www.openarchives.org/ore/terms/',
-    'rdf' => 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
-    'islandora' => 'http://islandora.ca/',
-    'pcdm' => 'http://pcdm.org/models#',
-    'use' => 'http://pcdm.org/use#',
-    'iana' => 'http://www.iana.org/assignments/relation/',
-    'premis' => 'http://www.loc.gov/premis/rdf/v1#',
-    'premis3' => 'http://www.loc.gov/premis/rdf/v3/',
-    'co' => 'http://purl.org/co/',
-  ];
-}
-
-/**
  * Implements hook_node_insert().
  */
 function islandora_node_insert(NodeInterface $node) {

--- a/src/Form/IslandoraSettingsForm.php
+++ b/src/Form/IslandoraSettingsForm.php
@@ -7,6 +7,7 @@ use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Site\Settings;
+use Drupal\Core\Url;
 use Stomp\Client;
 use Stomp\Exception\StompException;
 use Stomp\StatefulStomp;
@@ -184,6 +185,13 @@ class IslandoraSettingsForm extends ConfigFormBase {
         '#default_value' => $selected_bundles,
       ],
     ];
+
+    $form['rdf_namespaces'] = [
+      '#type' => 'link',
+      '#title' => $this->t('Update RDF namespace configurations in the JSON-LD module settings.'),
+      '#url' => Url::fromRoute('system.jsonld_settings'),
+    ];
+
     return parent::buildForm($form, $form_state);
   }
 


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1520

Supersedes https://github.com/Islandora/islandora/pull/831

# What does this Pull Request do?

Enables adding RDF namespaces in config.

# What's new?

* Removes hook_rdf_namespaces
* Adds install and update hooks to add the previously hard-coded namespaces into the jsonld.settings config

# How should this be tested?

Test in conjunction with https://github.com/Islandora/jsonld/pull/53.

# Interested parties
@Islandora/8-x-committers