### PR TITLE
Add image loading (to fix breaking tests on Drupal 9.4.x).

### DIFF
--- a/tests/src/Functional/IslandoraImageFormatterTest.php
+++ b/tests/src/Functional/IslandoraImageFormatterTest.php
@@ -35,7 +35,7 @@ class IslandoraImageFormatterTest extends IslandoraFunctionalTestBase {
       'settings' => [
         'image_style' => NULL,
         'image_link' => 'content',
-        'image_loading' => 'lazy',
+        'image_loading' => ['attribute' => 'lazy'],
       ],
     ];
     $display = $this->container->get('entity_display.repository')->getViewDisplay('media', $testImageMediaType->id(), 'default');

--- a/tests/src/Functional/IslandoraImageFormatterTest.php
+++ b/tests/src/Functional/IslandoraImageFormatterTest.php
@@ -32,7 +32,11 @@ class IslandoraImageFormatterTest extends IslandoraFunctionalTestBase {
     // Also, only show the image on display to remove clutter.
     $display_options = [
       'type' => 'islandora_image',
-      'settings' => ['image_style' => NULL, 'image_link' => 'content', 'image_loading' => 'lazy'],
+      'settings' => [
+        'image_style' => NULL,
+        'image_link' => 'content',
+        'image_loading' => 'lazy',
+      ],
     ];
     $display = $this->container->get('entity_display.repository')->getViewDisplay('media', $testImageMediaType->id(), 'default');
     $display->setComponent('field_media_image', $display_options)

--- a/tests/src/Functional/IslandoraImageFormatterTest.php
+++ b/tests/src/Functional/IslandoraImageFormatterTest.php
@@ -32,7 +32,7 @@ class IslandoraImageFormatterTest extends IslandoraFunctionalTestBase {
     // Also, only show the image on display to remove clutter.
     $display_options = [
       'type' => 'islandora_image',
-      'settings' => ['image_style' => NULL, 'image_link' => 'content'],
+      'settings' => ['image_style' => NULL, 'image_link' => 'content', 'image_loading' => 'lazy'],
     ];
     $display = $this->container->get('entity_display.repository')->getViewDisplay('media', $testImageMediaType->id(), 'default');
     $display->setComponent('field_media_image', $display_options)


### PR DESCRIPTION
**GitHub Issue**:  https://github.com/Islandora/documentation/issues/2093 

* Other Relevant Links : Tests are failing on 9.4.x on all Islandora PRs

# What does this Pull Request do?

Tries to correct for the new image formatter setting by supplying it in the functional tests. 

# What's new?

This now passes the "image_loading" parameter. Hopefully it won't break on 9.3.x where this feature isn't available.

# How should this be tested?

If the tests all pass, then this worked.

# Documentation Status

* Does this change existing behaviour that's currently documented? no
* Does this change require new pages or sections of documentation? no
* Who does this need to be documented for? no-one
* Associated documentation pull request(s): ___  or documentation issue ___

# Additional Notes:


# Interested parties
@Islandora/8-x-committers
