### PR TITLE
Has media view filter

### DIFF
--- a/islandora.views.inc
+++ b/islandora.views.inc
@@ -22,4 +22,16 @@ function islandora_views_data_alter(&$data) {
       $data['node__' . $field][$field]['field']['id'] = 'integer_weight_selector';
     }
   }
+
+  // Add Has Media filter.
+  $data['node_field_data']['islandora_has_media'] = [
+    'title' => t('Node has Media Use'),
+    'group' => t('Content'),
+    'filter' => [
+      'title' => t('Node has media use filter'),
+      'help' => t('Provides a custom filter for nodes that do or do not have media with a given use.'),
+      'field' => 'nid',
+      'id' => 'islandora_node_has_media_use',
+    ],
+  ];
 }

--- a/src/Plugin/views/filter/NodeHasMediaUse.php
+++ b/src/Plugin/views/filter/NodeHasMediaUse.php
@@ -70,7 +70,8 @@ class NodeHasMediaUse extends FilterPluginBase {
    */
   public function adminSummary() {
     $operator = ($this->options['negated']) ? "does not have" : "has";
-    return "Node {$operator} media with use: '{$this->options['use_uri']}'";
+    $term = \Drupal::service('islandora.utils')->getTermForUri($this->options['use_uri']);
+    return "Node {$operator} a '{$term->label()}' media";
   }
 
   /**

--- a/src/Plugin/views/filter/NodeHasMediaUse.php
+++ b/src/Plugin/views/filter/NodeHasMediaUse.php
@@ -18,20 +18,16 @@ class NodeHasMediaUse extends FilterPluginBase {
    * {@inheritdoc}
    */
   protected function defineOptions() {
-    $options = parent::defineOptions();
-
-    $options['use_uri'] = ['default' => NULL];
-    $options['negated'] = ['default' => FALSE];
-
-    return $options;
+    return [
+      'use_uri' => ['default' => NULL],
+      'negated' => ['default' => FALSE],
+    ];
   }
 
   /**
    * {@inheritdoc}
    */
   public function validateOptionsForm(&$form, FormStateInterface $form_state) {
-    parent::validateOptionsForm($form, $form_state);
-
     $uri = $form_state->getValues()['options']['use_uri'];
     $term = \Drupal::service('islandora.utils')->getTermForUri($uri);
     if (empty($term)) {
@@ -42,12 +38,13 @@ class NodeHasMediaUse extends FilterPluginBase {
   /**
    * {@inheritdoc}
    */
-  protected function valueForm(&$form, FormStateInterface $form_state) {
+  public function buildOptionsForm(&$form, FormStateInterface $form_state) {
     $terms = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->loadByProperties(['vid' => 'islandora_media_use']);
     $uris = [];
     foreach ($terms as $term) {
-      $uri = reset($term->get('field_external_uri')->getValue());
-      $uris[$uri['uri']] = $term->label();
+      foreach ($term->get('field_external_uri')->getValue() as $uri) {
+        $uris[$uri['uri']] = $term->label();
+      }
     }
 
     $form['use_uri'] = [
@@ -92,7 +89,6 @@ class NodeHasMediaUse extends FilterPluginBase {
     $sub_query->fields('of', ['field_media_of_target_id'])
       ->condition('use.field_media_use_target_id', $term->id());
     $this->query->addWhere(0, 'nid', $sub_query, $condition);
-
   }
 
 }

--- a/src/Plugin/views/filter/NodeHasMediaUse.php
+++ b/src/Plugin/views/filter/NodeHasMediaUse.php
@@ -43,9 +43,17 @@ class NodeHasMediaUse extends FilterPluginBase {
    * {@inheritdoc}
    */
   protected function valueForm(&$form, FormStateInterface $form_state) {
+    $terms = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->loadByProperties(['vid' => 'islandora_media_use']);
+    $uris = [];
+    foreach ($terms as $term) {
+      $uri = reset($term->get('field_external_uri')->getValue());
+      $uris[$uri['uri']] = $term->label();
+    }
+
     $form['use_uri'] = [
-      '#type' => 'textfield',
-      '#title' => "Media Use URI",
+      '#type' => 'select',
+      '#title' => "Media Use Term",
+      '#options' => $uris,
       '#default_value' => $this->options['use_uri'],
       '#required' => TRUE,
     ];

--- a/src/Plugin/views/filter/NodeHasMediaUse.php
+++ b/src/Plugin/views/filter/NodeHasMediaUse.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Drupal\islandora\Plugin\views\filter;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\views\Plugin\views\filter\FilterPluginBase;
+
+/**
+ * Views Filter on Having Media of a Type.
+ *
+ * @ingroup views_field_handlers
+ *
+ * @ViewsFilter("islandora_node_has_media_use")
+ */
+class NodeHasMediaUse extends FilterPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function defineOptions() {
+    $options = parent::defineOptions();
+
+    $options['use_uri'] = ['default' => NULL];
+    $options['negated'] = ['default' => FALSE];
+
+    return $options;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateOptionsForm(&$form, FormStateInterface $form_state) {
+    parent::validateOptionsForm($form, $form_state);
+
+    $uri = $form_state->getValues()['options']['use_uri'];
+    $term = \Drupal::service('islandora.utils')->getTermForUri($uri);
+    if (empty($term)) {
+      $form_state->setError($form['use_uri'], $this->t('Could not find term with URI: "%uri"', ['%uri' => $uri]));
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function valueForm(&$form, FormStateInterface $form_state) {
+    $form['use_uri'] = [
+      '#type' => 'textfield',
+      '#title' => "Media Use URI",
+      '#default_value' => $this->options['use_uri'],
+      '#required' => TRUE,
+    ];
+    $form['negated'] = [
+      '#type' => 'checkbox',
+      '#title' => 'Negated',
+      '#description' => $this->t("Return nodes that <em>don't</em> have this use URI"),
+      '#default_value' => $this->options['negated'],
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function adminSummary() {
+    $operator = ($this->options['negated']) ? "does not have" : "has";
+    return "Node {$operator} media with use: '{$this->options['use_uri']}'";
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function query() {
+    $condition = ($this->options['negated']) ? 'NOT IN' : 'IN';
+    $utils = \Drupal::service('islandora.utils');
+    $term = $utils->getTermForUri($this->options['use_uri']);
+    if (empty($term)) {
+      \Drupal::logger('islandora')->warning('Node Has Media Filter could not find term with URI: "%uri"', ['%uri' => $this->options['use_uri']]);
+      return;
+    }
+    $sub_query = \Drupal::database()->select('media', 'm');
+    $sub_query->join('media__field_media_use', 'use', 'm.mid = use.entity_id');
+    $sub_query->join('media__field_media_of', 'of', 'm.mid = of.entity_id');
+    $sub_query->fields('of', ['field_media_of_target_id'])
+      ->condition('use.field_media_use_target_id', $term->id());
+    $this->query->addWhere(0, 'nid', $sub_query, $condition);
+
+  }
+
+}

--- a/src/Plugin/views/filter/NodeHasMediaUse.php
+++ b/src/Plugin/views/filter/NodeHasMediaUse.php
@@ -71,7 +71,8 @@ class NodeHasMediaUse extends FilterPluginBase {
   public function adminSummary() {
     $operator = ($this->options['negated']) ? "does not have" : "has";
     $term = \Drupal::service('islandora.utils')->getTermForUri($this->options['use_uri']);
-    return "Node {$operator} a '{$term->label()}' media";
+    $label = (empty($term)) ? 'BROKEN TERM URI' : $term->label();
+    return "Node {$operator} a '{$label}' media";
   }
 
   /**


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/islandora-starter-site/issues/33

# What does this Pull Request do?

Adds a new View Filter that allows you to include or exclude nodes with a media with a given Media Use URI.

# What's new?

* Added a new View Filter
* Does this change add any new dependencies? No.
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? No.
* Could this change impact execution of existing code? No.

# How should this be tested?

* Pull in the PR
* Clear your Cache so Drupal can find it
* Create a new view of nodes (not necessarily the repository object, but that will be the most useful)
* Add the "Node has media use filter" filter and provide it with a URI, e.g. "http://pcdm.org/use#ThumbnailImage".
* Update the preview and it will only list nodes with a thumbnail media related to it.
* Update the filter with the "Negate" checkbox selected
* Update the preview and it will only list nodes _without_ a thumbnail media related to it.

# Documentation Status

* Does this change existing behaviour that's currently documented? No.
* Does this change require new pages or sections of documentation? Maybe?
* Who does this need to be documented for? Site managers.
* Associated documentation pull request(s): ___  or documentation issue ___

# Additional Notes:
View config that can be used for testing:
```yml
uuid: c8e796db-c226-407d-aa3c-f9963be42c16
langcode: en
status: true
dependencies:
  module:
    - islandora
    - node
    - user
id: test
label: TEST
module: views
description: ''
tag: ''
base_table: node_field_data
base_field: nid
display:
  default:
    id: default
    display_title: Default
    display_plugin: default
    position: 0
    display_options:
      title: TEST
      fields:
        title:
          id: title
          table: node_field_data
          field: title
          relationship: none
          group_type: group
          admin_label: ''
          entity_type: node
          entity_field: title
          plugin_id: field
          label: ''
          exclude: false
          alter:
            alter_text: false
            make_link: false
            absolute: false
            word_boundary: false
            ellipsis: false
            strip_tags: false
            trim: false
            html: false
          element_type: ''
          element_class: ''
          element_label_type: ''
          element_label_class: ''
          element_label_colon: true
          element_wrapper_type: ''
          element_wrapper_class: ''
          element_default_classes: true
          empty: ''
          hide_empty: false
          empty_zero: false
          hide_alter_empty: true
          click_sort_column: value
          type: string
          settings:
            link_to_entity: true
          group_column: value
          group_columns: {  }
          group_rows: true
          delta_limit: 0
          delta_offset: 0
          delta_reversed: false
          delta_first_last: false
          multi_type: separator
          separator: ', '
          field_api_classes: false
      pager:
        type: mini
        options:
          offset: 0
          items_per_page: 10
          total_pages: null
          id: 0
          tags:
            next: ››
            previous: ‹‹
          expose:
            items_per_page: false
            items_per_page_label: 'Items per page'
            items_per_page_options: '5, 10, 25, 50'
            items_per_page_options_all: false
            items_per_page_options_all_label: '- All -'
            offset: false
            offset_label: Offset
      exposed_form:
        type: basic
        options:
          submit_button: Apply
          reset_button: false
          reset_button_label: Reset
          exposed_sorts_label: 'Sort by'
          expose_sort_order: true
          sort_asc_label: Asc
          sort_desc_label: Desc
      access:
        type: perm
        options:
          perm: 'access content'
      cache:
        type: tag
        options: {  }
      empty: {  }
      sorts:
        created:
          id: created
          table: node_field_data
          field: created
          relationship: none
          group_type: group
          admin_label: ''
          entity_type: node
          entity_field: created
          plugin_id: date
          order: DESC
          expose:
            label: ''
            field_identifier: ''
          exposed: false
          granularity: second
      arguments: {  }
      filters:
        status:
          id: status
          table: node_field_data
          field: status
          entity_type: node
          entity_field: status
          plugin_id: boolean
          value: '1'
          group: 1
          expose:
            operator: ''
            operator_limit_selection: false
            operator_list: {  }
        islandora_has_media:
          id: islandora_has_media
          table: node_field_data
          field: islandora_has_media
          relationship: none
          group_type: group
          admin_label: ''
          entity_type: node
          plugin_id: islandora_node_has_media_use
          operator: '='
          value: ''
          group: 1
          exposed: false
          expose:
            operator_id: ''
            label: ''
            description: ''
            use_operator: false
            operator: ''
            operator_limit_selection: false
            operator_list: {  }
            identifier: ''
            required: false
            remember: false
            multiple: false
            remember_roles:
              authenticated: authenticated
          is_grouped: false
          group_info:
            label: ''
            description: ''
            identifier: ''
            optional: true
            widget: select
            multiple: false
            remember: false
            default_group: All
            default_group_multiple: {  }
            group_items: {  }
          use_uri: 'http://pcdm.org/use#ThumbnailImage'
          negated: 1
        islandora_has_media_1:
          id: islandora_has_media_1
          table: node_field_data
          field: islandora_has_media
          relationship: none
          group_type: group
          admin_label: ''
          entity_type: node
          plugin_id: islandora_node_has_media_use
          operator: '='
          value: ''
          group: 1
          exposed: false
          expose:
            operator_id: ''
            label: ''
            description: ''
            use_operator: false
            operator: ''
            operator_limit_selection: false
            operator_list: {  }
            identifier: ''
            required: false
            remember: false
            multiple: false
            remember_roles:
              authenticated: authenticated
          is_grouped: false
          group_info:
            label: ''
            description: ''
            identifier: ''
            optional: true
            widget: select
            multiple: false
            remember: false
            default_group: All
            default_group_multiple: {  }
            group_items: {  }
          use_uri: 'http://pcdm.org/use#ServiceFile'
          negated: 0
      filter_groups:
        operator: AND
        groups:
          1: AND
      style:
        type: default
      row:
        type: fields
      query:
        type: views_query
        options:
          query_comment: ''
          disable_sql_rewrite: false
          distinct: false
          replica: false
          query_tags: {  }
      relationships: {  }
      header: {  }
      footer: {  }
      display_extenders: {  }
    cache_metadata:
      max-age: -1
      contexts:
        - 'languages:language_content'
        - 'languages:language_interface'
        - url.query_args
        - 'user.node_grants:view'
        - user.permissions
      tags: {  }
  page_1:
    id: page_1
    display_title: Page
    display_plugin: page
    position: 1
    display_options:
      display_extenders: {  }
      path: test
    cache_metadata:
      max-age: -1
      contexts:
        - 'languages:language_content'
        - 'languages:language_interface'
        - url.query_args
        - 'user.node_grants:view'
        - user.permissions
      tags: {  }
```
The view could be cleaned up and enhanced and then added to `islandora_defaults/config/optional`.

# Interested parties
@rosiel, @wgilling, @amyrb 