### PR TITLE
IsIslandora views filter and context condition use Islandora Utils.

### DIFF
--- a/islandora.views.inc
+++ b/islandora.views.inc
@@ -37,4 +37,16 @@ function islandora_views_data_alter(&$data) {
       'id' => 'islandora_node_has_media_use',
     ],
   ];
+
+  // Add Is Islandora filter.
+  $data['node_field_data']['islandora_node_is_islandora'] = [
+    'title' => t('Node is Islandora'),
+    'group' => t('Content'),
+    'filter' => [
+      'title' => t('Node is Islandora'),
+      'help' => t('Node has a content type that possesses the mandatory Islandora fields.'),
+      'field' => 'nid',
+      'id' => 'islandora_node_is_islandora',
+    ],
+  ];
 }

--- a/src/Plugin/Condition/NodeIsIslandoraObject.php
+++ b/src/Plugin/Condition/NodeIsIslandoraObject.php
@@ -20,6 +20,31 @@ use Drupal\Islandora\IslandoraUtils;
  */
 class NodeIsIslandoraObject extends ConditionPluginBase implements ContainerFactoryPluginInterface {
 
+  /**
+   * Islandora Utils.
+   *
+   * @var \Drupal\islandora\IslandoraUtils
+   */
+  protected $utils;
+  
+   /**
+   * Constructs a Node is Islandora Condition plugin.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\islandora\IslandoraUtils $islandora_utils
+   *   Islandora utilities.
+   * @param \Drupal\Core\Entity\EntityTypeBundleInfoInterface $entity_type_bundle_info
+   *   The entity type bundle service.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, IslandoraUtils $islandora_utils) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->utils = $islandora_utils;
+  }
 
   /**
    * {@inheritdoc}
@@ -28,7 +53,8 @@ class NodeIsIslandoraObject extends ConditionPluginBase implements ContainerFact
     return new static(
       $configuration,
       $plugin_id,
-      $plugin_definition
+      $plugin_definition,
+      $container->get('islandora.utils')
     );
   }
 
@@ -40,9 +66,8 @@ class NodeIsIslandoraObject extends ConditionPluginBase implements ContainerFact
     if (!$node) {
       return FALSE;
     }
-    // Islandora objects are determined by Islandora Utils.
-    $utils = \Drupal::service('islandora.utils');
-    if ($utils->isIslandoraType('node',$node->bundle())) {
+    // Determine if node is Islandora.
+    if ($this->utils->isIslandoraType('node', $node->bundle())) {
       return TRUE;
     }
   }

--- a/src/Plugin/Condition/NodeIsIslandoraObject.php
+++ b/src/Plugin/Condition/NodeIsIslandoraObject.php
@@ -26,8 +26,8 @@ class NodeIsIslandoraObject extends ConditionPluginBase implements ContainerFact
    * @var \Drupal\islandora\IslandoraUtils
    */
   protected $utils;
-  
-   /**
+
+  /**
    * Constructs a Node is Islandora Condition plugin.
    *
    * @param array $configuration
@@ -38,8 +38,6 @@ class NodeIsIslandoraObject extends ConditionPluginBase implements ContainerFact
    *   The plugin implementation definition.
    * @param \Drupal\islandora\IslandoraUtils $islandora_utils
    *   Islandora utilities.
-   * @param \Drupal\Core\Entity\EntityTypeBundleInfoInterface $entity_type_bundle_info
-   *   The entity type bundle service.
    */
   public function __construct(array $configuration, $plugin_id, $plugin_definition, IslandoraUtils $islandora_utils) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);

--- a/src/Plugin/Condition/NodeIsIslandoraObject.php
+++ b/src/Plugin/Condition/NodeIsIslandoraObject.php
@@ -5,19 +5,21 @@ namespace Drupal\islandora\Plugin\Condition;
 use Drupal\Core\Condition\ConditionPluginBase;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Islandora\IslandoraUtils;
 
 /**
  * Checks whether node has fields that qualify it as an "Islandora" node.
  *
  * @Condition(
  *   id = "node_is_islandora_object",
- *   label = @Translation("Node is an Islandora object"),
+ *   label = @Translation("Node is an Islandora node"),
  *   context_definitions = {
  *     "node" = @ContextDefinition("entity:node", required = TRUE , label = @Translation("node"))
  *   }
  * )
  */
 class NodeIsIslandoraObject extends ConditionPluginBase implements ContainerFactoryPluginInterface {
+
 
   /**
    * {@inheritdoc}
@@ -38,8 +40,9 @@ class NodeIsIslandoraObject extends ConditionPluginBase implements ContainerFact
     if (!$node) {
       return FALSE;
     }
-    // Islandora objects have these two fields.
-    if ($node->hasField('field_model') && $node->hasField('field_member_of')) {
+    // Islandora objects are determined by Islandora Utils.
+    $utils = \Drupal::service('islandora.utils');
+    if ($utils->isIslandoraType('node',$node->bundle())) {
       return TRUE;
     }
   }
@@ -49,10 +52,10 @@ class NodeIsIslandoraObject extends ConditionPluginBase implements ContainerFact
    */
   public function summary() {
     if (!empty($this->configuration['negate'])) {
-      return $this->t('The node is not an Islandora object.');
+      return $this->t('The node is not an Islandora node.');
     }
     else {
-      return $this->t('The node is an Islandora object.');
+      return $this->t('The node is an Islandora node.');
     }
   }
 

--- a/src/Plugin/views/filter/NodeIsIslandora.php
+++ b/src/Plugin/views/filter/NodeIsIslandora.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Drupal\islandora\Plugin\views\filter;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\views\Plugin\views\filter\FilterPluginBase;
+use Drupal\views\Plugin\ViewsHandlerManager;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Views Filter to show only Islandora nodes.
+ *
+ * @ingroup views_filter_handlers
+ *
+ * @ViewsFilter("islandora_node_is_islandora")
+ */
+class NodeIsIslandora extends FilterPluginBase implements ContainerFactoryPluginInterface {
+
+  /**
+  * Views Handler Plugin Manager.
+  *
+  * @var \Drupal\views\Plugin\ViewsHandlerManager
+  */
+  protected $joinHandler;
+
+  /**
+   * Constructs a Node is Islandora views filter plugin.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\views\Plugin\ViewsHandlerManager $join_handler
+   *   Views Handler Plugin Manager.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, ViewsHandlerManager $join_handler) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->joinHandler = $join_handler;
+  }
+
+   /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration, $plugin_id, $plugin_definition,
+      $container->get('plugin.manager.views.join')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function defineOptions() {
+    return [
+      'negated' => ['default' => FALSE],
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildOptionsForm(&$form, FormStateInterface $form_state) {
+    $types = [];
+    $utils = \Drupal::service('islandora.utils');
+    foreach (\Drupal::service('entity_type.bundle.info')->getBundleInfo('node') as $bundle_id => $bundle) {
+        if ($utils->isIslandoraType('node', $bundle_id)) {
+            $types[] = $bundle['label'] . ' (' . $bundle_id . ')' ;
+        }
+    }
+    $form['info'] = [
+      '#type' => 'item',
+      '#title' => 'Information',
+      '#description' => t("Configured Islandora bundles: ") . implode(', ', $types),
+    ];
+    $form['negated'] = [
+      '#type' => 'checkbox',
+      '#title' => 'Negated',
+      '#description' => $this->t("Return nodes that <em>don't</em> have islandora fields"),
+      '#default_value' => $this->options['negated'],
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function adminSummary() {
+    $operator = ($this->options['negated']) ? "is not" : "is";
+    return "Node {$operator} an islandora node";
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function query() {
+    $types = [];
+    $utils = \Drupal::service('islandora.utils');
+    foreach (array_keys(\Drupal::service('entity_type.bundle.info')->getBundleInfo('node')) as $bundle_id) {
+        if ($utils->isIslandoraType('node', $bundle_id)) {
+            $types[] = $bundle_id;
+        }
+    }
+    $condition = ($this->options['negated']) ? 'NOT IN' : 'IN';
+    $query_base_table = $this->relationship ?: $this->view->storage->get('base_table');
+
+    $definition = [
+      'table' => 'node',
+      'type' => 'LEFT',
+      'field' => 'nid',
+      'left_table' => $query_base_table,
+      'left_field' => 'nid',
+    ];
+    $join = $this->joinHandler->createInstance('standard', $definition);
+    $node_table_alias = $this->query->addTable('node', $this->relationship, $join);
+    $this->query->addWhere($this->options['group'], "$node_table_alias.type", $types, $condition);
+  }
+
+}

--- a/src/Plugin/views/filter/NodeIsIslandora.php
+++ b/src/Plugin/views/filter/NodeIsIslandora.php
@@ -98,7 +98,7 @@ class NodeIsIslandora extends FilterPluginBase implements ContainerFactoryPlugin
     $form['info'] = [
       '#type' => 'item',
       '#title' => 'Information',
-      '#description' => t("Configured Islandora bundles: {$types_list} "),
+      '#description' => t("Configured Islandora bundles: @types", ['@types' => $types_list]),
     ];
     $form['negated'] = [
       '#type' => 'checkbox',
@@ -140,5 +140,6 @@ class NodeIsIslandora extends FilterPluginBase implements ContainerFactoryPlugin
     $node_table_alias = $this->query->addTable('node', $this->relationship, $join);
     $this->query->addWhere($this->options['group'], "$node_table_alias.type", $types, $condition);
   }
+
 }
 

--- a/src/Plugin/views/filter/NodeIsIslandora.php
+++ b/src/Plugin/views/filter/NodeIsIslandora.php
@@ -142,4 +142,3 @@ class NodeIsIslandora extends FilterPluginBase implements ContainerFactoryPlugin
   }
 
 }
-

--- a/src/Plugin/views/filter/NodeIsIslandora.php
+++ b/src/Plugin/views/filter/NodeIsIslandora.php
@@ -91,13 +91,14 @@ class NodeIsIslandora extends FilterPluginBase implements ContainerFactoryPlugin
     $types = [];
     foreach ($this->entityTypeBundleInfo->getBundleInfo('node') as $bundle_id => $bundle) {
       if ($this->utils->isIslandoraType('node', $bundle_id)) {
-        $types[] = $bundle['label'] . ' (' . $bundle_id . ')' ;
+        $types[] = "{$bundle['label']} ($bundle_id)";
       }
     }
+    $types_list = implode(', ', $types);
     $form['info'] = [
       '#type' => 'item',
       '#title' => 'Information',
-      '#description' => t("Configured Islandora bundles: ") . implode(', ', $types),
+      '#description' => t("Configured Islandora bundles: {$types_list} "),
     ];
     $form['negated'] = [
       '#type' => 'checkbox',
@@ -139,6 +140,5 @@ class NodeIsIslandora extends FilterPluginBase implements ContainerFactoryPlugin
     $node_table_alias = $this->query->addTable('node', $this->relationship, $join);
     $this->query->addWhere($this->options['group'], "$node_table_alias.type", $types, $condition);
   }
-
 }
 

--- a/src/Plugin/views/filter/NodeIsIslandora.php
+++ b/src/Plugin/views/filter/NodeIsIslandora.php
@@ -7,6 +7,8 @@ use Drupal\views\Plugin\views\filter\FilterPluginBase;
 use Drupal\views\Plugin\ViewsHandlerManager;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\islandora\IslandoraUtils;
+use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 
 /**
  * Views Filter to show only Islandora nodes.
@@ -18,11 +20,25 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class NodeIsIslandora extends FilterPluginBase implements ContainerFactoryPluginInterface {
 
   /**
-  * Views Handler Plugin Manager.
-  *
-  * @var \Drupal\views\Plugin\ViewsHandlerManager
-  */
+   * Views Handler Plugin Manager.
+   *
+   * @var \Drupal\views\Plugin\ViewsHandlerManager
+   */
   protected $joinHandler;
+
+  /**
+   * Islandora Utils.
+   *
+   * @var \Drupal\islandora\IslandoraUtils
+   */
+  protected $utils;
+
+  /**
+   * The entity type bundle info service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeBundleInfoInterface
+   */
+  protected $entityTypeBundleInfo;
 
   /**
    * Constructs a Node is Islandora views filter plugin.
@@ -35,19 +51,27 @@ class NodeIsIslandora extends FilterPluginBase implements ContainerFactoryPlugin
    *   The plugin implementation definition.
    * @param \Drupal\views\Plugin\ViewsHandlerManager $join_handler
    *   Views Handler Plugin Manager.
+   * @param \Drupal\islandora\IslandoraUtils $islandora_utils
+   *   Islandora utilities.
+   * @param \Drupal\Core\Entity\EntityTypeBundleInfoInterface $entity_type_bundle_info
+   *   The entity type bundle service.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, ViewsHandlerManager $join_handler) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, ViewsHandlerManager $join_handler, IslandoraUtils $islandora_utils, EntityTypeBundleInfoInterface $entity_type_bundle_info) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->joinHandler = $join_handler;
+    $this->utils = $islandora_utils;
+    $this->entityTypeBundleInfo = $entity_type_bundle_info;
   }
 
-   /**
+  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
     return new static(
       $configuration, $plugin_id, $plugin_definition,
-      $container->get('plugin.manager.views.join')
+      $container->get('plugin.manager.views.join'),
+      $container->get('islandora.utils'),
+      $container->get('entity_type.bundle.info')
     );
   }
 
@@ -65,11 +89,10 @@ class NodeIsIslandora extends FilterPluginBase implements ContainerFactoryPlugin
    */
   public function buildOptionsForm(&$form, FormStateInterface $form_state) {
     $types = [];
-    $utils = \Drupal::service('islandora.utils');
-    foreach (\Drupal::service('entity_type.bundle.info')->getBundleInfo('node') as $bundle_id => $bundle) {
-        if ($utils->isIslandoraType('node', $bundle_id)) {
-            $types[] = $bundle['label'] . ' (' . $bundle_id . ')' ;
-        }
+    foreach ($this->entityTypeBundleInfo->getBundleInfo('node') as $bundle_id => $bundle) {
+      if ($this->utils->isIslandoraType('node', $bundle_id)) {
+        $types[] = $bundle['label'] . ' (' . $bundle_id . ')' ;
+      }
     }
     $form['info'] = [
       '#type' => 'item',
@@ -97,11 +120,10 @@ class NodeIsIslandora extends FilterPluginBase implements ContainerFactoryPlugin
    */
   public function query() {
     $types = [];
-    $utils = \Drupal::service('islandora.utils');
-    foreach (array_keys(\Drupal::service('entity_type.bundle.info')->getBundleInfo('node')) as $bundle_id) {
-        if ($utils->isIslandoraType('node', $bundle_id)) {
-            $types[] = $bundle_id;
-        }
+    foreach (array_keys($this->entityTypeBundleInfo->getBundleInfo('node')) as $bundle_id) {
+      if ($this->utils->isIslandoraType('node', $bundle_id)) {
+        $types[] = $bundle_id;
+      }
     }
     $condition = ($this->options['negated']) ? 'NOT IN' : 'IN';
     $query_base_table = $this->relationship ?: $this->view->storage->get('base_table');
@@ -119,3 +141,4 @@ class NodeIsIslandora extends FilterPluginBase implements ContainerFactoryPlugin
   }
 
 }
+


### PR DESCRIPTION
**GitHub Issue**:
- https://github.com/Islandora/documentation/issues/1625
- related: https://github.com/Islandora/documentation/issues/1255
* and a discussion I had recently with some of the Committers/TAG (sorry, it has slipped my mind)
* And some concerns that I've had recently about Reporting - namely, the abiliity to create a report to show "your islandora content" and not need to update it as you change what content types are islandora.

# What does this Pull Request do?

- Creates a Views filter that uses that, so you can make a view for "Islandora nodes" and it won't get out of date when you make new content. 
- Notices that there was a Context condition that detected if a node was Islandora, but it did its own testing. Now we just use one test.
- That one test, for the record, relies on (and only on) `field_member_of`. 


* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)?  no
* Could this change impact execution of existing code? If you were using the context condition, AND you have non-islandora nodes using field_member_of, then you have set up a weird repository and you probably want to create your own context conditions.

# How should this be tested?

* Create a view and play with the filter.
* Especially create a view that uses relationships and you have to do the filter on a related node.
* Test the context condition similarly.
They should all be "true" when `field_member_of` is on the node, and false otherwise.

# Documentation Status

* Does this change existing behaviour that's currently documented? Possibly
* Does this change require new pages or sections of documentation? It could - this and the 'missing media' view filter.
* Who does this need to be documented for? site admins using islandora to set up administrative things
* Associated documentation pull request(s): ___  or documentation issue ___

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
@seth-shaw_asu  and @Islandora/8-x-committers
