### PR TITLE
Produce error if viewing a media without a source file (Issue-2110)

### DIFF
--- a/islandora.module
+++ b/islandora.module
@@ -422,7 +422,7 @@ function islandora_entity_extra_field_info() {
 
   if (!empty($pseudo_bundles)) {
     foreach ($pseudo_bundles as $key) {
-      list($bundle, $content_entity) = explode(":", $key);
+      [$bundle, $content_entity] = explode(":", $key);
       $extra_field[$content_entity][$bundle]['display']['field_gemini_uri'] = [
         'label' => t('Fedora URI'),
         'description' => t('The URI to the persistent'),
@@ -451,6 +451,17 @@ function islandora_entity_view(array &$build, EntityInterface $entity, EntityVie
         // Check if the source file is in Fedora or not.
         $media_source_service = \Drupal::service('islandora.media_source_service');
         $source_file = $media_source_service->getSourceFile($entity);
+        if (!$source_file) {
+          \Drupal::logger('islandora')->error(
+            \Drupal::service('string_translation')->translate(
+              "Can't get source file for @label (@id)", [
+                '@label' => $entity->label(),
+                "@id" => $entity->id(),
+              ]
+            )
+          );
+          return;
+        }
         $uri = $source_file->getFileUri();
         $scheme = \Drupal::service('stream_wrapper_manager')->getScheme($uri);
         $flysystem_config = Settings::get('flysystem');


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/2110

# What does this Pull Request do?

Produces an error message instead of a WSOD when viewing a media where the source file is absent and the fedora URI is set to display.

# What's new?

Adds a check to `islandora_entity_view` around the source file to throw an error and return early if it wasn't found.
* Does this change add any new dependencies? No.
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? No.
* Could this change impact execution of existing code? Makes it not crash.

# How should this be tested?

* Create a media without a source file (this occurred with a broken migration).
  * Create a media via the UI
  * Jump to the command-line and the interactive terminial `drush php:cli`
  * Load the media, e.g. `$m = \Drupal::entityTypeManager()->getStorage('media')->load(1);` (replacing "1" with your test media's ID)
  * Get the source file: `$f = \Drupal::service('islandora.media_source_service')->getSourceFile($m);`
  * Delete it: `$f->delete();`
  * Clear your cache
* Make sure the field_gemini_uri is set to display with the media's default mode
* Visit the media's page and receive a WSOD
* Apply the PR
* Visit the media's page again and NOT WSOD.
* Check the logs to see appropriate error message.

# Interested parties
@Islandora/committers 
