### PR TITLE
Allowing Image fields for multi-file media

### DIFF
--- a/src/Plugin/Action/AbstractGenerateDerivativeMediaFile.php
+++ b/src/Plugin/Action/AbstractGenerateDerivativeMediaFile.php
@@ -88,10 +88,16 @@ class AbstractGenerateDerivativeMediaFile extends AbstractGenerateDerivativeBase
    */
   public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
     $form = parent::buildConfigurationForm($form, $form_state);
+
     $map = $this->entityFieldManager->getFieldMapByFieldType('file');
     $file_fields = $map['media'];
     $file_options = array_combine(array_keys($file_fields), array_keys($file_fields));
-    $file_options = array_merge(['' => ''], $file_options);
+
+    $map = $this->entityFieldManager->getFieldMapByFieldType('image');
+    $image_fields = $map['media'];
+    $image_options = array_combine(array_keys($image_fields), array_keys($image_fields));
+
+    $file_options = array_merge(['' => ''], $file_options, $image_options);
     $form['event']['#disabled'] = 'disabled';
 
     $form['destination_field_name'] = [


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/2003

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What does this Pull Request do?

Adds image field support for multi-file media

# What's new?
Let's you name an image field as the 'destination field' for multi-file media.  Basically just adds some extra options in the `buildConfigurationForm()` function of `AbstractGenerateDerivativeMediaFile` class.

# How should this be tested?

You have to set up media type for multifile media.  But a good check that doesn't involve the full setup is to go to Admin > Config > System > Actions and create a new 'Generate a Derivative File for Media Attachment' action.  You should see image fields in the dropdown for 'Destination Field Name':

![image](https://user-images.githubusercontent.com/20773151/145858960-48b0cbe4-aec9-4a48-8409-5920525a7a10.png)

# Documentation Status

I don't think this stuff is really documented at all?  If it were I'd at least mention that you can do image fields now.  If it is documented, point me to it and i'll add a PR for that too.

# Interested parties
@Islandora/8-x-committers
