### PR TITLE
The "Node has ancestor" condition shouldn't be required

### DIFF
--- a/src/Plugin/Condition/NodeHasAncestor.php
+++ b/src/Plugin/Condition/NodeHasAncestor.php
@@ -96,7 +96,7 @@ class NodeHasAncestor extends ConditionPluginBase implements ContainerFactoryPlu
       '#type' => 'entity_autocomplete',
       '#title' => $this->t('Parent node(s)'),
       '#default_value' => $default_nids,
-      '#required' => TRUE,
+      '#required' => FALSE,
       '#description' => $this->t("Can be a collection node, compound object or paged content. Accepts multiple values separated by a comma."),
       '#target_type' => 'node',
       '#tags' => TRUE,
@@ -130,9 +130,11 @@ class NodeHasAncestor extends ConditionPluginBase implements ContainerFactoryPlu
   public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
     // Entity autocomplete store things with target IDs, for convenience just
     // store the plain nid.
-    $this->configuration['ancestor_nids'] = array_map(function ($nid) {
-      return $nid['target_id'];
-    }, $form_state->getValue('ancestor_nids'));
+    if (!empty($form_state->getValue('ancestor_nids'))) {
+      $this->configuration['ancestor_nids'] = array_map(function ($nid) {
+        return $nid['target_id'];
+      }, $form_state->getValue('ancestor_nids'));
+    }
     $this->configuration['parent_reference_field'] = $form_state->getValue('parent_reference_field');
     parent::submitConfigurationForm($form, $form_state);
   }


### PR DESCRIPTION
**GitHub Issue**: (link)

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)  

 (https://github.com/Islandora/islandora/pull/865#issuecomment-1101835377)

# What does this Pull Request do?

Make the "Node has ancestor" to be "not required".

# What's new?
A in-depth description of the changes made by this PR. Technical details and
 possible side effects.

* Changes x feature to such that y
* Added x
* Removed y
* Does this change add any new dependencies? 
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? 
* Could this change impact execution of existing code?

# How should this be tested?

Place a block without filling the "Node has ancestor" condition.

# Documentation Status

* Does this change existing behaviour that's currently documented?
* Does this change require new pages or sections of documentation?
* Who does this need to be documented for?
* Associated documentation pull request(s): ___  or documentation issue ___

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/8-x-committers
