### PR TITLE
check audio textTracks before trying to use them for #1871

### DIFF
--- a/modules/islandora_audio/js/audio.js
+++ b/modules/islandora_audio/js/audio.js
@@ -21,10 +21,12 @@
     function init(context,settings){
         if (!initialized){
             initialized = true;
-	    $('audio')[0].textTracks[0].oncuechange = function() {
-		var currentCue = this.activeCues[0].text;
-		$('#audioTrack').html(currentCue);
-	    }
+            if ($('audio')[0].textTracks.length > 0) {
+                $('audio')[0].textTracks[0].oncuechange = function() {
+                    var currentCue = this.activeCues[0].text;
+                    $('#audioTrack').html(currentCue);
+                }
+            }
         }
     }
     Drupal.Audio = Drupal.Audio || {};


### PR DESCRIPTION
**GitHub Issue**: ([https://github.com/Islandora/documentation/issues/1871](https://github.com/Islandora/documentation/issues/1871))

# What does this Pull Request do?
This should fix the error that was noticed with issue [#1871](https://github.com/Islandora/documentation/issues/1871). The adjusted code only checks that the textTracks exist before trying to loop through the cues within them to set the HTML accordingly.

# How should this be tested?
### To see the problem that is observed in the related issue 1871:
 - The Format for the audio file must also be set to "Audio with Captions" for either Source or Default http://localhost:8000/admin/structure/media/manage/audio/display or http://localhost:8000/admin/structure/media/manage/audio/display/source... otherwise the audio.js file is not attached via the twig template.
 - With an item that has an audio model -- and media attached that is a simple MP3 file or WAV file (for example, https://file-examples-com.github.io/uploads/2017/11/file_example_MP3_700KB.mp3 can be downloaded locally and used as an item's media) -- and there has not been a .vtt file associated with the media, then the error would be visible on the items' media page in the (Chrome | Inspect) javascript console.
 - confirm that the audio that DOES have tracks works as expected

### To test the pull request:
1. pull in the code change for this PR
2. Check the item that exhibited the javascript console error as above and confirm that the error message is gone.