### PR TITLE
Use the interface not the class.

### DIFF
--- a/src/Commands/IslandoraCommands.php
+++ b/src/Commands/IslandoraCommands.php
@@ -4,7 +4,7 @@ namespace Drupal\islandora\Commands;
 
 use Consolidation\AnnotatedCommand\CommandData;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\Session\AccountProxy;
+use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\Session\AccountSwitcherInterface;
 use Drupal\Core\Session\UserSession;
 use Drush\Commands\DrushCommands;
@@ -39,7 +39,7 @@ class IslandoraCommands extends DrushCommands {
   /**
    * {@inheritdoc}
    */
-  public function __construct(EntityTypeManagerInterface $entity_type_manager, AccountProxy $current_user, AccountSwitcherInterface $account_switcher) {
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, AccountProxyInterface $current_user, AccountSwitcherInterface $account_switcher) {
     $this->entityTypeManager = $entity_type_manager;
     $this->currentUser = $current_user;
     $this->accountSwitcher = $account_switcher;


### PR DESCRIPTION
**GitHub Issue**: N/A

* Other Relevant Links (Google Groups discussion, related pull requests,
N/A

# What does this Pull Request do?

Uses the interface not the class such that other modules can override the core user service (example: https://git.drupalcode.org/project/restrict_by_ip/-/blob/f91edc105e886eb625852cc36361b938e09147ce/src/RestrictByIpServiceProvider.php#L24) without it blowing up like so:

```
TypeError: Argument 2 passed to Drupal\islandora\Commands\IslandoraCommands::__construct() must be an instance of Drupal\Core\Session\AccountProxy, instance of Drupal\restrict_by_ip\Session\AccountProxy given, called in /opt/www/drupal/core/lib/Drupal/Component/DependencyInjection/Container.php on line 262 in Drupal\islandora\Commands\IslandoraCommands->__construct() (line 42 of /opt/www/drupal/modules/contrib/islandora/src/Commands/IslandoraCommands.php).
```

# What's new?
Nothing notable.

# How should this be tested?

Test the `migrate:import` command I guess?

# Documentation Status

* Does this change existing behaviour that's currently documented?
No.
* Does this change require new pages or sections of documentation?
No.
* Who does this need to be documented for?
N/A.
* Associated documentation pull request(s): ___  or documentation issue ___
N/A.

# Interested parties
@Islandora/8-x-committers
