### PR TITLE
Fixing 'Undefined index: rel' notice in logs

### DIFF
--- a/src/Flysystem/Adapter/FedoraAdapter.php
+++ b/src/Flysystem/Adapter/FedoraAdapter.php
@@ -152,7 +152,7 @@ class FedoraAdapter implements AdapterInterface {
     }
     // phpcs:enable
     foreach ($links as $link) {
-      if ($link['rel'] == 'type' && $link[0] == '<http://www.w3.org/ns/ldp#NonRDFSource>') {
+      if (isset($link['rel']) && $link['rel'] == 'type' && $link[0] == '<http://www.w3.org/ns/ldp#NonRDFSource>') {
         $type = 'file';
         break;
       }


### PR DESCRIPTION
**GitHub Issue**: Resolves https://github.com/Islandora/documentation/issues/1870

# What does this Pull Request do?

`isset` check on the `rel` attribute for link headers in the code that talks to Fedora.

# How should this be tested?

If you were experiencing the notices in logs from https://github.com/Islandora/documentation/issues/1870
, this should remove those from the logs

# Documentation Status

No changes neccessary

# Interested parties
@Islandora/8-x-committers
