### PR TITLE
Rename multifile media ocr derivative type.

### DIFF
--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -98,22 +98,6 @@ jobs:
             mysql: "8.0"
             test-suite: "functional-javascript"
             allowed_failure: true
-          # 10.0.x-dev on PHP 8.0
-          - drupal-version: '10.0.x-dev'
-            php-versions: '8.0'
-            mysql: "8.0"
-            test-suite: "kernel"
-            allowed_failure: true
-          - drupal-version: '10.0.x-dev'
-            php-versions: '8.0'
-            mysql: "8.0"
-            test-suite: "functional"
-            allowed_failure: true
-          - drupal-version: '10.0.x-dev'
-            php-versions: '8.0'
-            mysql: "8.0"
-            test-suite: "functional-javascript"
-            allowed_failure: true
           # 10.0.x-dev on PHP 8.1
           - drupal-version: '10.0.x-dev'
             php-versions: '8.1'

--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -77,11 +77,6 @@ jobs:
             mysql: "8.0"
             test-suite: "functional-javascript"
             allowed_failure: true
-          - drupal-version: '10.0.x-dev'
-            php-versions: '8.0'
-            mysql: "8.0"
-            test-suite: "kernel"
-            allowed_failure: true
           # 9.4.x-dev on PHP 8.1
           - drupal-version: '9.4.x-dev'
             php-versions: '8.1'

--- a/modules/islandora_text_extraction/src/Plugin/Action/GenerateOCRDerivativeFile.php
+++ b/modules/islandora_text_extraction/src/Plugin/Action/GenerateOCRDerivativeFile.php
@@ -12,7 +12,7 @@ use Drupal\islandora\Plugin\Action\AbstractGenerateDerivativeMediaFile;
  *
  * @Action(
  *   id = "generate_extracted_text_file",
- *   label = @Translation("Generate an Extracted Text derivative file"),
+ *   label = @Translation("Generate Extracted Text for Media Attachment"),
  *   type = "media"
  * )
  */


### PR DESCRIPTION
**GitHub Issue**: (none)

# What does this Pull Request do?

I am documenting how derivatives work as Drupal actions. The fact that we had two derivatives types, "Generate an extracted text derivative file" and "generate OCR from image" was concerning. 

They do the same thing, but one was multi=file media. The other MFM derivative types use "for media attachment" in their names so that's what I did here. 

# What's new?
* Changed the display name of the MFM OCR derivative type.

* Does this change add any new dependencies?  np
* Does this change require any other modifications to be made to the repository np
 (i.e. Regeneration activity, etc.)? 
* Could this change impact execution of existing code? np

# How should this be tested?

With this PR, does the list of derivative options make sense?

# Documentation Status

* Does this change existing behaviour that's currently documented? unlikely that it's documented
* Does this change require new pages or sections of documentation? yes, i'm working on them
* Who does this need to be documented for? repository admins who need to know how derivatives work
* Associated documentation pull request(s): ___  or documentation issue ___

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/8-x-committers
