### PR TITLE
Explicitly close fedora flysystem connections

### DIFF
--- a/src/Flysystem/Adapter/FedoraAdapter.php
+++ b/src/Flysystem/Adapter/FedoraAdapter.php
@@ -96,7 +96,7 @@ class FedoraAdapter implements AdapterInterface {
    * {@inheritdoc}
    */
   public function getMetadata($path) {
-    $response = $this->fedora->getResourceHeaders($path);
+    $response = $this->fedora->getResourceHeaders($path, ['Connection' => 'close']);
 
     if ($response->getStatusCode() != 200) {
       return FALSE;

--- a/src/Flysystem/Adapter/FedoraAdapter.php
+++ b/src/Flysystem/Adapter/FedoraAdapter.php
@@ -50,7 +50,7 @@ class FedoraAdapter implements AdapterInterface {
    * {@inheritdoc}
    */
   public function has($path) {
-    $response = $this->fedora->getResourceHeaders($path);
+    $response = $this->fedora->getResourceHeaders($path, ['Connection' => 'close']);
     return $response->getStatusCode() == 200;
   }
 
@@ -77,7 +77,7 @@ class FedoraAdapter implements AdapterInterface {
    * {@inheritdoc}
    */
   public function readStream($path) {
-    $response = $this->fedora->getResource($path);
+    $response = $this->fedora->getResource($path, ['Connection' => 'close']);
 
     if ($response->getStatusCode() != 200) {
       return FALSE;
@@ -184,7 +184,10 @@ class FedoraAdapter implements AdapterInterface {
       return [];
     }
     // Get the resource from Fedora.
-    $response = $this->fedora->getResource($normalized, ['Accept' => 'application/ld+json']);
+    $response = $this->fedora->getResource($normalized, [
+      'Accept' => 'application/ld+json',
+      'Connection' => 'close',
+    ]);
     $jsonld = (string) $response->getBody();
     $graph = json_decode($jsonld, TRUE);
 
@@ -379,7 +382,7 @@ class FedoraAdapter implements AdapterInterface {
    *   NULL if no tombstone, TRUE if tombstone deleted, FALSE otherwise.
    */
   private function deleteTombstone($path) {
-    $response = $this->fedora->getResourceHeaders($path);
+    $response = $this->fedora->getResourceHeaders($path, ['Connection' => 'close']);
     $return = NULL;
     if ($response->getStatusCode() == 410) {
       $return = FALSE;

--- a/tests/src/Kernel/FedoraAdapterTest.php
+++ b/tests/src/Kernel/FedoraAdapterTest.php
@@ -51,8 +51,8 @@ class FedoraAdapterTest extends IslandoraKernelTestBase {
     $response = $prophecy->reveal();
 
     $prophecy = $this->prophesize(IFedoraApi::class);
-    $prophecy->getResourceHeaders('')->willReturn($response);
-    $prophecy->getResource('')->willReturn($response);
+    $prophecy->getResourceHeaders('', ['Connection' => 'close'])->willReturn($response);
+    $prophecy->getResource('', ['Connection' => 'close'])->willReturn($response);
     $api = $prophecy->reveal();
 
     $mime_guesser = $this->prophesize(MimeTypeGuesserInterface::class)
@@ -69,8 +69,8 @@ class FedoraAdapterTest extends IslandoraKernelTestBase {
     $response = $prophecy->reveal();
 
     $prophecy = $this->prophesize(IFedoraApi::class);
-    $prophecy->getResourceHeaders('')->willReturn($response);
-    $prophecy->getResource('')->willReturn($response);
+    $prophecy->getResourceHeaders('', ['Connection' => 'close'])->willReturn($response);
+    $prophecy->getResource('', ['Connection' => 'close'])->willReturn($response);
     $api = $prophecy->reveal();
 
     $mime_guesser = $this->prophesize(MimeTypeGuesserInterface::class)
@@ -95,7 +95,7 @@ class FedoraAdapterTest extends IslandoraKernelTestBase {
     $response = $prophecy->reveal();
 
     $prophecy = $this->prophesize(IFedoraApi::class);
-    $prophecy->getResourceHeaders('')->willReturn($response);
+    $prophecy->getResourceHeaders('', ['Connection' => 'close'])->willReturn($response);
     $api = $prophecy->reveal();
 
     $mime_guesser = $this->prophesize(MimeTypeGuesserInterface::class)
@@ -122,7 +122,7 @@ class FedoraAdapterTest extends IslandoraKernelTestBase {
 
     $prophecy = $this->createAdapterBase();
 
-    $fedora_prophecy->getResourceHeaders('')->willReturn($prophecy->reveal());
+    $fedora_prophecy->getResourceHeaders('', ['Connection' => 'close'])->willReturn($prophecy->reveal());
 
     $api = $fedora_prophecy->reveal();
 
@@ -139,7 +139,7 @@ class FedoraAdapterTest extends IslandoraKernelTestBase {
     $fedora_prophecy = $this->prophesize(IFedoraApi::class);
     $prophecy = $this->prophesize(Response::class);
     $prophecy->getStatusCode()->willReturn(500);
-    $fedora_prophecy->getResourceHeaders('')->willReturn($prophecy->reveal());
+    $fedora_prophecy->getResourceHeaders('', ['Connection' => 'close'])->willReturn($prophecy->reveal());
 
     $prophecy = $this->prophesize(Response::class);
     $prophecy->getStatusCode()->willReturn(500);
@@ -176,7 +176,7 @@ class FedoraAdapterTest extends IslandoraKernelTestBase {
         '<http://www.w3.org/ns/ldp#RDFSource>;rel="type"',
       ]);
 
-    $fedora_prophecy->getResourceHeaders('')->willReturn($prophecy->reveal());
+    $fedora_prophecy->getResourceHeaders('', ['Connection' => 'close'])->willReturn($prophecy->reveal());
 
     $api = $fedora_prophecy->reveal();
 
@@ -196,7 +196,7 @@ class FedoraAdapterTest extends IslandoraKernelTestBase {
     $prophecy->getStatusCode()->willReturn(204);
 
     $fedora_prophecy->deleteResource('')->willReturn($prophecy->reveal());
-    $fedora_prophecy->getResourceHeaders('')->willReturn($prophecy->reveal());
+    $fedora_prophecy->getResourceHeaders('', ['Connection' => 'close'])->willReturn($prophecy->reveal());
     $api = $fedora_prophecy->reveal();
 
     $mime_guesser = $this->prophesize(MimeTypeGuesserInterface::class)
@@ -242,7 +242,7 @@ class FedoraAdapterTest extends IslandoraKernelTestBase {
     $tombstone_prophecy->getStatusCode()->willReturn(204);
 
     $fedora_prophecy->deleteResource('')->willReturn($prophecy->reveal());
-    $fedora_prophecy->getResourceHeaders('')
+    $fedora_prophecy->getResourceHeaders('', ['Connection' => 'close'])
       ->willReturn($head_prophecy->reveal());
     $fedora_prophecy->deleteResource('some-path-to-a-tombstone')
       ->willReturn($tombstone_prophecy->reveal());
@@ -273,7 +273,7 @@ class FedoraAdapterTest extends IslandoraKernelTestBase {
     $tombstone_prophecy->getStatusCode()->willReturn(500);
 
     $fedora_prophecy->deleteResource('')->willReturn($prophecy->reveal());
-    $fedora_prophecy->getResourceHeaders('')
+    $fedora_prophecy->getResourceHeaders('', ['Connection' => 'close'])
       ->willReturn($head_prophecy->reveal());
     $fedora_prophecy->deleteResource('some-path-to-a-tombstone')
       ->willReturn($tombstone_prophecy->reveal());
@@ -606,7 +606,7 @@ class FedoraAdapterTest extends IslandoraKernelTestBase {
     $response = $prophecy->reveal();
 
     $fedora_prophecy = $this->prophesize(IFedoraApi::class);
-    $fedora_prophecy->getResource(Argument::any())->willReturn($response);
+    $fedora_prophecy->getResource(Argument::any(), ['Connection' => 'close'])->willReturn($response);
 
     $prophecy = $this->prophesize(Response::class);
     $prophecy->getStatusCode()->willReturn(201);
@@ -633,7 +633,7 @@ class FedoraAdapterTest extends IslandoraKernelTestBase {
     $prophecy->getHeader('Content-Length')->willReturn([strlen("DERP")]);
     $response = $prophecy->reveal();
 
-    $fedora_prophecy->getResourceHeaders(Argument::any())
+    $fedora_prophecy->getResourceHeaders(Argument::any(), ['Connection' => 'close'])
       ->willReturn($response);
 
     $prophecy = $this->prophesize(Response::class);


### PR DESCRIPTION
**GitHub Issue**: None

See https://islandora.slack.com/archives/CM5PPAV28/p1634323444315000 for the problem description and https://islandora.slack.com/archives/CM5PPAV28/p1634827620002700?thread_ts=1634323444.315000&cid=CM5PPAV28 for the explanation.

# What does this Pull Request do?

Imagine you run a restaurant. Normally volume is low so you can allow guests to sit at their table as long as they wish after completing their meal. Now imagine that volume has jumped drastically and that guests hanging around after their meal is resulting in a massive table wait-times.

Flysystem/Fedora client/Guzzle was issuing requests to Fedora with Connections as 'keep alive' which kept them open long after they were done and absorbing all the available TCP connections resulting in an unresponsive server.

This PR explicitly tells the Fedora/Guzzle client to close the connection when it is done, freeing up connections for new requests.

# What's new?

Update the fedora getResource calls in the Flysystem adapter with header arrays to include `'Connection' => 'close'` .

* Does this change add any new dependencies? No.
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? No.
* Could this change impact execution of existing code? No.

# How should this be tested?

_Really, this should be good with just a smoke test. Spin up the PR and see that nothing breaks. Trying to test scalability issues can be a beast..._

* Spin up an Islandora site
* Download a bunch of original files using flysystem
* Observe that the TCP connections are starting to pile up.
* Restart Tomcat and see them all disappear.
* Apply the PR
* Download a bunch of original files using flysystem again
* Observe that the TCP connections remain reasonably low.

# Documentation Status

* Does this change existing behaviour that's currently documented? No.
* Does this change require new pages or sections of documentation? No.
* Who does this need to be documented for? N/A

# Interested parties
@Islandora/8-x-committers
