### PR TITLE
Include day as a valid time integer for JWT

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,9 +6,9 @@ name: CI
 on:
   # Triggers the workflow on push or pull request events but only for the 7.x branch
   push:
-    branches: [ 8.x-1.x ]
+    branches: [ 2.x ]
   pull_request:
-    branches: [ 8.x-1.x ]
+    branches: [ 2.x ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/src/Form/IslandoraSettingsForm.php
+++ b/src/Form/IslandoraSettingsForm.php
@@ -34,6 +34,7 @@ class IslandoraSettingsForm extends ConfigFormBase {
     'min',
     'minute',
     'hour',
+    'day',
     'week',
     'month',
     'year',


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1498

# What does this Pull Request do?

The field documentation suggests '2 days' but it looks like 'day' was overlooked in the valid time interval list. 
I don't see a list of strtotime's acceptable integers but since 'day' is mentioned so much (including in validation messages!) it should at least pass. 

# What's new?
 
you can specify integers in days.

# How should this be tested?

`1 day` or `2 days` or `120 days` should pass validation.

They should also probably cause the JWT token to be good for that long, but I dont' know how to test that!

# Documentation Status

* Does this change existing behaviour that's currently documented? -  it makes behaviour match documentation. 
* Does this change require new pages or sections of documentation? - no
* Who does this need to be documented for? - admins.
* Associated documentation pull request(s): ___  or documentation issue ___ (already documented)

# Additional Notes:

# Interested parties

 @Islandora/8-x-committers
