### PR TITLE
In media migrate, error "Call to function getMimeType() on null" (1825)

### DIFF
--- a/src/Plugin/Condition/MediaSourceHasMimetype.php
+++ b/src/Plugin/Condition/MediaSourceHasMimetype.php
@@ -55,7 +55,7 @@ class MediaSourceHasMimetype extends ConditionPluginBase {
         $source = $entity->getSource();
         if ($source) {
           $source_file = File::load($source->getSourceFieldValue($entity));
-          if ($this->configuration['mimetype'] == $source_file->getMimeType()) {
+          if (!empty($source_file) && $this->configuration['mimetype'] == $source_file->getMimeType()) {
             return TRUE;
           }
         }


### PR DESCRIPTION
[In media migrate, error "Call to function getMimeType() on null](https://github.com/Islandora/documentation/issues/1825)

# What does this Pull Request do?

Fixes error where a function is potentially called on a null object.

# What's new?
Add a check to make sure the $source_file variable is not empty before getting the file's mime type.

# How should this be tested?

Testing of a migration that includes files and media, the migration should complete without this error.

# Additional Notes:

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/7-x-1-x-committers
