### PR TITLE
Update testing

### DIFF
--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -19,17 +19,124 @@ jobs:
   build:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.allowed_failure }}
     strategy:
+      fail-fast: false
       matrix:
         php-versions: ["7.3", "7.4"]
         test-suite: ["kernel", "functional", "functional-javascript"]
-        drupal-version: ["8.9.11", "9.1.5"]
+        drupal-version: ["9.3.x", "9.4.x-dev"]
+        allowed_failure: [false]
+        mysql: ["5.7"]
+        # include experimental parts
+        include:
+          # 9.3.x on PHP 8.0
+          - drupal-version: '9.3.x'
+            php-versions: '8.0'
+            mysql: "8.0"
+            test-suite: "kernel"
+            allowed_failure: true
+          - drupal-version: '9.3.x'
+            php-versions: '8.0'
+            mysql: "8.0"
+            test-suite: "functional"
+            allowed_failure: true
+          - drupal-version: '9.3.x'
+            php-versions: '8.0'
+            mysql: "8.0"
+            test-suite: "functional-javascript"
+            allowed_failure: true
+          # 9.3.x on PHP 8.1
+          - drupal-version: '9.3.x'
+            php-versions: '8.1'
+            mysql: "8.0"
+            test-suite: "kernel"
+            allowed_failure: true
+          - drupal-version: '9.3.x'
+            php-versions: '8.1'
+            mysql: "8.0"
+            test-suite: "functional"
+            allowed_failure: true
+          - drupal-version: '9.3.x'
+            php-versions: '8.1'
+            mysql: "8.0"
+            test-suite: "functional-javascript"
+            allowed_failure: true
+          # 9.4.x-dev on PHP "8.0"
+          - drupal-version: '9.4.x-dev'
+            php-versions: '8.0'
+            mysql: "8.0"
+            test-suite: "kernel"
+            allowed_failure: true
+          - drupal-version: '9.4.x-dev'
+            php-versions: '8.0'
+            mysql: "8.0"
+            test-suite: "functional"
+            allowed_failure: true
+          - drupal-version: '9.4.x-dev'
+            php-versions: '8.0'
+            mysql: "8.0"
+            test-suite: "functional-javascript"
+            allowed_failure: true
+          - drupal-version: '10.0.x-dev'
+            php-versions: '8.0'
+            mysql: "8.0"
+            test-suite: "kernel"
+            allowed_failure: true
+          # 9.4.x-dev on PHP 8.1
+          - drupal-version: '9.4.x-dev'
+            php-versions: '8.1'
+            mysql: "8.0"
+            test-suite: "kernel"
+            allowed_failure: true
+          - drupal-version: '9.4.x-dev'
+            php-versions: '8.1'
+            mysql: "8.0"
+            test-suite: "functional"
+            allowed_failure: true
+          - drupal-version: '9.4.x-dev'
+            php-versions: '8.1'
+            mysql: "8.0"
+            test-suite: "functional-javascript"
+            allowed_failure: true
+          # 10.0.x-dev on PHP 8.0
+          - drupal-version: '10.0.x-dev'
+            php-versions: '8.0'
+            mysql: "8.0"
+            test-suite: "kernel"
+            allowed_failure: true
+          - drupal-version: '10.0.x-dev'
+            php-versions: '8.0'
+            mysql: "8.0"
+            test-suite: "functional"
+            allowed_failure: true
+          - drupal-version: '10.0.x-dev'
+            php-versions: '8.0'
+            mysql: "8.0"
+            test-suite: "functional-javascript"
+            allowed_failure: true
+          # 10.0.x-dev on PHP 8.1
+          - drupal-version: '10.0.x-dev'
+            php-versions: '8.1'
+            mysql: "8.0"
+            test-suite: "kernel"
+            allowed_failure: true
+          - drupal-version: '10.0.x-dev'
+            php-versions: '8.1'
+            mysql: "8.0"
+            test-suite: "functional"
+            allowed_failure: true
+          - drupal-version: '10.0.x-dev'
+            php-versions: '8.1'
+            mysql: "8.0"
+            test-suite: "functional-javascript"
+            allowed_failure: true
 
-    name: PHP ${{ matrix.php-versions }} drupal ${{ matrix.drupal-version }} test-suite ${{ matrix.test-suite }}
+    name: PHP ${{ matrix.php-versions }} | drupal ${{ matrix.drupal-version }} | mysql ${{ matrix.mysql }} | test-suite ${{ matrix.test-suite }}
 
     services:
       mysql:
-        image: mysql:5.7
+        image: mysql:${{ matrix.mysql }}
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
           MYSQL_DATABASE: drupal
@@ -44,6 +151,7 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
+      
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout code
         uses: actions/checkout@v2
@@ -53,8 +161,8 @@ jobs:
       - name: Checkout islandora_ci
         uses: actions/checkout@v2
         with:
-          repository: islandora/islandora_ci
-          ref: github-actions
+          repository: whikloj/islandora_ci
+          ref: fix-things
           path: islandora_ci
 
       - name: Setup PHP
@@ -66,6 +174,7 @@ jobs:
       - name: Setup Mysql client
         run: |
           sudo apt-get update
+          sudo apt-get remove -y mysql-client mysql-common
           sudo apt-get install -y mysql-client
 
       - name: Set environment variables

--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -161,8 +161,8 @@ jobs:
       - name: Checkout islandora_ci
         uses: actions/checkout@v2
         with:
-          repository: whikloj/islandora_ci
-          ref: fix-things
+          repository: islandora/islandora_ci
+          ref: github-actions
           path: islandora_ci
 
       - name: Setup PHP


### PR DESCRIPTION
**GitHub Issue**: n/a

# What does this Pull Request do?

Updates the testing matrix to pull the current minor version instead of locking.

This will test:
1. Drupal 9.3.x, 9.4.x on PHP 7.3 and 7.4
2. Drupal 9.3.x, 9.4.x on PHP 8.0 and 8.1.
3. Drupal 10.0.x on PHP 8.0 and 8.1 (D10 doesn't support 7.3/7.4)

Only number 1 above is required to pass, the others can fail.

# How should this be tested?

Changes testing matrix

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/8-x-committers
