### PR TITLE
Ensure node exists before using it.

### DIFF
--- a/src/Controller/ManageMediaController.php
+++ b/src/Controller/ManageMediaController.php
@@ -45,13 +45,19 @@ class ManageMediaController extends ManageMembersController {
    *   Whether we can or can't show the "thing".
    */
   public function access(RouteMatch $route_match) {
+    // Route match is being used as opposed to slugs as there are a few
+    // admin routes being altered.
+    // @see: \Drupal\islandora\EventSubscriber\AdminViewsRouteSubscriber::alterRoutes().
     if ($route_match->getParameters()->has('node')) {
       $node = $route_match->getParameter('node');
       if (!$node instanceof NodeInterface) {
         $node = Node::load($node);
       }
-      if ($this->utils->isIslandoraType($node->getEntityTypeId(), $node->bundle())) {
-        return AccessResult::allowed();
+      // Ensure there's actually a node before referencing it.
+      if ($node) {
+        if ($this->utils->isIslandoraType($node->getEntityTypeId(), $node->bundle())) {
+          return AccessResult::allowed();
+        }
       }
     }
     return AccessResult::forbidden();


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/2067

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)
https://islandora.slack.com/archives/CM5PPAV28/p1648151773957529

# What does this Pull Request do?
Fixes a bug that can be encountered when navigating to a `node/anode/media` when `anode` does not exist.

# What's new?
Checking if things exist.

# How should this be tested?
Navigating to `yoursite/node/somethingthatdoesnotexist/media` and you should a WSOD. Full stack trace noted in the issue.


# Interested parties
@Islandora/8-x-committers, @hachacha for catching it.
