### PR TITLE
Fix typo to support multiple tracks.

### DIFF
--- a/modules/islandora_video/templates/islandora-file-video.html.twig
+++ b/modules/islandora_video/templates/islandora-file-video.html.twig
@@ -21,7 +21,7 @@
   {% endfor %}
   {% if tracks %}
     {% for track in tracks %}
-      <track {{ track.track_attributes }}
+      <track {{ track.track_attributes }} />
     {% endfor %}
   {% endif %}
 </video>


### PR DESCRIPTION
**GitHub Issue**: [Oral History Transcriptions](https://github.com/Islandora/documentation/issues/1305) seems the most relevant

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What does this Pull Request do?

Attempts at loading multiple tracks into an islandora video for alternate captions/subtitles failed; the problem seems to be an unclosed tag in the twig template.

# What's new?
Close the tag in the twig template. 


* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)?  no
* Could this change impact execution of existing code? yes, to work as expected

# How should this be tested?

* Add two differently labeled subtitle tracks to an islandora video. Only one will show up. If you inspect the `<video> `element it'll have a stub `<track` within the other `<track `(which wasn't closed properly)
* With this PR, both should show up and you'll see two `<track>`s. 

# Documentation Status

* Does this change existing behaviour that's currently documented? no, sadly, but that's how I found it.
* Does this change require new pages or sections of documentation? Working on it.
* Who does this need to be documented for? Users expecting to add subtitles/captions.
* Associated documentation pull request(s): ___  or documentation issue ___

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/8-x-committers
