### PR TITLE
Issues 1888 & 1886: fix broken islandora_core_feature_update_8001

### DIFF
--- a/modules/islandora_core_feature/islandora_core_feature.install
+++ b/modules/islandora_core_feature/islandora_core_feature.install
@@ -114,7 +114,7 @@ function islandora_core_feature_update_8001(&$sandbox) {
         ->orderBy('o.entity_id', 'ASC')
         ->orderBy('o.revision_id', 'ASC')
         ->orderBy('o.delta', 'ASC')
-        ->range($sandbox['progress'], $sandbox['progress'] + $limit);
+        ->range($sandbox['progress'], $limit);
       $database->insert($table)->from($query)->execute();
     }
   }

--- a/modules/islandora_core_feature/islandora_core_feature.install
+++ b/modules/islandora_core_feature/islandora_core_feature.install
@@ -125,7 +125,7 @@ function islandora_core_feature_update_8001(&$sandbox) {
     // Clean up.
     foreach ($tables as $table) {
       $database->schema()->dropTable($table . '_o');
-      if ($sandbox['progress'] + $limit >= $progress[$table]['size']) {
+      if ($sandbox['progress'] + $limit >= $sandbox[$table]['size']) {
         $sandbox[$table]['done'] = TRUE;
       }
     }


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1888 & https://github.com/Islandora/documentation/issues/1886

# What does this Pull Request do?

I mistakenly added the progress marker to the range's limit parameter when copying values back from a temporary table into the updated file size table. 🤦‍♂️ This broke the migration for any site with more than 1,000 media.

This PR removes that erroneous addition so the limit stays constant, _like it supposed to_.

Also fixes the undefined $progress variable.

# What's new?

Fixes a broken update hook.

# How should this be tested?

* Take an islandora ^8.x-1.0 site (or dev pre-March 2021) with more than 1000 media.
* Backup your database.
* `composer require islandora/islandora:^2`
* `drush updb -y` and watch it go *boom* with a message similar to:
 ```
>  [error]  SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '1004-1004-0-0-en' for key 'PRIMARY': 
INSERT INTO {media_revision__field_file_size} SELECT o.*
> FROM
> {media_revision__field_file_size_o} o
> ORDER BY o.entity_id ASC, o.revision_id ASC, o.delta ASC
> LIMIT 1500 OFFSET 1000; Array
> (
> )
>  
>  [error]  Update failed: islandora_core_feature_update_8001 
```
* Restore your backed-up database
* Apply the PR
* `drush updb -y` again and this time it should complete successfully.

# Interested parties
@Islandora/8-x-committers, especially @kayakr
