### PR TITLE
Add check for cache tags in JSON-LD alter hook.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "islandora/jsonld": "^2",
     "stomp-php/stomp-php": "4.*",
     "drupal/jwt": "^1.0.0-beta5",
-    "drupal/filehash": "^2",
+    "drupal/filehash": "^1.1 || ^2",
     "drupal/prepopulate" : "^2.2",
     "drupal/eva" : "^2.0",
     "drupal/features" : "^3.7",
@@ -39,7 +39,7 @@
   "suggest": {
     "drupal/transliterate_filenames": "Sanitizes filenames when they are uploaded so they don't break your repository." 
   },
-  "license": "GPL-2.0+",
+  "license": "GPL-2.0-or-later",
   "authors": [
     {
       "name": "Islandora Foundation",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "islandora/jsonld": "^2",
     "stomp-php/stomp-php": "4.*",
     "drupal/jwt": "^1.0.0-beta5",
-    "drupal/filehash": "^1.1",
+    "drupal/filehash": "^2",
     "drupal/prepopulate" : "^2.2",
     "drupal/eva" : "^2.0",
     "drupal/features" : "^3.7",

--- a/islandora.module
+++ b/islandora.module
@@ -251,7 +251,8 @@ function islandora_jsonld_alter_normalized_array(EntityInterface $entity, array 
     $reaction->execute($entity, $normalized, $context);
     foreach ($context_manager->getActiveContexts() as $context_config) {
       try {
-        if ($context_config->getReaction($reaction->getPluginId()) && isset($context['cacheability'])) {
+        if ($context_config->getReaction($reaction->getPluginId()) && isset($context['cacheability'])
+        && method_exists($context['cacheability'], 'addCacheTags')) {
           $context['cacheability']->addCacheTags($context_config->getCacheTags());
         };
       }

--- a/islandora.module
+++ b/islandora.module
@@ -26,6 +26,7 @@ use Drupal\media\MediaInterface;
 use Drupal\file\FileInterface;
 use Drupal\taxonomy\TermInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\serialization\Normalizer\CacheableNormalizerInterface;
 
 /**
  * Implements hook_help().

--- a/islandora.module
+++ b/islandora.module
@@ -253,8 +253,7 @@ function islandora_jsonld_alter_normalized_array(EntityInterface $entity, array 
     foreach ($context_manager->getActiveContexts() as $context_config) {
       try {
         if ($context_config->getReaction($reaction->getPluginId()) && isset($context[CacheableNormalizerInterface::SERIALIZATION_CONTEXT_CACHEABILITY])) {
-          $context[CacheableNormalizerInterface::SERIALIZATION_CONTEXT_CACHEABILITY]->addCacheableDependency($context_config);
-        };
+          $context[CacheableNormalizerInterface::SERIALIZATION_CONTEXT_CACHEABILITY]->addCacheableDependency($context_config); 
         };
       }
       catch (PluginNotFoundException $e) {

--- a/islandora.module
+++ b/islandora.module
@@ -253,7 +253,7 @@ function islandora_jsonld_alter_normalized_array(EntityInterface $entity, array 
     foreach ($context_manager->getActiveContexts() as $context_config) {
       try {
         if ($context_config->getReaction($reaction->getPluginId()) && isset($context[CacheableNormalizerInterface::SERIALIZATION_CONTEXT_CACHEABILITY])) {
-          $context[CacheableNormalizerInterface::SERIALIZATION_CONTEXT_CACHEABILITY]->addCacheableDependency($context_config); 
+          $context[CacheableNormalizerInterface::SERIALIZATION_CONTEXT_CACHEABILITY]->addCacheableDependency($context_config);
         };
       }
       catch (PluginNotFoundException $e) {

--- a/islandora.module
+++ b/islandora.module
@@ -251,7 +251,7 @@ function islandora_jsonld_alter_normalized_array(EntityInterface $entity, array 
     $reaction->execute($entity, $normalized, $context);
     foreach ($context_manager->getActiveContexts() as $context_config) {
       try {
-        if ($context_config->getReaction($reaction->getPluginId())) {
+        if ($context_config->getReaction($reaction->getPluginId()) && isset($context['cacheability'])) {
           $context['cacheability']->addCacheTags($context_config->getCacheTags());
         };
       }

--- a/islandora.module
+++ b/islandora.module
@@ -251,9 +251,9 @@ function islandora_jsonld_alter_normalized_array(EntityInterface $entity, array 
     $reaction->execute($entity, $normalized, $context);
     foreach ($context_manager->getActiveContexts() as $context_config) {
       try {
-        if ($context_config->getReaction($reaction->getPluginId()) && isset($context['cacheability'])
-        && method_exists($context['cacheability'], 'addCacheTags')) {
-          $context['cacheability']->addCacheTags($context_config->getCacheTags());
+        if ($context_config->getReaction($reaction->getPluginId()) && isset($context[CacheableNormalizerInterface::SERIALIZATION_CONTEXT_CACHEABILITY])) {
+          $context[CacheableNormalizerInterface::SERIALIZATION_CONTEXT_CACHEABILITY]->addCacheableDependency($context_config);
+        };
         };
       }
       catch (PluginNotFoundException $e) {


### PR DESCRIPTION
**GitHub Issue**: (link) https://github.com/Islandora/documentation/issues/2039

# What does this Pull Request do?

Fixes a white screen when getting a JSON-LD representation of a node when the controller includes an entity access check.

# What's new?
Adds an 'isset' to fix a null array access in the jsonld normalizer alter function.

* Does this change add any new dependencies? 
no

* Does this change require any other modifications to be made to the repository
no


* Could this change impact execution of existing code?
No 


# How should this be tested?


Problem occurs when dealing with unpublished content.

If you have a controller that correctly checks for entity access, e.g., in routing.yml:

```yaml

islandora_premis.premis:
  path: '/node/{node}/premis'
  defaults:
    _controller: '\Drupal\islandora_premis\Controller\IslandoraPremisPremisController::main'
  options:
    parameters:
      node:
        type: 'entity:node'
  requirements:
    _entity_access: 'node.view'

```

The entity access check makes it such that the output is not cacheable as it would be without it. Thus there is no 'cache ability' array element.

All entities accessible to the logged-in user should now be visible as JSON-LD, e.g.

/node/{nid}?_premis=jsonld

# Documentation Status

* Does this change existing behaviour that's currently documented? no
* Does this change require new pages or sections of documentation? no
# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/8-x-committers
