### PR TITLE
Purge Migrate Tools (Issue 1994)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ Installing via composer will download all required libraries and modules.  Howev
 - [eva](http://drupal.org/project/eva)
 - [features](http://drupal.org/project/features)
 - [migrate_plus](http://drupal.org/project/migrate_plus)
-- [migrate_tools](http://drupal.org/project/migrate_tools)
 - [migrate_source_csv](http://drupal.org/project/migrate_source_csv)
 - [flysystem](http://drupal.org/project/flysystem)
 
@@ -48,6 +47,8 @@ It also requires the following PHP libraries:
 
 - [Crayfish Commons](https://packagist.org/packages/islandora/crayfish-commons)
 - [Stomp PHP](http://drupal.org/project/)
+
+If you are using a Drush version less than 10.4 you will also need to install and enable [migrate_tools](http://drupal.org/project/migrate_tools) separately.
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -24,13 +24,16 @@
     "drupal/eva" : "^2.0",
     "drupal/features" : "^3.7",
     "drupal/migrate_plus" : "^5.1",
-    "drupal/migrate_tools" : "^5.0",
+    "drupal/migrate_tools" : "5.0",
     "drupal/migrate_source_csv" : "^3.4",
     "drupal/token" : "^1.3",
     "drupal/flysystem" : "^2.0@alpha",
     "islandora/crayfish-commons": "^2",
     "drupal/file_replace": "^1.1"
 
+  },
+  "conflict": {
+    "drush/drush" : ">=10.4"
   },
   "require-dev": {
     "phpunit/phpunit": "^6",

--- a/composer.json
+++ b/composer.json
@@ -24,16 +24,11 @@
     "drupal/eva" : "^2.0",
     "drupal/features" : "^3.7",
     "drupal/migrate_plus" : "^5.1",
-    "drupal/migrate_tools" : "5.0",
     "drupal/migrate_source_csv" : "^3.4",
     "drupal/token" : "^1.3",
     "drupal/flysystem" : "^2.0@alpha",
     "islandora/crayfish-commons": "^2",
     "drupal/file_replace": "^1.1"
-
-  },
-  "conflict": {
-    "drush/drush" : ">=10.4"
   },
   "require-dev": {
     "phpunit/phpunit": "^6",

--- a/islandora.info.yml
+++ b/islandora.info.yml
@@ -27,7 +27,6 @@ dependencies:
   - drupal:media
   - drupal:prepopulate
   - drupal:features_ui
-  - drupal:migrate_tools
   - drupal:migrate_source_csv
   - drupal:content_translation
   - drupal:flysystem


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1994

# What does this Pull Request do?

~Tells composer to use Migrate Tools 5.0 _explicitly_ and conflict with Drush 10.4.~

New strategy: purge Migrate Tools altogether.

# How should this be tested?

Github workflows should all return green, even the D8 ones.

# Additional Notes:

Solution still under discussion. This puts the onus on deployment methods (ansible or isle) to either install migrate tools themselves to use Drush < 10.4 OR ensure that they are using Drush 10.4+.

# Interested parties
@Islandora/8-x-committers
