### PR TITLE
Add "Documentation" section to pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -30,7 +30,7 @@ A description of what steps someone could take to:
 
 # Documentation Status
 
-* Does this change existing behaveiour that's currently documented?
+* Does this change existing behaviour that's currently documented?
 * Does this change require new pages or sections of documentation?
 * Who does this need to be documented for?
 * Associated documentation pull request(s): ___  or documentation issue ___

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,7 +15,6 @@ A in-depth description of the changes made by this PR. Technical details and
 * Changes x feature to such that y
 * Added x
 * Removed y
-* Does this change require documentation to be updated? 
 * Does this change add any new dependencies? 
 * Does this change require any other modifications to be made to the repository
  (i.e. Regeneration activity, etc.)? 
@@ -28,6 +27,13 @@ A description of what steps someone could take to:
 * Test that the Pull Request does what is intended.
 * Please be as detailed as possible.
 * Good testing instructions help get your PR completed faster.
+
+# Documentation Status
+
+* Does this change existing behaveiour that's currently documented?
+* Does this change require new pages or sections of documentation?
+* Who does this need to be documented for?
+* Associated documentation pull request(s): ___  or documentation issue ___
 
 # Additional Notes:
 Any additional information that you think would be helpful when reviewing this


### PR DESCRIPTION
**GitHub Issue**: none

in response to the ICG report, many groups have discussed improving the documentation workflow. This is a result of the [Tech Call of Aug 11 2021](https://github.com/Islandora/documentation/wiki/August-11%2C-2021). 

# What does this Pull Request do?

New section to consider in this here pull request template.

# What's new?

We want to encourage documentation thoughts, if not actions, along with changes to code.  We don't want to hold up the process of getting code in, but there is an implication that you should create an issue or PR to document it.

# How should this be tested?

Take a look, do you think it'll be useful?

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag  @Islandora/8-x-committers 