### PR TITLE
Fill in blanks for IntegerWeightSelector (Islandora#2065)

### DIFF
--- a/src/Plugin/views/field/IntegerWeightSelector.php
+++ b/src/Plugin/views/field/IntegerWeightSelector.php
@@ -46,7 +46,7 @@ class IntegerWeightSelector extends FieldPluginBase {
       $options[$this->getValue($row)] = $this->getValue($row);
     }
 
-    // If we were given some blank values, or less than the 
+    // If we were given some blank values, or less than the
     // total_rows for the view, we need to fill
     // out the option list from 1 through the result count
     // to make sure we have enough. (Blanks should only appear

--- a/src/Plugin/views/field/IntegerWeightSelector.php
+++ b/src/Plugin/views/field/IntegerWeightSelector.php
@@ -46,12 +46,13 @@ class IntegerWeightSelector extends FieldPluginBase {
       $options[$this->getValue($row)] = $this->getValue($row);
     }
 
-    // If we were given some blank values we need to fill
+    // If we were given some blank values, or less than the 
+    // total_rows for the view, we need to fill
     // out the option list from 1 through the result count
     // to make sure we have enough. (Blanks should only appear
     // at the beginning of the results list.)
     // Also, blank values will break the selector, remove it.
-    if (array_key_exists('', $options)) {
+    if (array_key_exists('', $options) || (count($options) < $this->view->total_rows)) {
       unset($options['']);
       for ($i = 1; $i <= $this->view->total_rows; $i++) {
         $options[$i] = $i;


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/2065

# What does this Pull Request do?

Fills in the blanks on the IntegerWeightSelector views form when the number of `$options` is less than the total number of rows in the view. 

# What's new?

* Add condition to if statement on https://github.com/Islandora/islandora/blob/2.x/src/Plugin/views/field/IntegerWeightSelector.php#L54

# How should this be tested?

* Reproduce issue by creating a paged content repository item, add two child objects, set both of their weights to 1 and save.

# Documentation Status

* I don't think this requires any changes to documentation.

# Additional Notes:

none.

# Interested parties

@Islandora/8-x-committers
