### PR TITLE
Set IIIF Manifest title from source entity

### DIFF
--- a/config/schema/islandora.schema.yml
+++ b/config/schema/islandora.schema.yml
@@ -169,3 +169,11 @@ field.formatter.settings.islandora_image:
     image_style:
       type: string
       label: 'Image style'
+    image_loading:
+      type: mapping
+      label: 'Image loading settings'
+      mapping:
+        attribute:
+          type: string
+          label: 'Loading attribute'
+

--- a/config/schema/islandora.schema.yml
+++ b/config/schema/islandora.schema.yml
@@ -158,22 +158,6 @@ condition.plugin.node_had_namespace:
     pid_field:
       type: ignore
       label: 'PID field'
-
 field.formatter.settings.islandora_image:
-  type: mapping
-  label: 'Image field display format settings'
-  mapping:
-    image_link:
-      type: string
-      label: 'Link image to'
-    image_style:
-      type: string
-      label: 'Image style'
-    image_loading:
-      type: mapping
-      label: 'Image loading settings'
-      mapping:
-        attribute:
-          type: string
-          label: 'Loading attribute'
-
+  type: field.formatter.settings.image
+  label: 'Islandora image field display format settings'

--- a/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
+++ b/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
@@ -3,6 +3,7 @@
 namespace Drupal\islandora_iiif\Plugin\views\style;
 
 use Drupal\views\Plugin\views\style\StylePluginBase;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Url;
@@ -70,6 +71,13 @@ class IIIFManifest extends StylePluginBase {
   protected $iiifConfig;
 
   /**
+   * The Drupal Entity Type Manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
    * The Drupal Filesystem.
    *
    * @var \Drupal\Core\File\FileSystem
@@ -86,12 +94,13 @@ class IIIFManifest extends StylePluginBase {
   /**
    * {@inheritdoc}
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, SerializerInterface $serializer, Request $request, ImmutableConfig $iiif_config, FileSystemInterface $file_system, Client $http_client, MessengerInterface $messenger) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, SerializerInterface $serializer, Request $request, ImmutableConfig $iiif_config, EntityTypeManagerInterface $entity_type_manager, FileSystemInterface $file_system, Client $http_client, MessengerInterface $messenger) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
 
     $this->serializer = $serializer;
     $this->request = $request;
     $this->iiifConfig = $iiif_config;
+    $this->entityTypeManager = $entity_type_manager;
     $this->fileSystem = $file_system;
     $this->httpClient = $http_client;
     $this->messenger = $messenger;
@@ -108,6 +117,7 @@ class IIIFManifest extends StylePluginBase {
       $container->get('serializer'),
       $container->get('request_stack')->getCurrentRequest(),
       $container->get('config.factory')->get('islandora_iiif.settings'),
+      $container->get('entity_type.manager'),
       $container->get('file_system'),
       $container->get('http_client'),
       $container->get('messenger')
@@ -278,11 +288,11 @@ class IIIFManifest extends StylePluginBase {
     try {
       $params = Url::fromUserInput($content_path)->getRouteParameters();
       if (isset($params['node'])) {
-        $node = \Drupal::entityTypeManager()->getStorage('node')->load($params['node']);
+        $node = $this->entityTypeManager->getStorage('node')->load($params['node']);
         $entity_title = $node->getTitle();
       }
       elseif (isset($params['media'])) {
-        $media = \Drupal::entityTypeManager()->getStorage('media')->load($params['media']);
+        $media = $this->entityTypeManager->getStorage('media')->load($params['media']);
         $entity_title = $media->getName();
       }
     }

--- a/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
+++ b/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
@@ -130,7 +130,6 @@ class IIIFManifest extends StylePluginBase {
       $content_path = implode('/', $url_components);
       $iiif_base_id = $request_host . '/' . $content_path;
 
-
       // @see https://iiif.io/api/presentation/2.1/#manifest
       $json += [
         '@type' => 'sc:Manifest',
@@ -272,13 +271,17 @@ class IIIFManifest extends StylePluginBase {
    */
   public function getEntityTitle(string $content_path): string {
     $entity_title = $this->t('IIIF Manifest');
-    $params = \Drupal\Core\Url::fromUserInput($content_path)->getRouteParameters();
-    if (isset($params['node'])) {
-      $node = \Drupal\node\Entity\Node::load($params['node']);
-      $entity_title = $node->getTitle();
-    } elseif (isset($params['media'])) {
-      $media = \Drupal\media\Entity\Media::load($params['media']);
-      $entity_title = $media->getName();
+    try {
+      $params = \Drupal\Core\Url::fromUserInput($content_path)->getRouteParameters();
+      if (isset($params['node'])) {
+        $node = \Drupal\node\Entity\Node::load($params['node']);
+        $entity_title = $node->getTitle();
+      } elseif (isset($params['media'])) {
+        $media = \Drupal\media\Entity\Media::load($params['media']);
+        $entity_title = $media->getName();
+      }
+    } catch (\InvalidArgumentException $e) {
+
     }
     return $entity_title;
   }

--- a/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
+++ b/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
@@ -5,6 +5,7 @@ namespace Drupal\islandora_iiif\Plugin\views\style;
 use Drupal\views\Plugin\views\style\StylePluginBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Url;
 use Drupal\views\ResultRow;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -267,20 +268,25 @@ class IIIFManifest extends StylePluginBase {
    * Pull a title from the node or media passed to this view.
    *
    * @param string $content_path
+   *   The path of the content being requested.
+   *
    * @return string
+   *   The entity's title.
    */
   public function getEntityTitle(string $content_path): string {
     $entity_title = $this->t('IIIF Manifest');
     try {
-      $params = \Drupal\Core\Url::fromUserInput($content_path)->getRouteParameters();
+      $params = Url::fromUserInput($content_path)->getRouteParameters();
       if (isset($params['node'])) {
-        $node = \Drupal\node\Entity\Node::load($params['node']);
+        $node = \Drupal::entityTypeManager()->getStorage('node')->load($params['node']);
         $entity_title = $node->getTitle();
-      } elseif (isset($params['media'])) {
-        $media = \Drupal\media\Entity\Media::load($params['media']);
+      }
+      elseif (isset($params['media'])) {
+        $media = \Drupal::entityTypeManager()->getStorage('media')->load($params['media']);
         $entity_title = $media->getName();
       }
-    } catch (\InvalidArgumentException $e) {
+    }
+    catch (\InvalidArgumentException $e) {
 
     }
     return $entity_title;

--- a/tests/src/Functional/IslandoraImageFormatterTest.php
+++ b/tests/src/Functional/IslandoraImageFormatterTest.php
@@ -11,11 +11,6 @@ namespace Drupal\Tests\islandora\Functional;
 class IslandoraImageFormatterTest extends IslandoraFunctionalTestBase {
 
   /**
-   * @var bool Suppresses "Schema incomplete" error.
-   */
-  protected $strictConfigSchema = FALSE;
-
-  /**
    * @covers \Drupal\islandora\Plugin\Field\FieldFormatter\IslandoraImageFormatter::viewElements
    */
   public function testIslandoraImageFormatter() {
@@ -31,16 +26,21 @@ class IslandoraImageFormatterTest extends IslandoraFunctionalTestBase {
     // Create an image media type.
     $testImageMediaType = $this->createMediaType('image', ['id' => 'test_image_media_type']);
     $testImageMediaType->save();
-    $this->createEntityReferenceField('media', $testImageMediaType->id(), 'field_media_of', 'Media Of', 'node', 'default', [], 2);("Got past create media type.");
+    $this->createEntityReferenceField('media', $testImageMediaType->id(), 'field_media_of', 'Media Of', 'node', 'default', [], 2);
     // Set the display mode to use the islandora_image formatter.
     // Also, only show the image on display to remove clutter.
     $display_options = [
       'type' => 'islandora_image',
-      'settings' => [/*'image_style' => NULL,*/ 'image_link' => 'content'],
+      'settings' => [
+        'image_style' => '',
+        'image_link' => 'content',
+        'image_loading' => [
+          'attribute' => 'eager',
+        ],
+      ],
     ];
 
     $display = $this->container->get('entity_display.repository')->getViewDisplay('media', $testImageMediaType->id(), 'default');
-
     $display->setComponent('field_media_image', $display_options)
       ->removeComponent('created')
       ->removeComponent('uid')

--- a/tests/src/Functional/IslandoraImageFormatterTest.php
+++ b/tests/src/Functional/IslandoraImageFormatterTest.php
@@ -11,6 +11,11 @@ namespace Drupal\Tests\islandora\Functional;
 class IslandoraImageFormatterTest extends IslandoraFunctionalTestBase {
 
   /**
+   * @var bool Suppresses "Schema incomplete" error.
+   */
+  protected $strictConfigSchema = FALSE;
+
+  /**
    * @covers \Drupal\islandora\Plugin\Field\FieldFormatter\IslandoraImageFormatter::viewElements
    */
   public function testIslandoraImageFormatter() {
@@ -26,15 +31,16 @@ class IslandoraImageFormatterTest extends IslandoraFunctionalTestBase {
     // Create an image media type.
     $testImageMediaType = $this->createMediaType('image', ['id' => 'test_image_media_type']);
     $testImageMediaType->save();
-    $this->createEntityReferenceField('media', $testImageMediaType->id(), 'field_media_of', 'Media Of', 'node', 'default', [], 2);
-
+    $this->createEntityReferenceField('media', $testImageMediaType->id(), 'field_media_of', 'Media Of', 'node', 'default', [], 2);("Got past create media type.");
     // Set the display mode to use the islandora_image formatter.
     // Also, only show the image on display to remove clutter.
     $display_options = [
       'type' => 'islandora_image',
-      'settings' => ['image_style' => NULL, 'image_link' => 'content'],
+      'settings' => [/*'image_style' => NULL,*/ 'image_link' => 'content'],
     ];
+
     $display = $this->container->get('entity_display.repository')->getViewDisplay('media', $testImageMediaType->id(), 'default');
+
     $display->setComponent('field_media_image', $display_options)
       ->removeComponent('created')
       ->removeComponent('uid')
@@ -47,7 +53,6 @@ class IslandoraImageFormatterTest extends IslandoraFunctionalTestBase {
       'title' => 'Test Node',
     ]);
     $node->save();
-
     // Make a image for the Media.
     $file = $this->container->get('entity_type.manager')->getStorage('file')->create([
       'uid' => $account->id(),


### PR DESCRIPTION

# What does this Pull Request do?

Changes default title of IIIF Manifest view from "IIIF Manifest" to the title of the node or media the manifest is generated from.

# What's new?

Add a function to the IIIF Manifest view type that that gets the title of the node or media that the manifest represents.

If a user changes the display title in the view settings that will be used instead.

# How should this be tested?

1.  Enable islandora_mirador module.
2. Create content as follows:: A Repository Item with model "Paged content"
3. One or more Repository Items with type FIle
4. Media for each Page items, of type Document, with a TIFF file attached.
5. Go to node/[nid]/book-manifest. Observe the Label field contains the title of the Paged Content node.
6. Optionally, Set the display Hint  to Mirador and ensure the viewer displays the node title rather than "IIIF Manifest" 


# Documentation Status

* Does this change existing behaviour that's currently documented?

No


# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/8-x-committers
