### PR TITLE
Add file access check to IIIF manifest generation.

### DIFF
--- a/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
+++ b/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
@@ -198,6 +198,10 @@ class IIIFManifest extends StylePluginBase {
         /** @var \Drupal\Core\Field\FieldItemListInterface $images */
         $images = $entity->{$viewsField->definition['field_name']};
         foreach ($images as $image) {
+          if (!$image->entity->access('view')) {
+            // If the user does not have permission to view the file, skip it.
+            continue;
+          }
           // Create the IIIF URL for this file
           // Visiting $iiif_url will resolve to the info.json for the image.
           $file_url = $image->entity->createFileUrl(FALSE);


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/2134

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What does this Pull Request do?

Prevent the inclusion of files to which a user may not have access in IIIF manifests.

# What's new?

Performs an access check before returning things.

* Does this change add any new dependencies? No.
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? No.
* Could this change impact execution of existing code? Should not.

# How should this be tested?

Use some mechanism (e.g., [`embargoes`](https://github.com/discoverygarden/embargoes/)) to apply file access controls, and ensure that multi-page viewers should follow suit (single/non-manifest version handled in https://github.com/Islandora/openseadragon/pull/42).

For testing, adding a small `hook_file_access()` blurb to your code somewhere is probably easiest, such as:

```php
function islandora_file_access($entity, $op) {
  if ($op == 'view') {
    if (in_array($entity->id(), [
      # These are file IDs to test being restricted: change as necessary to target the files
      # being shown in your environment. May also have to clear cache when changed?
      1,
      2,
      3,
    ])) {
      return AccessResult::forbidden('No touchy.')->addCacheableDependency($entity);
    }
  }
  return AccessResult::neutral()->addCacheableDependency($entity);
}
```

# Documentation Status

* Does this change existing behaviour that's currently documented? 
* Does this change require new pages or sections of documentation?
* Who does this need to be documented for?
* Associated documentation pull request(s): ___  or documentation issue ___

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/8-x-committers
