### PR TITLE
Avoid attempting to refer to an unknown index in views alter hook

### DIFF
--- a/islandora.views.inc
+++ b/islandora.views.inc
@@ -13,13 +13,16 @@ function islandora_views_data_alter(&$data) {
   $fields = \Drupal::service('entity_field.manager')->getFieldStorageDefinitions('node');
   foreach ($fields as $field => $field_storage_definition) {
     if ($field_storage_definition->getType() == 'integer' && strpos($field, "field_") === 0) {
-      $data['node__' . $field][$field . '_value']['field'] = $data['node__' . $field][$field]['field'];
-      $data['node__' . $field][$field]['title'] = t('Integer Weight Selector (@field)', [
-        '@field' => $field,
-      ]);
-      $data['node__' . $field][$field]['help'] = t('Provides a drag-n-drop reordering of integer-based weight fields.');
-      $data['node__' . $field][$field]['title short'] = t('Integer weight selector');
-      $data['node__' . $field][$field]['field']['id'] = 'integer_weight_selector';
+      $prefixed_field = 'node__' . $field;
+      if (isset($data[$prefixed_field])) {
+        $data[$prefixed_field][$field . '_value']['field'] = $data[$prefixed_field][$field]['field'];
+        $data[$prefixed_field][$field]['title'] = t('Integer Weight Selector (@field)', [
+          '@field' => $field,
+        ]);
+        $data[$prefixed_field][$field]['help'] = t('Provides a drag-n-drop reordering of integer-based weight fields.');
+        $data[$prefixed_field][$field]['title short'] = t('Integer weight selector');
+        $data[$prefixed_field][$field]['field']['id'] = 'integer_weight_selector';
+      }
     }
   }
 }


### PR DESCRIPTION
When running in a bare site (without any content... like, in a unit
testing rig), this ends up trying to refer to a non-existent offset.

... add an `isset()` test to avoid doing so.

**GitHub Issue**: This one.

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

N/A

# What does this Pull Request do?

Tests of the existence of views data being copied before attempting to reference it, as it may not exist.

# What's new?

Just added an `isset()` check before blindly attempting to use views data.

* Does this change add any new dependencies? No.
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? No.
* Could this change impact execution of existing code? Shouldn't.

# How should this be tested?

Good question... kind of surprised this doesn't pop up in this module's tests...

# Documentation Status

* Does this change existing behaviour that's currently documented? Shouldn't.
* Does this change require new pages or sections of documentation? No.
* Who does this need to be documented for? Unknown
* Associated documentation pull request(s): ___  or documentation issue ___

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/8-x-committers
