### PR TITLE
Prefer stable in github workflows

### DIFF
--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -95,7 +95,7 @@ jobs:
           cd $DRUPAL_DIR
           composer config repositories.local path "$GITHUB_WORKSPACE/build_dir"
           composer config minimum-stability dev
-          composer config prefer-stable
+          composer config prefer-stable true
           composer require "islandora/islandora:dev-github-testing as dev-2.x"
 
       - name: Install modules

--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -95,6 +95,7 @@ jobs:
           cd $DRUPAL_DIR
           composer config repositories.local path "$GITHUB_WORKSPACE/build_dir"
           composer config minimum-stability dev
+          composer config prefer-stable
           composer require "islandora/islandora:dev-github-testing as dev-2.x"
 
       - name: Install modules


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1994

# What does this Pull Request do?

Tells composer to prefer stable releases when setting up the testing environment.

# How should this be tested?

Github workflows should all return green, even the D8 ones.

# Additional Notes:

Solution still under discussion.

# Interested parties
@Islandora/8-x-committers
