### PR TITLE
Add missing use statement

### DIFF
--- a/src/EventSubscriber/StompHeaderEventSubscriber.php
+++ b/src/EventSubscriber/StompHeaderEventSubscriber.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\islandora\EventSubscriber;
 
+use Drupal\islandora\Event\StompHeaderEventException;
 use Drupal\islandora\Event\StompHeaderEventInterface;
 use Drupal\jwt\Authentication\Provider\JwtAuth;
 


### PR DESCRIPTION
**GitHub Issue**: n/a

See [this comment](https://github.com/Islandora-Devops/islandora-playbook/pull/201#issuecomment-932492663), but essentially a `use` statement is missing. 

# What does this Pull Request do?

Adds the missing use statement

# How should this be tested?

This appeared when installing the module (during the creation of a playbook instance), but I imagine if you uninstalled islandora (and all the dependant modules) and tried to re-install it you would get the error.

# Interested parties
@Islandora/8-x-committers (@rosiel and @alxp)
