### PR TITLE
Check if the cue has changed before updating the HTML.

### DIFF
--- a/modules/islandora_audio/js/audio.js
+++ b/modules/islandora_audio/js/audio.js
@@ -23,8 +23,10 @@
             initialized = true;
             if ($('audio')[0].textTracks.length > 0) {
                 $('audio')[0].textTracks[0].oncuechange = function() {
+                  if (this.activeCues.length > 0) {
                     var currentCue = this.activeCues[0].text;
                     $('#audioTrack').html(currentCue);
+                  }
                 }
             }
         }


### PR DESCRIPTION
**GitHub Issue**: N/A

# What does this Pull Request do?
Fixes a JS error that can pop when a cue is attempting to be updated but has not yet changed.

# What's new?
A conditional.

# How should this be tested?

- Create an audio object, media and associated file and attach a VTT track to the service file.
- View the audio object and play it in the player
- Open the console and notice a similar looking screenshot:


<img width="1709" alt="Screen Shot 2021-10-27 at 1 55 55 PM" src="https://user-images.githubusercontent.com/1337738/139111690-62b61cef-9bb4-47b7-8f16-efc2380ca791.png">

# Documentation Status

* Does this change existing behaviour that's currently documented? No
* Does this change require new pages or sections of documentation? No

# Interested parties
@elizoller / @Islandora/8-x-committers
