### PR TITLE
Welcome message on new site / homepage

### DIFF
--- a/islandora.install
+++ b/islandora.install
@@ -174,3 +174,26 @@ function update_jsonld_included_namespaces() {
       ->warning("Could not find required jsonld.settings to add default RDF namespaces.");
   }
 }
+
+/**
+ * Switches homepage to a twig based version.
+ */
+function islandora_update_8007() {
+  reset_homepage();
+}
+
+/**
+ * Used by install and update_8007 to reset homepage to use twig.
+ */
+function reset_homepage() {
+  $frontPage = \Drupal::configFactory()->get('system.site')->get('page.front');
+  $original_template = \Drupal::service('file_system')->realpath(\Drupal::service('module_handler')->getModule('islandora')->getPath());
+  $theme_templates = DRUPAL_ROOT . '/' . drupal_get_path('theme', \Drupal::config('system.theme')->get('default')) . '/templates';
+  if (! file_exists($theme_templates . '/welcome.html.twig')) {
+    copy( $original_template . '/templates/welcome.html.twig', $theme_templates . '/welcome.html.twig');
+    copy( $original_template . '/templates/welcome_base.html.twig', $theme_templates . '/welcome_base.html.twig');
+  }
+  if ($frontPage != '/welcome') {
+    \Drupal::configFactory()->getEditable('system.site')->set('page.front', '/welcome')->save();
+  }
+}

--- a/islandora.install
+++ b/islandora.install
@@ -176,14 +176,7 @@ function update_jsonld_included_namespaces() {
 }
 
 /**
- * Switches homepage to a twig based version.
- */
-function islandora_update_8007() {
-  reset_homepage();
-}
-
-/**
- * Used by install and update_8007 to reset homepage to use twig.
+ * Used to set homepage to use twig.
  */
 function reset_homepage() {
   $frontPage = \Drupal::configFactory()->get('system.site')->get('page.front');
@@ -193,7 +186,7 @@ function reset_homepage() {
     copy( $original_template . '/templates/welcome.html.twig', $theme_templates . '/welcome.html.twig');
     copy( $original_template . '/templates/welcome_base.html.twig', $theme_templates . '/welcome_base.html.twig');
   }
-  if ($frontPage != '/welcome') {
-    \Drupal::configFactory()->getEditable('system.site')->set('page.front', '/welcome')->save();
+  if ($frontPage != '/islandora_welcome') {
+    \Drupal::configFactory()->getEditable('system.site')->set('page.front', '/islandora_welcome')->save();
   }
 }

--- a/islandora.module
+++ b/islandora.module
@@ -536,3 +536,17 @@ function islandora_preprocess_views_view_table(&$variables) {
     }
   }
 }
+
+/**
+ * Implements hook_theme()
+ * @return mixed
+ */
+function islandora_theme() {
+  // If homepage is not manually set, use the default.
+  $theme['welcome'] = [
+    'variables' => ['name' => NULL],
+    'template' => 'welcome',
+  ];
+
+  return $theme;
+}

--- a/islandora.routing.yml
+++ b/islandora.routing.yml
@@ -108,3 +108,11 @@ islandora.confirm_delete_media_and_file:
     _form: 'Drupal\islandora\Form\ConfirmDeleteMediaAndFile'
   requirements:
     _permission: 'administer media+delete any media'
+
+islandora.welcome:
+  path: '/welcome'
+  defaults:
+    _controller: '\Drupal\islandora\Controller\HomeController::welcome'
+    _title: 'Welcome to Islandora'
+  requirements:
+    _permission: 'access content'

--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * @file
+ * Contains \Drupal\islandora\Controller\HomeController.
+ */
+
+namespace Drupal\islandora\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Views\ViewExecutable;
+use Drupal\views\Views;
+
+class HomeController extends ControllerBase {
+  public function welcome() {
+    $frontPage = \Drupal::configFactory()->get('system.site')->get('page.front');
+    $original_template = \Drupal::service('file_system')->realpath(\Drupal::service('module_handler')->getModule('islandora')->getPath());
+    $theme_templates = DRUPAL_ROOT . '/' . drupal_get_path('theme', \Drupal::config('system.theme')->get('default')) . '/templates';
+    if (! file_exists($theme_templates . '/welcome.html.twig')) {
+        copy( $original_template . '/templates/welcome.html.twig', $theme_templates . '/welcome.html.twig');
+        copy( $original_template . '/templates/welcome_base.html.twig', $theme_templates . '/welcome_base.html.twig');
+    }
+    if ($frontPage != '/welcome') {
+        \Drupal::configFactory()->getEditable('system.site')->set('page.front', '/welcome')->save();
+    }
+    return [
+        '#theme' => 'welcome'
+      ];
+  }
+}

--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -12,16 +12,6 @@ use Drupal\views\Views;
 
 class HomeController extends ControllerBase {
   public function welcome() {
-    $frontPage = \Drupal::configFactory()->get('system.site')->get('page.front');
-    $original_template = \Drupal::service('file_system')->realpath(\Drupal::service('module_handler')->getModule('islandora')->getPath());
-    $theme_templates = DRUPAL_ROOT . '/' . drupal_get_path('theme', \Drupal::config('system.theme')->get('default')) . '/templates';
-    if (! file_exists($theme_templates . '/welcome.html.twig')) {
-        copy( $original_template . '/templates/welcome.html.twig', $theme_templates . '/welcome.html.twig');
-        copy( $original_template . '/templates/welcome_base.html.twig', $theme_templates . '/welcome_base.html.twig');
-    }
-    if ($frontPage != '/welcome') {
-        \Drupal::configFactory()->getEditable('system.site')->set('page.front', '/welcome')->save();
-    }
     return [
         '#theme' => 'welcome'
       ];

--- a/templates/welcome.html.twig
+++ b/templates/welcome.html.twig
@@ -1,0 +1,25 @@
+{% extends "modules/contrib/islandora/templates/welcome_base.html.twig" %}
+
+{% block title %}Islandora Welcome Page{% endblock %}
+
+{% block body %}
+<style>
+    .example-wrapper { margin: 1em auto; max-width: 800px; width: 95%; font: 18px/1.5 sans-serif; }
+    .example-wrapper code { background: #F5F5F5; padding: 2px 6px; }
+</style>
+
+<div class="example-wrapper">
+
+<p>Our sandbox environment illustrates the basic functionality of Islandora's latest release. To log in with full administrative privileges, please use the following credentials:</p>
+<ul>
+	<li><strong>Username: Test</strong></li>
+	<li><strong>Password: islandora</strong></li>
+</ul>
+
+<p>This sandbox is periodically wiped and refreshed.</p>
+
+<p>To learn more about Islandora 8, please visit the project on <a href="https://github.com/Islandora/Documentation">GitHub</a> and read our <a href="https://github.com/Islandora-Devops/islandora-playbook">Ansible playbook</a>.&nbsp;</p>
+
+<p> To learn more on how to override this homepage see <a href="https://islandora.github.io/documentation/tutorials/homepage">Islandora documentation # How to modify the frontpage</a>.</p>
+</div>
+{% endblock %}

--- a/templates/welcome_base.html.twig
+++ b/templates/welcome_base.html.twig
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <title>{% block title %}Welcome!{% endblock %}</title>
+        {% block stylesheets %}{% endblock %}
+    </head>
+    <body>
+        {% block body %}{% endblock %}
+        {% block javascripts %}{% endblock %}
+    </body>
+</html>


### PR DESCRIPTION
**GitHub Issue**: [(link)](https://github.com/Islandora/documentation/issues/1787)

# What does this Pull Request do?
Makes the homepage an editable TWIG file by routing all traffic to the URL alias "/islandora_welcome" use the **welcome.html.twig** file. 

# What's new?
* Adds a route '/islandora_welcome`
* Adds a "HomeController" to set the needed twig override
* Update hook to change the homepage from the current (node/6) to the new `/welcome` route.
* Adds 2 TWIG files to showcase how to leverage TWIGS to simplify development.

# How should this be tested?
Before you start, using terminal go to the system's default theme directory and check that within the "templates" directory there is no welcome & welcome_base twig files. Running through these steps should result in those files being copied into this directory. The demo build uses Solid so the directory is **/var/www/drupal/web/themes/contrib/solid/templates/**.

1. Got to homepage. It should be editable as a node.
2. Run drush command to run the reset_homepage function `drush php-eval "module_load_install('islandora'); reset_homepage();"`
3. Now check homepage (no longer editable and the description should now include where to go for information on how to modify this page. The link won't work until the docs MR is merged. There is no reason to wait for it. 
4. Now got to the [/islandora_welcome](https://islandora.traefik.me/islandora_welcome) page and the slideshow banner should also be showing. This indicates that this alias URL is recognized by drupal as **<front>**.
5. Now from within terminal go to the system's default theme directory and check that within the "templates" directory now sits welcome & welcome_base twig files.
6. Modify the new /var/www/drupal/web/themes/contrib/solid/templates/welcome.html.twig file and refresh your page. The changes should happen without needing to clear cache (normally).
7. Now try to override the homepage from within the system's config page via the browser. https://islandora.traefik.me/admin/config/system/site-information Change it to another node like node/6. 

This last step should show that it makes the change once but can be overridden. And because the reset was written as a function `reset_homepage()` it can be manually triggered at a later time if the user wishes.
# Documentation Status

* Associated documentation pull request(s): https://github.com/Islandora/documentation/pull/1989 

# Additional Notes:
N/A

# Interested parties
@Islandora/8-x-committers
