### PR TITLE
added tokens to handle islandora > media operation

### DIFF
--- a/islandora.tokens.inc
+++ b/islandora.tokens.inc
@@ -1,0 +1,124 @@
+<?php
+
+/**
+ * @file
+ * Contains islandora.tokens.inc.
+ *
+ * This file provides islandora tokens.
+ */
+
+use Drupal\media\Entity\Media;
+use Drupal\file\Entity\File;
+use Drupal\Core\Render\BubbleableMetadata;
+use Drupal\islandora\IslandoraUtils;
+
+/**
+ * Implements hook_token_info().
+ */
+function islandora_token_info() {
+  $type = [
+    'name' => t('Islandora Tokens'),
+    'description' => t('Tokens for Islandora objects.'),
+  ];
+  $node['media-thumbnail-image:url'] = [
+    'name' => t('Media: Thumbnail Image URL.'),
+    'description' => t('URL of Thumbnail Image associated with Islandora Object via Media.'),
+  ];
+
+  $node['media-thumbnail-image:alt'] = [
+    'name' => t('Alternative text for Media: Thumbnail Image.'),
+    'description' => t('Alternative text for Thumbnail Image associated with Islandora Object via Media.'),
+  ];
+
+  // Deprecated in favour if hyphenated version.
+  $node['media_thumbnail_image:url'] = [
+    'name' => t('Media: Thumbnail Image URL.'),
+    'description' => t('Deprecated: URL of Thumbnail Image associated with Islandora Object via Media.'),
+  ];
+
+  // Deprecated in favour if hyphenated version.
+  $node['media_thumbnail_image:alt'] = [
+    'name' => t('Alternative text for Media: Thumbnail Image.'),
+    'description' => t('Deprecated: Alternative text for Thumbnail Image associated with Islandora Object via Media.'),
+  ];
+
+
+  return [
+    'types' => ['islandoratokens' => $type],
+    'tokens' => ['islandoratokens' => $node],
+  ];
+}
+
+/**
+ * Implements hook_tokens().
+ */
+function islandora_tokens($type, $tokens, array $data, array $options, BubbleableMetadata $bubbleable_metadata) {
+  $replacements = [];
+  if ($type == 'islandoratokens' && !empty($data['node'])) {
+    if (!is_array($tokens) || empty($tokens)) {
+      \Drupal::logger('controlled_access_terms')
+        ->alert('Tokens not correct format: @tokens', [
+          '@tokens' => print_r($tokens, 1),
+        ]);
+      return;
+    }
+    foreach ($tokens as $name => $original) {
+      switch ($name) {
+        case 'media-thumbnail-image:url':
+        case 'media_thumbnail_image:url':
+          $term = $islandoraUtils->getTermForUri('http://pcdm.org/use#ThumbnailImage');
+          $media = $islandoraUtils->getMediaWithTerm($data['node'], $term);
+          // Is there media?
+          // @todo: is this single or multiple?
+          if ($media) {
+            $file = controlled_access_terms_image_from_media($media);
+            if (!empty($file)) {
+              $url = $file->url();
+              $replacements[$original] = $url;
+            }
+          }
+          break;
+
+        case 'media-thumbnail-image:alt':
+        case 'media_thumbnail_image:alt':
+          $alt = '';
+          $islandoraUtils = \Drupal::service('islandora.utils');
+          $term = $islandoraUtils->getTermForUri('http://pcdm.org/use#ThumbnailImage');
+          $media = $islandoraUtils->getMediaWithTerm($data['node'], $term);
+          // Is there media?
+          // @todo: is this single or multiple?
+          if ($media) {
+            // Is the media an image?
+            if (isset($media->field_media_image)) {
+              $alt = $media->field_media_image[0]->alt;
+            }
+          }
+          // @todo: get alt from original or service file, if thumbnail alt is empty.
+          $replacements[$original] = $alt;
+          break;
+      }
+    }
+  }
+  return $replacements;
+}
+
+/**
+ * Get File referenced by given Media.
+ *
+ * @todo: Add to IslandoraUtils?
+ * @todo: Had to remove typehint MediaInterface from function.
+ *
+ * @param \Drupal\media\MediaInterface $media
+ *   The Media to operate on.
+ *
+ * @return mixed
+ *   \Drupal\file\FileInterface on success, NULL otherwise.
+ */
+function controlled_access_terms_image_from_media($media) {
+  $files = [];
+  if ($media->hasField('field_media_image')) {
+    $files = $media->get('field_media_image')->referencedEntities();
+  }
+  return !empty($files) ? reset($files) : NULL;
+}
+

--- a/islandora.tokens.inc
+++ b/islandora.tokens.inc
@@ -7,10 +7,7 @@
  * This file provides islandora tokens.
  */
 
-use Drupal\media\Entity\Media;
-use Drupal\file\Entity\File;
 use Drupal\Core\Render\BubbleableMetadata;
-use Drupal\islandora\IslandoraUtils;
 
 /**
  * Implements hook_token_info().
@@ -42,7 +39,6 @@ function islandora_token_info() {
     'description' => t('Deprecated: Alternative text for Thumbnail Image associated with Islandora Object via Media.'),
   ];
 
-
   return [
     'types' => ['islandoratokens' => $type],
     'tokens' => ['islandoratokens' => $node],
@@ -57,9 +53,11 @@ function islandora_tokens($type, $tokens, array $data, array $options, Bubbleabl
   if ($type == 'islandoratokens' && !empty($data['node'])) {
     if (!is_array($tokens) || empty($tokens)) {
       \Drupal::logger('islandora')
-        ->alert('Tokens not correct format: @tokens', [
-          '@tokens' => print_r($tokens, 1),
-        ]);
+        ->alert(
+            'Tokens not correct format: @tokens', [
+              '@tokens' => print_r($tokens, 1),
+            ]
+        );
       return;
     }
     $islandoraUtils = \Drupal::service('islandora.utils');
@@ -70,7 +68,7 @@ function islandora_tokens($type, $tokens, array $data, array $options, Bubbleabl
           $term = $islandoraUtils->getTermForUri('http://pcdm.org/use#ThumbnailImage');
           $media = $islandoraUtils->getMediaWithTerm($data['node'], $term);
           // Is there media?
-          // @todo: is this single or multiple?
+          // @todo is this single or multiple?
           if ($media) {
             $file = \Drupal::service('islandora.media_source_service')->getSourceFile($media);
             if (!empty($file)) {
@@ -86,14 +84,15 @@ function islandora_tokens($type, $tokens, array $data, array $options, Bubbleabl
           $term = $islandoraUtils->getTermForUri('http://pcdm.org/use#ThumbnailImage');
           $media = $islandoraUtils->getMediaWithTerm($data['node'], $term);
           // Is there media?
-          // @todo: is this single or multiple?
+          // @todo is this single or multiple?
           if ($media) {
             // Is the media an image?
             if (isset($media->field_media_image)) {
               $alt = $media->field_media_image[0]->alt;
             }
           }
-          // @todo: get alt from original or service file, if thumbnail alt is empty.
+          // @todo get alt from original or service file, if thumbnail
+          // alt is empty.
           $replacements[$original] = $alt;
           break;
       }

--- a/islandora.tokens.inc
+++ b/islandora.tokens.inc
@@ -56,7 +56,7 @@ function islandora_tokens($type, $tokens, array $data, array $options, Bubbleabl
   $replacements = [];
   if ($type == 'islandoratokens' && !empty($data['node'])) {
     if (!is_array($tokens) || empty($tokens)) {
-      \Drupal::logger('controlled_access_terms')
+      \Drupal::logger('islandora')
         ->alert('Tokens not correct format: @tokens', [
           '@tokens' => print_r($tokens, 1),
         ]);
@@ -72,7 +72,7 @@ function islandora_tokens($type, $tokens, array $data, array $options, Bubbleabl
           // Is there media?
           // @todo: is this single or multiple?
           if ($media) {
-            $file = controlled_access_terms_image_from_media($media);
+            $file = \Drupal::service('islandora.media_source_service')->getSourceFile($media);
             if (!empty($file)) {
               $url = $file->url();
               $replacements[$original] = $url;
@@ -101,24 +101,3 @@ function islandora_tokens($type, $tokens, array $data, array $options, Bubbleabl
   }
   return $replacements;
 }
-
-/**
- * Get File referenced by given Media.
- *
- * @todo: Add to IslandoraUtils?
- * @todo: Had to remove typehint MediaInterface from function.
- *
- * @param \Drupal\islandora\MediaSource\MediaSourceService $media
- *   The Media to operate on.
- *
- * @return mixed
- *   \Drupal\file\FileInterface on success, NULL otherwise.
- */
-function controlled_access_terms_image_from_media($media) {
-  $files = [];
-  if ($media->hasField('field_media_image')) {
-    $files = $media->get('field_media_image')->referencedEntities();
-  }
-  return !empty($files) ? reset($files) : NULL;
-}
-

--- a/islandora.tokens.inc
+++ b/islandora.tokens.inc
@@ -62,6 +62,7 @@ function islandora_tokens($type, $tokens, array $data, array $options, Bubbleabl
         ]);
       return;
     }
+    $islandoraUtils = \Drupal::service('islandora.utils');
     foreach ($tokens as $name => $original) {
       switch ($name) {
         case 'media-thumbnail-image:url':
@@ -82,7 +83,6 @@ function islandora_tokens($type, $tokens, array $data, array $options, Bubbleabl
         case 'media-thumbnail-image:alt':
         case 'media_thumbnail_image:alt':
           $alt = '';
-          $islandoraUtils = \Drupal::service('islandora.utils');
           $term = $islandoraUtils->getTermForUri('http://pcdm.org/use#ThumbnailImage');
           $media = $islandoraUtils->getMediaWithTerm($data['node'], $term);
           // Is there media?
@@ -108,7 +108,7 @@ function islandora_tokens($type, $tokens, array $data, array $options, Bubbleabl
  * @todo: Add to IslandoraUtils?
  * @todo: Had to remove typehint MediaInterface from function.
  *
- * @param \Drupal\media\MediaInterface $media
+ * @param \Drupal\islandora\MediaSource\MediaSourceService $media
  *   The Media to operate on.
  *
  * @return mixed


### PR DESCRIPTION
This adds the two tokens that relate to media from the previously created "islandora_tokens" made by @kayakr 

**JIRA Ticket**: https://github.com/Islandora/documentation/issues/1171

* Other Relevant Links (Google Groups discussion, related pull requests, Release pull requests, etc.)
The other part of the tokens (that was in the "ASU islandora_tokens" module) have been moved into a pull request on the `controlled_access_terms` module.

# What does this Pull Request do?
Adds two tokens (well four if you count the deprecated aliases) that can output a Repository Item's media field_media_image value by using one of the tokens like "media-thumbnail-image:alt" and "media-thumbnail-image:url", or "media_thumbnail_image:alt" and "media_thumbnail_image:url"

A brief description of what the intended result of the PR will be and/or what problem it solves.
Anywhere tokens may be used in Drupal, this allows the output of a Repository Item's media field_media_image value

# How should this be tested?
From the Metatag settings interface, adjust the configuration for a "Repository item" to add a field value that uses one of the new tokens. Save config.
Refresh the page for any Repository item that does have media and inspect the <html><head><meta> section to see if the new value is represented.


# Additional Notes:
This branch and the identically named branch on `controlled_access_terms` together represent the entire set of tokens that were made in two separate `islandora_tokens` modules that were simultaneously invented for slightly different needs. The ASU one was mostly for populating the Google Scholar metatags.
 
# Interested parties
@dannylamb, @Islandora/8-x-committers, @kayakr 
