### PR TITLE
Check we're not trying to delete default media thumbnails

### DIFF
--- a/src/Form/ConfirmDeleteMediaAndFile.php
+++ b/src/Form/ConfirmDeleteMediaAndFile.php
@@ -134,6 +134,15 @@ class ConfirmDeleteMediaAndFile extends DeleteMultipleForm {
           $file = File::load($target_id);
           if ($file) {
             if (!$file->access('delete', $this->currentUser)) {
+              // May not be allowed access because it is a default thumbnail for media type.
+              if ($field->getName() == 'thumbnail') {
+                $default_thumbnail_filename = $entity->getSource()->getPluginDefinition()['default_thumbnail_filename'];
+                $default_thumbnail_uri = \Drupal::config('media.settings')
+                  ->get('icon_base_uri') . '/' . $default_thumbnail_filename;
+                if ($default_thumbnail_uri == $file->getFileUri()) {
+                  continue;
+                }
+              }              
               $inaccessible_entities[] = $file;
               continue;
             }


### PR DESCRIPTION
When using the "Delete media and files" views bulk operation on a FITS media type, for example, Drupal comes back saying we don't have permission to delete "x" number of files. This is because one of the files it is trying to delete is the default thumbnail for the media type. This is confusing to clients and so I suggest we remove default thumbnails from the list of inaccessible entities.

**GitHub Issue**: [(link)](https://github.com/Islandora/documentation/issues/1982)

# What does this Pull Request do?

Removes default thumbnails from the list of inaccessible entities when deleting multiple media and files.

# What's new?
A in-depth description of the changes made by this PR. Technical details and
 possible side effects.

* Checks whether one of the files being deleted is a default thumbnail for the type of media being deleted.

# How should this be tested?

Create a media item on a repository item which uses a default thumbnail (eg: FITs), then use the "Delete media and files" action on it and you should see a warning: "X items have not been deleted because you do not have the necessary permissions".

Checkout this pull request branch, repeat steps above and you should not see the warning.

# Documentation Status

This is under-the-hood, shouldn't need any docs updated.

# Additional Notes:

Let me know if I'm using the system incorrectly, and/or whether there is a better solution to this.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/8-x-committers
