### PR TITLE
Issue #1848 EmitFileEvent.php: Call to undefined function getFileUri()

### DIFF
--- a/src/Plugin/Action/EmitFileEvent.php
+++ b/src/Plugin/Action/EmitFileEvent.php
@@ -105,18 +105,22 @@ class EmitFileEvent extends EmitEvent {
    * {@inheritdoc}
    */
   protected function generateData(EntityInterface $entity) {
-    $uri = $entity->getFileUri();
-    $scheme = StreamWrapperManager::getScheme($uri);
-    $flysystem_config = Settings::get('flysystem');
-
     $data = parent::generateData($entity);
-    if (isset($flysystem_config[$scheme]) && $flysystem_config[$scheme]['driver'] == 'fedora') {
-      // Fdora $uri for files may contain ':///' so we need to replace
-      // the three / with two.
-      if (strpos($uri, $scheme . ':///') !== FALSE) {
-        $uri = str_replace($scheme . ':///', $scheme . '://', $uri);
+
+    // This function is called on Media and File entity types.
+    if (method_exists($entity, 'getFileUri')) {
+      $uri = $entity->getFileUri();
+      $scheme = StreamWrapperManager::getScheme($uri);
+      $flysystem_config = Settings::get('flysystem');
+
+      if (isset($flysystem_config[$scheme]) && $flysystem_config[$scheme]['driver'] == 'fedora') {
+        // Fdora $uri for files may contain ':///' so we need to replace
+        // the three / with two.
+        if (strpos($uri, $scheme . ':///') !== FALSE) {
+          $uri = str_replace($scheme . ':///', $scheme . '://', $uri);
+        }
+        $data['fedora_uri'] = str_replace("$scheme://", $flysystem_config[$scheme]['config']['root'], $uri);
       }
-      $data['fedora_uri'] = str_replace("$scheme://", $flysystem_config[$scheme]['config']['root'], $uri);
     }
     return $data;
   }


### PR DESCRIPTION


Github Issue: [EmitFileEvent.php: Call to undefined function getFileUri()](https://github.com/Islandora/documentation/issues/1848)

# What does this Pull Request do?

Adds an explicit check before calling a function that can be on a Media or File entity type.

# What's new?

The event generation that happens after a context reaction to index an external file in fedora accepts entity types that are either Media or File objects.  The generateData function assumes that the object is always a File when it checks to make sure the fedora:// URI does not have one-too-many slashes in it.

This change simply explicitly checks if a getFileUri() function exists before calling it.

# How should this be tested?


Follow the steps to reproduce in the linked GitHub issue, namely: Create a Media such as Image in a fresh Islandora install. 

Check that all derivatives are generated, and look in the Watchdog log to ensure that the error that the getFileUri() function does not exist is no longer reported.

, @Islandora/8-x-committers 
