### PR TITLE
Move to int for filehash.settings:dedupe config

### DIFF
--- a/modules/islandora_core_feature/config/install/filehash.settings.yml
+++ b/modules/islandora_core_feature/config/install/filehash.settings.yml
@@ -2,4 +2,4 @@ algos:
   sha1: sha1
   md5: '0'
   sha256: '0'
-dedupe: '0'
+dedupe: 0

--- a/modules/islandora_core_feature/config/install/filehash.settings.yml
+++ b/modules/islandora_core_feature/config/install/filehash.settings.yml
@@ -2,4 +2,4 @@ algos:
   sha1: sha1
   md5: '0'
   sha256: '0'
-dedupe: false
+dedupe: '0'


### PR DESCRIPTION
**GitHub Issue**: This one.

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What does this Pull Request do?

https://github.com/Islandora/islandora/pull/862 moved to allow the newer version of filehash to be used; however, the newer version of filehash has updated the schema for the `filehash.settings:dedupe` property, meaning applying the configs from `islandora_core_feature` run into the warning(/error, when encountering in the context of a unit test):

```
Drupal\Core\Config\Schema\SchemaIncompleteException: Schema errors for filehash.settings with the following errors: filehash.settings:dedupe variable type is boolean but applied schema class is Drupal\Core\TypedData\Plugin\DataType\IntegerData

/opt/drupal/web/core/lib/Drupal/Core/Config/Development/ConfigSchemaChecker.php:94
/opt/drupal/web/core/lib/Drupal/Component/EventDispatcher/ContainerAwareEventDispatcher.php:142
/opt/drupal/web/core/lib/Drupal/Core/Config/Config.php:229
/opt/drupal/web/core/lib/Drupal/Core/Config/ConfigInstaller.php:399
/opt/drupal/web/modules/contrib/features/src/FeaturesConfigInstaller.php:99
/opt/drupal/web/core/lib/Drupal/Core/Config/ConfigInstaller.php:152
/opt/drupal/web/core/lib/Drupal/Core/Extension/ModuleInstaller.php:324
/opt/drupal/web/core/lib/Drupal/Core/ProxyClass/Extension/ModuleInstaller.php:83
/opt/drupal/web/core/lib/Drupal/Core/Test/FunctionalTestSetupTrait.php:474
/opt/drupal/web/core/tests/Drupal/Tests/BrowserTestBase.php:559
/opt/drupal/web/core/tests/Drupal/Tests/BrowserTestBase.php:378
[...]
/opt/drupal/vendor/phpunit/phpunit/src/Framework/TestResult.php:726
```

# What's new?

Updated the value for `filehash.settings:dedupe` to follow the [upstream schema change](https://git.drupalcode.org/project/filehash/-/commit/536f5d6d81d948b84cf4f5bd18de7c3854b86ed7#b1b05f5849f49afb51cdc2061b728b058f398486_65_64), to be an integer instead of a boolean. 

* Does this change add any new dependencies? No.
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? No.
* Could this change impact execution of existing code? In and of itself, not really our concern (would be more of an issue of whatever downstream's binding to filehash). There's [existing update hooks in `filehash`](https://git.drupalcode.org/project/filehash/-/commit/536f5d6d81d948b84cf4f5bd18de7c3854b86ed7#e5e27ab2ac4f640ca0884ce4879611f56f59f238_54_99) that would address this issue in the context of updating `filehash` in already-installed sites... that said, if one was to update and apply this config with an older version of `filehash` installed, presumably there were be warnings about the schema mismatching in the other direction.

# How should this be tested?

Unsure. I'm encountering this in the context of unit testing a private module, which requires some of the fields defined in the `islandora_core_feature`. Could probably reproduce by similarly, in a Drupal site, install the bare minimum set of features, including:
* `islandora_core_feature` and
* `filehash` 2.x

# Documentation Status

Doesn't seem like there should be anything documenting the specific data type of this config setting, in the context of Islandora.

* Does this change existing behaviour that's currently documented?
* Does this change require new pages or sections of documentation?
* Who does this need to be documented for?
* Associated documentation pull request(s): ___  or documentation issue ___

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/8-x-committers
