### PR TITLE
Ensure we can connect to the JMS Broker everytime

### DIFF
--- a/src/EventGenerator/EmitEvent.php
+++ b/src/EventGenerator/EmitEvent.php
@@ -5,6 +5,7 @@ namespace Drupal\islandora\EventGenerator;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Action\ConfigurableActionBase;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
@@ -68,6 +69,12 @@ abstract class EmitEvent extends ConfigurableActionBase implements ContainerFact
   protected $messenger;
 
   /**
+   * The logger
+   * @var \Drupal\Core\Logger\LoggerChannelInterface
+   */
+  protected $logger_channel;
+
+  /**
    * Constructs a EmitEvent action.
    *
    * @param array $configuration
@@ -88,6 +95,8 @@ abstract class EmitEvent extends ConfigurableActionBase implements ContainerFact
    *   The messenger.
    * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $event_dispatcher
    *   Event dispatcher service.
+   * @param \Drupal\Core\Logger\LoggerChannelInterface $logger
+   *   Logger channel.
    */
   public function __construct(
     array $configuration,
@@ -98,7 +107,8 @@ abstract class EmitEvent extends ConfigurableActionBase implements ContainerFact
     EventGeneratorInterface $event_generator,
     StatefulStomp $stomp,
     MessengerInterface $messenger,
-    EventDispatcherInterface $event_dispatcher
+    EventDispatcherInterface $event_dispatcher,
+    LoggerChannelInterface $channel
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->account = $account;
@@ -107,6 +117,7 @@ abstract class EmitEvent extends ConfigurableActionBase implements ContainerFact
     $this->stomp = $stomp;
     $this->messenger = $messenger;
     $this->eventDispatcher = $event_dispatcher;
+    $this->logger_channel = $channel;
   }
 
   /**
@@ -122,7 +133,8 @@ abstract class EmitEvent extends ConfigurableActionBase implements ContainerFact
       $container->get('islandora.eventgenerator'),
       $container->get('islandora.stomp'),
       $container->get('messenger'),
-      $container->get('event_dispatcher')
+      $container->get('event_dispatcher'),
+      $container->get('logger.channel.islandora')
     );
   }
 
@@ -132,6 +144,11 @@ abstract class EmitEvent extends ConfigurableActionBase implements ContainerFact
   public function execute($entity = NULL) {
     // Generate event as stomp message.
     try {
+      if (is_null($this->stomp->getClient()->getProtocol())) {
+        $this->stomp->getClient()->disconnect();
+        $this->stomp->getClient()->connect();
+      }
+
       $user = $this->entityTypeManager->getStorage('user')->load($this->account->id());
       $data = $this->generateData($entity);
 
@@ -146,18 +163,23 @@ abstract class EmitEvent extends ConfigurableActionBase implements ContainerFact
       );
     }
     catch (StompHeaderEventException $e) {
-      \Drupal::logger('islandora')->error($e->getMessage());
-      $this->messenger->addMessage($e->getMessage(), 'error');
+      $this->logger_channel->error($e->getMessage());
+      $this->messenger->addError($e->getMessage());
+      return;
+    }
+    catch (StompException $e) {
+      $this->logger_channel->error("Unable to connect to JMS Broker: @msg",
+      ["@msg" => $e->getMessage()]);
+      $this->messenger->addWarning("Unable to connect to JMS Broker, items might not be synchronized to external services.");
       return;
     }
     catch (\RuntimeException $e) {
       // Notify the user the event couldn't be generated and abort.
-      \Drupal::logger('islandora')->error(
+      $this->logger_channel->error(
         $this->t('Error generating event: @msg', ['@msg' => $e->getMessage()])
       );
-      $this->messenger->addMessage(
-        $this->t('Error generating event: @msg', ['@msg' => $e->getMessage()]),
-        'error'
+      $this->messenger->addError(
+        $this->t('Error generating event: @msg', ['@msg' => $e->getMessage()])
       );
       return;
     }
@@ -170,17 +192,16 @@ abstract class EmitEvent extends ConfigurableActionBase implements ContainerFact
     }
     catch (StompException $e) {
       // Log it.
-      \Drupal::logger('islandora')->error(
+      $this->logger_channel->error(
         'Error publishing message: @msg',
         ['@msg' => $e->getMessage()]
       );
 
       // Notify user.
-      $this->messenger->addMessage(
+      $this->messenger->addError(
         $this->t('Error publishing message: @msg',
           ['@msg' => $e->getMessage()]
-        ),
-        'error'
+        )
       );
     }
   }

--- a/src/EventGenerator/EmitEvent.php
+++ b/src/EventGenerator/EmitEvent.php
@@ -146,6 +146,11 @@ abstract class EmitEvent extends ConfigurableActionBase implements ContainerFact
     // Generate event as stomp message.
     try {
       if (is_null($this->stomp->getClient()->getProtocol())) {
+        // getProtocol() can return NULL but that causes a larger problem.
+        // So attempt to disconnect + connect to re-establish the connection or
+        // throw a StompException.
+        // see: https://github.com/stomp-php/stomp-php/issues/167
+        // see: https://github.com/stomp-php/stomp-php/blob/3a9347a11743d0b79fd60564f356bc3efe40e615/src/Client.php#L429-L434
         $this->stomp->getClient()->disconnect();
         $this->stomp->getClient()->connect();
       }
@@ -169,8 +174,7 @@ abstract class EmitEvent extends ConfigurableActionBase implements ContainerFact
       return;
     }
     catch (StompException $e) {
-      $this->logger->error("Unable to connect to JMS Broker: @msg",
-      ["@msg" => $e->getMessage()]);
+      $this->logger->error("Unable to connect to JMS Broker: @msg", ["@msg" => $e->getMessage()]);
       $this->messenger->addWarning("Unable to connect to JMS Broker, items might not be synchronized to external services.");
       return;
     }

--- a/src/EventGenerator/EmitEvent.php
+++ b/src/EventGenerator/EmitEvent.php
@@ -69,10 +69,11 @@ abstract class EmitEvent extends ConfigurableActionBase implements ContainerFact
   protected $messenger;
 
   /**
-   * The logger
+   * The logger.
+   *
    * @var \Drupal\Core\Logger\LoggerChannelInterface
    */
-  protected $logger_channel;
+  protected $logger;
 
   /**
    * Constructs a EmitEvent action.
@@ -95,7 +96,7 @@ abstract class EmitEvent extends ConfigurableActionBase implements ContainerFact
    *   The messenger.
    * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $event_dispatcher
    *   Event dispatcher service.
-   * @param \Drupal\Core\Logger\LoggerChannelInterface $logger
+   * @param \Drupal\Core\Logger\LoggerChannelInterface $channel
    *   Logger channel.
    */
   public function __construct(
@@ -117,7 +118,7 @@ abstract class EmitEvent extends ConfigurableActionBase implements ContainerFact
     $this->stomp = $stomp;
     $this->messenger = $messenger;
     $this->eventDispatcher = $event_dispatcher;
-    $this->logger_channel = $channel;
+    $this->logger = $channel;
   }
 
   /**
@@ -163,19 +164,19 @@ abstract class EmitEvent extends ConfigurableActionBase implements ContainerFact
       );
     }
     catch (StompHeaderEventException $e) {
-      $this->logger_channel->error($e->getMessage());
+      $this->logger->error($e->getMessage());
       $this->messenger->addError($e->getMessage());
       return;
     }
     catch (StompException $e) {
-      $this->logger_channel->error("Unable to connect to JMS Broker: @msg",
+      $this->logger->error("Unable to connect to JMS Broker: @msg",
       ["@msg" => $e->getMessage()]);
       $this->messenger->addWarning("Unable to connect to JMS Broker, items might not be synchronized to external services.");
       return;
     }
     catch (\RuntimeException $e) {
       // Notify the user the event couldn't be generated and abort.
-      $this->logger_channel->error(
+      $this->logger->error(
         $this->t('Error generating event: @msg', ['@msg' => $e->getMessage()])
       );
       $this->messenger->addError(
@@ -192,7 +193,7 @@ abstract class EmitEvent extends ConfigurableActionBase implements ContainerFact
     }
     catch (StompException $e) {
       // Log it.
-      $this->logger_channel->error(
+      $this->logger->error(
         'Error publishing message: @msg',
         ['@msg' => $e->getMessage()]
       );

--- a/src/EventGenerator/EmitEvent.php
+++ b/src/EventGenerator/EmitEvent.php
@@ -149,8 +149,8 @@ abstract class EmitEvent extends ConfigurableActionBase implements ContainerFact
         // getProtocol() can return NULL but that causes a larger problem.
         // So attempt to disconnect + connect to re-establish the connection or
         // throw a StompException.
-        // see: https://github.com/stomp-php/stomp-php/issues/167
-        // see: https://github.com/stomp-php/stomp-php/blob/3a9347a11743d0b79fd60564f356bc3efe40e615/src/Client.php#L429-L434
+        // @see https://github.com/stomp-php/stomp-php/issues/167
+        // @see https://github.com/stomp-php/stomp-php/blob/3a9347a11743d0b79fd60564f356bc3efe40e615/src/Client.php#L429-L434
         $this->stomp->getClient()->disconnect();
         $this->stomp->getClient()->connect();
       }

--- a/src/Plugin/Action/AbstractGenerateDerivativeBase.php
+++ b/src/Plugin/Action/AbstractGenerateDerivativeBase.php
@@ -95,6 +95,8 @@ class AbstractGenerateDerivativeBase extends EmitEvent {
    *   Field Manager service.
    * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $event_dispatcher
    *   Event dispatcher service.
+   * @param \Drupal\Core\Logger\LoggerChannelInterface $channel
+   *   The logger channel.
    */
   public function __construct(
         array $configuration,

--- a/src/Plugin/Action/AbstractGenerateDerivativeBase.php
+++ b/src/Plugin/Action/AbstractGenerateDerivativeBase.php
@@ -5,6 +5,7 @@ namespace Drupal\islandora\Plugin\Action;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\islandora\IslandoraUtils;
@@ -109,7 +110,8 @@ class AbstractGenerateDerivativeBase extends EmitEvent {
         MessengerInterface $messenger,
         ConfigFactoryInterface $config,
         EntityFieldManagerInterface $entity_field_manager,
-        EventDispatcherInterface $event_dispatcher
+        EventDispatcherInterface $event_dispatcher,
+        LoggerChannelInterface $channel
     ) {
     $this->utils = $utils;
     $this->mediaSource = $media_source;
@@ -126,7 +128,8 @@ class AbstractGenerateDerivativeBase extends EmitEvent {
           $event_generator,
           $stomp,
           $messenger,
-          $event_dispatcher
+          $event_dispatcher,
+          $channel
       );
   }
 
@@ -148,7 +151,8 @@ class AbstractGenerateDerivativeBase extends EmitEvent {
           $container->get('messenger'),
           $container->get('config.factory'),
           $container->get('entity_field.manager'),
-          $container->get('event_dispatcher')
+          $container->get('event_dispatcher'),
+          $container->get('logger.channel.islandora')
       );
   }
 


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/2099

# What does this Pull Request do?

Specifically checks that the `getProtocol()` method does not return `null` which is the root cause of our problems. If it does it tries to disconnect and re-connect which should throw a catchable exception and stop the exploding.

Also, starts using the islandora logger channel instead of the static `\Drupal` call. This is just code clean-up.

# How should this be tested?

* With an existing Islandora setup
* Stop ActiveMQ (`sudo service stop activemq`)
* Try to add a new taxonomy term to the Language vocabulary.
* WSOD

Pull in this PR, clear cache and repeat.

# Documentation Status

* Does this change existing behaviour that's currently documented? no
* Does this change require new pages or sections of documentation? no
* Who does this need to be documented for? no one
* Associated documentation pull request(s): _0__  or documentation issue ___

# Additional Notes:

# Interested parties
@Islandora/committers, specifically (@jordandukart)
