### PR TITLE
Disable EVA view by default. Fixes #1874.

### DIFF
--- a/modules/islandora_core_feature/config/install/views.view.display_media.yml
+++ b/modules/islandora_core_feature/config/install/views.view.display_media.yml
@@ -1,5 +1,5 @@
 langcode: en
-status: true
+status: false 
 dependencies:
   config:
     - core.entity_view_mode.media.source
@@ -14,7 +14,7 @@ dependencies:
 id: display_media
 label: 'Media EVAs'
 module: views
-description: 'Displays media for content as EVA''s per model.'
+description: 'Displays media for content as EVA''s per model. Only enable if field_media_of is configured on a media type.'
 tag: ''
 base_table: media_field_data
 base_field: mid


### PR DESCRIPTION
**GitHub Issue**: [link](https://github.com/Islandora/documentation/issues/1784)

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What does this Pull Request do?

- disables the EVA view by default, since it includes handlers that are broken unless you have field_media_of configured on media and this module doesn't do that.

# What's new?

* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? yes - when provisioning, need to manually enable that view.   PR for playbook coming.
* Could this change impact execution of existing code? no.

# How should this be tested?

Spin up a site with Islandora. Create some content. You get a whitescreen.

With this PR, you will be able to create content normally.

# Documentation Status

* Does this change existing behaviour that's currently documented? no, but some install documentation may(?) need to be updated.
* Does this change require new pages or sections of documentation? 
* Who does this need to be documented for?
* Associated documentation pull request(s): [here](https://github.com/Islandora/documentation/pull/2133)  or documentation issue ___

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/8-x-committers
