### PR TITLE
Fix WSOD when media source file is missing

### DIFF
--- a/src/Plugin/Condition/MediaHasMimetype.php
+++ b/src/Plugin/Condition/MediaHasMimetype.php
@@ -151,7 +151,7 @@ class MediaHasMimetype extends ConditionPluginBase implements ContainerFactoryPl
       $mimetypes = explode(',', str_replace(' ', '', $this->configuration['mimetypes']));
       foreach ($media as $medium) {
         $file = $this->mediaSource->getSourceFile($medium);
-        if (in_array($file->getMimeType(), $mimetypes)) {
+        if ($file && in_array($file->getMimeType(), $mimetypes)) {
           return TRUE;
         }
       }


### PR DESCRIPTION
**GitHub Ticket**: N/A

# What does this Pull Request do?

Adds a check to the MediaHasMimetype condition plugin to ensure a source file is found before attempting to call `getMimeType()` on it. This will only occur in rare instances where a file is missing from the media due to a bad migration (which happened to me) or other system failure.

# What's new?

Adds the file variable returned from `$this->mediaSource->getSourceFile($medium)` (which returns false when no file is found) to the subsequent `if` statement and before the getMimeType check.

# How should this be tested?

* Setup a condition using the MediaHasMimetype condition
* Make a node+media where the node would trigger the condition and the media's file field is empty. (Can't be done via the UI.)
* Visit the node page and experience the WSOD.
* Apply the PR
* Visit the node page again; it should load without error.

# Interested parties
@Islandora/8-x-committers 
