### PR TITLE
Document the add members and add media pages.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -40,4 +40,4 @@ Any additional information that you think would be helpful when reviewing this
  PR.
 
 # Interested parties
-Tag (@ mention) interested parties or, if unsure, @Islandora/8-x-committers
+Tag (@ mention) interested parties or, if unsure, @Islandora/committers

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
     "drupal/token" : "^1.3",
     "drupal/flysystem" : "^2.0@alpha",
     "islandora/crayfish-commons": "^2",
-    "drupal/file_replace": "^1.1"
+    "drupal/file_replace": "^1.1",
+    "drupal/ctools": "^3.8 || ^4"
   },
   "require-dev": {
     "phpunit/phpunit": "^6",
@@ -37,7 +38,7 @@
     "sebastian/phpcpd": "*"
   },
   "suggest": {
-    "drupal/transliterate_filenames": "Sanitizes filenames when they are uploaded so they don't break your repository." 
+    "drupal/transliterate_filenames": "Sanitizes filenames when they are uploaded so they don't break your repository."
   },
   "license": "GPL-2.0-or-later",
   "authors": [

--- a/config/schema/islandora.schema.yml
+++ b/config/schema/islandora.schema.yml
@@ -87,6 +87,14 @@ condition.plugin.node_has_term:
     logic:
       type: string
       label: 'Logic (AND or OR)'
+    tids:
+      type: sequence
+      sequence:
+        type: mapping
+        mapping:
+          target_id:
+            type: integer
+            label: The target taxonomy term IDs
 
 condition.plugin.node_has_parent:
   type: condition.plugin
@@ -158,6 +166,76 @@ condition.plugin.node_had_namespace:
     pid_field:
       type: ignore
       label: 'PID field'
+      
 field.formatter.settings.islandora_image:
   type: field.formatter.settings.image
   label: 'Islandora image field display format settings'
+
+condition.plugin.islandora_entity_bundle:
+  type: condition.plugin
+  mapping:
+    bundles:
+      type: sequence
+      sequence:
+        type: string
+
+condition.plugin.media_source_mimetype:
+  type: condition.plugin
+  mapping:
+    mimetype:
+      type: string
+
+reaction.plugin.alter_jsonld_type:
+  type: islandora.reaction_plugin_with_saved
+  mapping:
+    source_field:
+      type: string
+
+islandora.reaction_plugin_with_saved:
+  type: reaction.plugin
+  mapping:
+    saved:
+      type: boolean
+      label: Default config upstream; however, left undefined in the schema.
+
+reaction.plugin.islandora_map_uri_predicate:
+  type: islandora.reaction_plugin_with_saved
+  mapping:
+    drupal_uri_predicate:
+      type: string
+
+reaction.plugin.view_mode_alter:
+  type: islandora.reaction_plugin_with_saved
+  mapping:
+    mode:
+      type: string
+      label: The view mode to which to switch
+
+islandora.reaction.actions:
+  type: islandora.reaction_plugin_with_saved
+  mapping:
+    actions:
+      type: sequence
+      sequence:
+        type: string
+
+reaction.plugin.index:
+  type: islandora.reaction.actions
+
+reaction.plugin.delete:
+  type: islandora.reaction.actions
+
+reaction.plugin.derivative:
+  type: islandora.reaction.actions
+
+field.widget.settings.media_track:
+  type: field.widget.settings.file_generic
+
+field.field_settings.media_track:
+  type: field.field_settings.file
+  mapping:
+    languages:
+      type: string
+
+field.storage_settings.media_track:
+  type: field.storage_settings.file

--- a/islandora.info.yml
+++ b/islandora.info.yml
@@ -13,22 +13,23 @@ dependencies:
   - drupal:text
   - drupal:options
   - drupal:link
-  - drupal:jsonld
-  - drupal:search_api
-  - drupal:jwt
+  - jsonld:jsonld
+  - search_api:search_api
+  - jwt:jwt
   - drupal:rest
-  - drupal:filehash
+  - filehash:filehash
   - drupal:basic_auth
-  - drupal:context_ui
+  - context:context_ui
   - drupal:action
-  - drupal:eva
+  - eva:eva
   - drupal:taxonomy
   - drupal:views_ui
   - drupal:media
-  - drupal:prepopulate
-  - drupal:features_ui
-  - drupal:migrate_source_csv
+  - prepopulate:prepopulate
+  - features:features_ui
+  - migrate_source_csv:migrate_source_csv
   - drupal:content_translation
-  - drupal:flysystem
-  - drupal:token
-  - drupal:file_replace
+  - flysystem:flysystem
+  - token:token
+  - file_replace:file_replace
+  - ctools:ctools

--- a/islandora.install
+++ b/islandora.install
@@ -5,6 +5,10 @@
  * Install/update hook implementations.
  */
 
+use Drupal\Core\Extension\ExtensionNameLengthException;
+use Drupal\Core\Extension\MissingDependencyException;
+use Drupal\Core\Utility\UpdateException;
+
 /**
  * Adds common namespaces to jsonld.settings.
  */
@@ -173,4 +177,38 @@ function update_jsonld_included_namespaces() {
     \Drupal::logger('islandora')
       ->warning("Could not find required jsonld.settings to add default RDF namespaces.");
   }
+}
+
+/**
+ * Ensure that ctools is enabled.
+ */
+function islandora_update_8007() {
+  $module_handler = \Drupal::moduleHandler();
+  if ($module_handler->moduleExists('ctools')) {
+    return t('The "@module_name" module is already enabled, no action necessary.', [
+      '@module_name' => 'ctools',
+    ]);
+  }
+
+  /** @var \Drupal\Core\Extension\ModuleInstallerInterface $installer */
+  $installer = \Drupal::service('module_installer');
+
+  try {
+    if ($installer->install(['ctools'], TRUE)) {
+      return t('The "@module_name" module was enabled successfully.', [
+        '@module_name' => 'ctools',
+      ]);
+    }
+  }
+  catch (ExtensionNameLengthException | MissingDependencyException $e) {
+    throw new UpdateException('Failed; ensure that the ctools module is available in the Drupal installation.', 0, $e);
+  }
+  catch (\Exception $e) {
+    throw new UpdateException('Failed; encountered an exception while trying to enable ctools.', 0, $e);
+  }
+
+  // Theoretically impossible to hit, as ModuleInstaller::install() only returns
+  // TRUE (or throws/propagates an exception), but... probably a good idea to
+  // have the here, just in case?
+  throw new UpdateException('Failed; hit the end of the update hook implementation, which is not expected.');
 }

--- a/islandora.module
+++ b/islandora.module
@@ -423,7 +423,7 @@ function islandora_entity_extra_field_info() {
   if (!empty($pseudo_bundles)) {
     foreach ($pseudo_bundles as $key) {
       [$bundle, $content_entity] = explode(":", $key);
-      $extra_field[$content_entity][$bundle]['display']['field_gemini_uri'] = [
+      $extra_field[$content_entity][$bundle]['display'][IslandoraSettingsForm::GEMINI_PSEUDO_FIELD] = [
         'label' => t('Fedora URI'),
         'description' => t('The URI to the persistent'),
         'weight' => 100,

--- a/islandora.routing.yml
+++ b/islandora.routing.yml
@@ -37,14 +37,15 @@ islandora.add_member_to_node_page:
     _entity_create_any_access: 'node'
 
 islandora.upload_children:
-  path: '/node/{node}/members/upload'
+  path: '/node/{node}/members/upload/{step}'
   defaults:
-    _form: '\Drupal\islandora\Form\AddChildrenForm'
+    _wizard: '\Drupal\islandora\Form\AddChildrenWizard\ChildForm'
     _title: 'Upload Children'
+    step: 'type_selection'
   options:
     _admin_route: 'TRUE'
   requirements:
-    _custom_access: '\Drupal\islandora\Form\AddChildrenForm::access'
+    _custom_access: '\Drupal\islandora\Form\AddChildrenWizard\Access::childAccess'
 
 islandora.add_media_to_node_page:
   path: '/node/{node}/media/add'
@@ -58,14 +59,15 @@ islandora.add_media_to_node_page:
     _entity_create_any_access: 'media'
 
 islandora.upload_media:
-  path: '/node/{node}/media/upload'
+  path: '/node/{node}/media/upload/{step}'
   defaults:
-    _form: '\Drupal\islandora\Form\AddMediaForm'
+    _wizard: '\Drupal\islandora\Form\AddChildrenWizard\MediaForm'
     _title: 'Add media'
+    step: 'type_selection'
   options:
     _admin_route: 'TRUE'
   requirements:
-    _custom_access: '\Drupal\islandora\Form\AddMediaForm::access'
+    _custom_access: '\Drupal\islandora\Form\AddChildrenWizard\Access::mediaAccess'
 
 islandora.media_source_update:
   path: '/media/{media}/source'

--- a/islandora.services.yml
+++ b/islandora.services.yml
@@ -59,3 +59,19 @@ services:
     arguments: ['@jwt.authentication.jwt']
     tags:
       - { name: event_subscriber }
+  islandora.upload_children.batch_processor:
+    class: Drupal\islandora\Form\AddChildrenWizard\ChildBatchProcessor
+    arguments:
+      - '@entity_type.manager'
+      - '@database'
+      - '@current_user'
+      - '@messenger'
+      - '@date.formatter'
+  islandora.upload_media.batch_processor:
+    class: Drupal\islandora\Form\AddChildrenWizard\MediaBatchProcessor
+    arguments:
+      - '@entity_type.manager'
+      - '@database'
+      - '@current_user'
+      - '@messenger'
+      - '@date.formatter'

--- a/islandora.views.inc
+++ b/islandora.views.inc
@@ -37,4 +37,16 @@ function islandora_views_data_alter(&$data) {
       'id' => 'islandora_node_has_media_use',
     ],
   ];
+
+  // Add Is Islandora filter.
+  $data['node_field_data']['islandora_node_is_islandora'] = [
+    'title' => t('Node is Islandora'),
+    'group' => t('Content'),
+    'filter' => [
+      'title' => t('Node is Islandora'),
+      'help' => t('Node has a content type that possesses the mandatory Islandora fields.'),
+      'field' => 'nid',
+      'id' => 'islandora_node_is_islandora',
+    ],
+  ];
 }

--- a/islandora.views.inc
+++ b/islandora.views.inc
@@ -9,19 +9,21 @@
  * Implements hook_views_data_alter().
  */
 function islandora_views_data_alter(&$data) {
-  // For now only support Nodes.
-  $fields = \Drupal::service('entity_field.manager')->getFieldStorageDefinitions('node');
-  foreach ($fields as $field => $field_storage_definition) {
-    if ($field_storage_definition->getType() == 'integer' && strpos($field, "field_") === 0) {
-      $prefixed_field = 'node__' . $field;
-      if (isset($data[$prefixed_field])) {
-        $data[$prefixed_field][$field . '_value']['field'] = $data[$prefixed_field][$field]['field'];
-        $data[$prefixed_field][$field]['title'] = t('Integer Weight Selector (@field)', [
-          '@field' => $field,
-        ]);
-        $data[$prefixed_field][$field]['help'] = t('Provides a drag-n-drop reordering of integer-based weight fields.');
-        $data[$prefixed_field][$field]['title short'] = t('Integer weight selector');
-        $data[$prefixed_field][$field]['field']['id'] = 'integer_weight_selector';
+  // For now only support Nodes and Media.
+  foreach (['node', 'media'] as $entity_type) {
+    $fields = \Drupal::service('entity_field.manager')->getFieldStorageDefinitions($entity_type);
+    foreach ($fields as $field => $field_storage_definition) {
+      if ($field_storage_definition->getType() == 'integer' && strpos($field, "field_") === 0) {
+        $prefixed_field = $entity_type . '__' . $field;
+        if (isset($data[$prefixed_field])) {
+          $data[$prefixed_field][$field . '_value']['field'] = $data[$prefixed_field][$field]['field'];
+          $data[$prefixed_field][$field]['title'] = t('Integer Weight Selector (@field)', [
+            '@field' => $field,
+          ]);
+          $data[$prefixed_field][$field]['help'] = t('Provides a drag-n-drop reordering of integer-based weight fields.');
+          $data[$prefixed_field][$field]['title short'] = t('Integer weight selector');
+          $data[$prefixed_field][$field]['field']['id'] = 'integer_weight_selector';
+        }
       }
     }
   }

--- a/modules/islandora_audio/config/schema/islandora_audio.schema.yml
+++ b/modules/islandora_audio/config/schema/islandora_audio.schema.yml
@@ -29,3 +29,6 @@ action.configuration.generate_audio_derivative:
     path:
       type: text
       label: 'File path with extension'
+
+field.formatter.settings.islandora_file_audio:
+  type: field.formatter.settings.file_audio

--- a/modules/islandora_core_feature/config/install/views.view.manage_members.yml
+++ b/modules/islandora_core_feature/config/install/views.view.manage_members.yml
@@ -1,15 +1,17 @@
 langcode: en
 status: true
 dependencies:
-  enforced:
-    module:
-      - islandora_core_feature
   module:
     - jsonld
     - node
     - rest
     - serialization
     - user
+  enforced:
+    module:
+      - islandora_core_feature
+_core:
+  default_config_hash: Zwu8JUsBiYaxPko_9DbJJhA-ZZSGOm81I9XtT9NH3M4
 id: manage_members
 label: 'Manage members'
 module: views
@@ -17,61 +19,14 @@ description: 'Manage members belonging to a piece of content'
 tag: ''
 base_table: node_field_data
 base_field: nid
-core: 8.x
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
-        options:
-          perm: 'manage members'
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: mini
-        options:
-          items_per_page: 10
-          offset: 0
-          id: 0
-          total_pages: null
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-          tags:
-            previous: ‹‹
-            next: ››
-      style:
-        type: table
-      row:
-        type: fields
+      title: 'Manage members'
       fields:
         node_bulk_form:
           id: node_bulk_form
@@ -80,6 +35,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          plugin_id: node_bulk_form
           label: 'Node operations bulk form'
           exclude: false
           alter:
@@ -124,33 +81,27 @@ display:
           action_title: Action
           include_exclude: exclude
           selected_actions: {  }
-          entity_type: node
-          plugin_id: node_bulk_form
         title:
           id: title
           table: node_field_data
           field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
           entity_type: node
           entity_field: title
+          plugin_id: field
+          label: Title
+          exclude: false
           alter:
             alter_text: false
             make_link: false
             absolute: false
-            trim: false
             word_boundary: false
             ellipsis: false
             strip_tags: false
+            trim: false
             html: false
-          hide_empty: false
-          empty_zero: false
-          settings:
-            link_to_entity: true
-          plugin_id: field
-          relationship: none
-          group_type: group
-          admin_label: ''
-          label: Title
-          exclude: false
           element_type: ''
           element_class: ''
           element_label_type: ''
@@ -160,9 +111,13 @@ display:
           element_wrapper_class: ''
           element_default_classes: true
           empty: ''
+          hide_empty: false
+          empty_zero: false
           hide_alter_empty: true
           click_sort_column: value
           type: string
+          settings:
+            link_to_entity: true
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -180,6 +135,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          plugin_id: entity_operations
           label: 'Operations links'
           exclude: false
           alter:
@@ -222,15 +179,56 @@ display:
           empty_zero: false
           hide_alter_empty: true
           destination: false
-          entity_type: node
-          plugin_id: entity_operations
-      filters: {  }
-      sorts: {  }
-      title: 'Manage members'
-      header: {  }
-      footer: {  }
+      pager:
+        type: mini
+        options:
+          offset: 0
+          items_per_page: 10
+          total_pages: null
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'manage members'
+      cache:
+        type: tag
+        options: {  }
       empty: {  }
-      relationships: {  }
+      sorts:
+        field_weight_value:
+          id: field_weight_value
+          table: node__field_weight
+          field: field_weight_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
       arguments:
         field_member_of_target_id:
           id: field_member_of_target_id
@@ -239,6 +237,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: numeric
           default_action: default
           exception:
             value: all
@@ -252,8 +251,8 @@ display:
           summary_options:
             base_path: ''
             count: true
-            items_per_page: 25
             override: false
+            items_per_page: 25
           summary:
             sort_order: asc
             number_of_records: 0
@@ -263,17 +262,32 @@ display:
             type: 'entity:node'
             fail: 'not found'
           validate_options:
-            operation: view
-            multiple: 0
             bundles: {  }
             access: false
+            operation: view
+            multiple: 0
           break_phrase: false
           not: false
-          plugin_id: numeric
-      display_extenders: {  }
+      filters: {  }
       filter_groups:
         operator: AND
         groups: {  }
+      style:
+        type: table
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
     cache_metadata:
       max-age: 0
       contexts:
@@ -285,9 +299,9 @@ display:
         - user.permissions
       tags: {  }
   page_1:
-    display_plugin: page
     id: page_1
     display_title: Page
+    display_plugin: page
     position: 1
     display_options:
       display_extenders: {  }
@@ -296,11 +310,11 @@ display:
         type: tab
         title: Children
         description: ''
-        expanded: false
-        parent: ''
         weight: 0
-        context: '0'
+        expanded: false
         menu_name: main
+        parent: ''
+        context: '0'
     cache_metadata:
       max-age: 0
       contexts:
@@ -312,13 +326,11 @@ display:
         - user.permissions
       tags: {  }
   rest_export_1:
-    display_plugin: rest_export
     id: rest_export_1
     display_title: 'REST export'
+    display_plugin: rest_export
     position: 1
     display_options:
-      display_extenders: {  }
-      path: node/%node/members
       style:
         type: serializer
         options:
@@ -326,6 +338,8 @@ display:
           formats:
             jsonld: jsonld
             json: json
+      display_extenders: {  }
+      path: node/%node/members
       auth:
         - basic_auth
         - jwt_auth

--- a/modules/islandora_iiif/config/schema/islandora_iiif.schema.yml
+++ b/modules/islandora_iiif/config/schema/islandora_iiif.schema.yml
@@ -5,3 +5,11 @@ islandora_iiif.settings:
     iiif_server:
       type: string
       label: 'IIIF Server Url'
+
+views.style.iiif_manifest:
+  type: views_style
+  mapping:
+    iiif_tile_field:
+      type: sequence
+      sequence:
+        type: string

--- a/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
+++ b/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
@@ -313,6 +313,7 @@ class IIIFManifest extends StylePluginBase {
     $options = parent::defineOptions();
 
     $options['iiif_tile_field'] = ['default' => ''];
+    $options['iiif_ocr_file_field'] = ['default' => ''];
 
     return $options;
   }
@@ -367,6 +368,15 @@ class IIIFManifest extends StylePluginBase {
       // we have more than one option to choose from
       // otherwise could lock up the form when setting up a View.
       '#required' => count($field_options) > 0,
+    ];
+
+    $form['iiif_ocr_file_field'] = [
+      '#title' => $this->t('Structured OCR data file field'),
+      '#type' => 'checkboxes',
+      '#default_value' => $this->options['iiif_ocr_file_field'],
+      '#description' => $this->t('The source of structured OCR text for each entity.'),
+      '#options' => $field_options,
+      '#required' => FALSE,
     ];
   }
 

--- a/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
+++ b/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
@@ -191,7 +191,7 @@ class IIIFManifest extends StylePluginBase {
     $canvases = [];
     foreach (array_filter(array_values($this->options['iiif_tile_field'])) as $iiif_tile_field) {
       $viewsField = $this->view->field[$iiif_tile_field];
-      $iiif_ocr_file_field = !empty($this->options['iiif_ocr_file_field']) ? array_filter(array_values($this->options['iiif_ocr_file_field'])): array();
+      $iiif_ocr_file_field = !empty($this->options['iiif_ocr_file_field']) ? array_filter(array_values($this->options['iiif_ocr_file_field'])) : [];
       $ocrField = count($iiif_ocr_file_field) > 0 ? $this->view->field[$iiif_ocr_file_field[0]] : NULL;
       $entity = $viewsField->getEntity($row);
 
@@ -205,7 +205,7 @@ class IIIFManifest extends StylePluginBase {
             continue;
           }
 
-        $ocrs = $entity->{$ocrField->definition['field_name']};
+          $ocrs = $entity->{$ocrField->definition['field_name']};
 
           // Create the IIIF URL for this file
           // Visiting $iiif_url will resolve to the info.json for the image.

--- a/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
+++ b/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
@@ -189,7 +189,7 @@ class IIIFManifest extends StylePluginBase {
    */
   protected function getTileSourceFromRow(ResultRow $row, $iiif_address, $iiif_base_id) {
     $canvases = [];
-    foreach ($this->options['iiif_tile_field'] as $iiif_tile_field) {
+    foreach (array_filter(array_values($this->options['iiif_tile_field'])) as $iiif_tile_field) {
       $viewsField = $this->view->field[$iiif_tile_field];
       $entity = $viewsField->getEntity($row);
 

--- a/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
+++ b/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
@@ -191,6 +191,7 @@ class IIIFManifest extends StylePluginBase {
     $canvases = [];
     foreach (array_filter(array_values($this->options['iiif_tile_field'])) as $iiif_tile_field) {
       $viewsField = $this->view->field[$iiif_tile_field];
+      $ocrField = array_pop(array_filter(array_values($this->options['iiif_ocr_file_field'])));
       $entity = $viewsField->getEntity($row);
 
       if (isset($entity->{$viewsField->definition['field_name']})) {

--- a/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
+++ b/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
@@ -277,7 +277,7 @@ class IIIFManifest extends StylePluginBase {
             ],
           ];
 
-          if (isset($ocr)) {
+          if (isset($ocr) && $ocr != FALSE) {
             $tmp_canvas['seeAlso'] = [
               '@id' => $ocr->entity->createFileUrl(FALSE),
               'format' => 'text/vnd.hocr+html',

--- a/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
+++ b/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
@@ -198,6 +198,10 @@ class IIIFManifest extends StylePluginBase {
         /** @var \Drupal\Core\Field\FieldItemListInterface $images */
         $images = $entity->{$viewsField->definition['field_name']};
         foreach ($images as $image) {
+          if (!$image->entity->access('view')) {
+            // If the user does not have permission to view the file, skip it.
+            continue;
+          }
           // Create the IIIF URL for this file
           // Visiting $iiif_url will resolve to the info.json for the image.
           $file_url = $image->entity->createFileUrl(FALSE);

--- a/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
+++ b/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
@@ -197,15 +197,15 @@ class IIIFManifest extends StylePluginBase {
 
       if (isset($entity->{$viewsField->definition['field_name']})) {
 
-        /** @var \Drupal\Core\Field\FieldItemListInterface $images */ 
-        $images = $entity->{$viewsField->definition['field_name']}; 
-        foreach ($images as $image) {
+        /** @var \Drupal\Core\Field\FieldItemListInterface $images */
+        $images = $entity->{$viewsField->definition['field_name']};
+        foreach ($images as $i => $image) {
           if (!$image->entity->access('view')) {
             // If the user does not have permission to view the file, skip it.
             continue;
           }
 
-        $ocrs = $entity->{$ocrField->definition['field_name']}; 
+        $ocrs = $entity->{$ocrField->definition['field_name']};
 
           // Create the IIIF URL for this file
           // Visiting $iiif_url will resolve to the info.json for the image.

--- a/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
+++ b/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
@@ -191,13 +191,13 @@ class IIIFManifest extends StylePluginBase {
     $canvases = [];
     foreach (array_filter(array_values($this->options['iiif_tile_field'])) as $iiif_tile_field) {
       $viewsField = $this->view->field[$iiif_tile_field];
-      $iiif_ocr_file_field = array_filter(array_values($this->options['iiif_ocr_file_field']));
+      $iiif_ocr_file_field = !empty($this->options['iiif_ocr_file_field']) ? array_filter(array_values($this->options['iiif_ocr_file_field'])): array();
       $ocrField = count($iiif_ocr_file_field) > 0 ? $this->view->field[$iiif_ocr_file_field[0]] : NULL;
       $entity = $viewsField->getEntity($row);
 
       if (isset($entity->{$viewsField->definition['field_name']})) {
 
-        /** @var \Drupal\Core\Field\FieldItemListInterface $images */
+        /** @var \Drupal\Core\Field\FieldItemListInterface $images */ 
         $images = $entity->{$viewsField->definition['field_name']}; 
         foreach ($images as $image) {
           if (!$image->entity->access('view')) {
@@ -209,7 +209,7 @@ class IIIFManifest extends StylePluginBase {
 
           // Create the IIIF URL for this file
           // Visiting $iiif_url will resolve to the info.json for the image.
-          $ocr = isset($ocrs[$i]) ? $ocrs[$i] : NULL;
+          $ocr = isset($ocrs[$i]) ? $ocrs[$i] : FALSE;
           $file_url = $image->entity->createFileUrl(FALSE);
           $mime_type = $image->entity->getMimeType();
           $iiif_url = rtrim($iiif_address, '/') . '/' . urlencode($file_url);

--- a/modules/islandora_text_extraction/src/Plugin/Action/GenerateOCRDerivativeFile.php
+++ b/modules/islandora_text_extraction/src/Plugin/Action/GenerateOCRDerivativeFile.php
@@ -97,6 +97,7 @@ class GenerateOCRDerivativeFile extends AbstractGenerateDerivativeMediaFile {
       case 'hocr':
         $this->configuration['args'] = '-c tessedit_create_hocr=1 -c hocr_font_info=0';
         break;
+
       case 'plain_text':
         $his->configuration['args'] = '';
         break;

--- a/modules/islandora_text_extraction/src/Plugin/Action/GenerateOCRDerivativeFile.php
+++ b/modules/islandora_text_extraction/src/Plugin/Action/GenerateOCRDerivativeFile.php
@@ -8,7 +8,7 @@ use Drupal\Core\Url;
 use Drupal\islandora\Plugin\Action\AbstractGenerateDerivativeMediaFile;
 
 /**
- * Emits a Node for generating fits derivatives event.
+ * Generates OCR derivatives event.
  *
  * @Action(
  *   id = "generate_extracted_text_file",
@@ -29,6 +29,7 @@ class GenerateOCRDerivativeFile extends AbstractGenerateDerivativeMediaFile {
     $config['destination_media_type'] = 'file';
     $config['scheme'] = $this->config->get('default_scheme');
     $config['destination_text_field_name'] = '';
+    $config['text_format'] = 'plain_text';
     return $config;
   }
 
@@ -38,7 +39,7 @@ class GenerateOCRDerivativeFile extends AbstractGenerateDerivativeMediaFile {
   public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
     $map = $this->entityFieldManager->getFieldMapByFieldType('text_long');
     $file_fields = $map['media'];
-    $field_options = array_combine(array_keys($file_fields), array_keys($file_fields));
+    $field_options = ['none' => $this->t('None')] + array_combine(array_keys($file_fields), array_keys($file_fields));
     $form = parent::buildConfigurationForm($form, $form_state);
     $form['mimetype']['#description'] = $this->t('Mimetype to convert to (e.g. application/xml, etc...)');
     $form['mimetype']['#value'] = 'text/plain';
@@ -48,12 +49,22 @@ class GenerateOCRDerivativeFile extends AbstractGenerateDerivativeMediaFile {
     $last = array_slice($form, count($form) - $position + 1);
 
     $middle['destination_text_field_name'] = [
-      '#required' => TRUE,
+      '#required' => FALSE,
       '#type' => 'select',
       '#options' => $field_options,
       '#title' => $this->t('Destination Text field Name'),
       '#default_value' => $this->configuration['destination_text_field_name'],
       '#description' => $this->t('Text field on Media Type to hold extracted text.'),
+    ];
+    $middle['text_format'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Format'),
+      '#options' => [
+        'plain_text' => $this->t('Plain text'),
+        'hocr' => $this->t('hOCR text with positional data'),
+      ],
+      '#default_value' => $this->configuration['text_format'],
+      '#description' => $this->t("The type of text to be returned."),
     ];
     $form = array_merge($first, $middle, $last);
 
@@ -81,17 +92,28 @@ class GenerateOCRDerivativeFile extends AbstractGenerateDerivativeMediaFile {
   public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
     parent::submitConfigurationForm($form, $form_state);
     $this->configuration['destination_text_field_name'] = $form_state->getValue('destination_text_field_name');
+    $this->configuration['text_format'] = $form_state->getValue('text_format');
+    switch ($form_state->getValue('text_format')) {
+      case 'hocr':
+        $this->configuration['args'] = '-c tessedit_create_hocr=1 -c hocr_font_info=0';
+        break;
+      case 'plain_text':
+        $his->configuration['args'] = '';
+        break;
+    }
   }
 
   /**
    * Override this to return arbitrary data as an array to be json encoded.
    */
   protected function generateData(EntityInterface $entity) {
+
     $data = parent::generateData($entity);
     $route_params = [
       'media' => $entity->id(),
       'destination_field' => $this->configuration['destination_field_name'],
       'destination_text_field' => $this->configuration['destination_text_field_name'],
+      'text_format' => $this->configuration['text_format'],
     ];
     $data['destination_uri'] = Url::fromRoute('islandora_text_extraction.attach_file_to_media', $route_params)
       ->setAbsolute()

--- a/modules/islandora_video/config/schema/islandora_video.schema.yml
+++ b/modules/islandora_video/config/schema/islandora_video.schema.yml
@@ -29,3 +29,6 @@ action.configuration.generate_video_derivative:
     path:
       type: text
       label: 'File path with extension'
+
+field.formatter.settings.islandora_file_video:
+  type: field.formatter.settings.file_video

--- a/src/Controller/ManageMediaController.php
+++ b/src/Controller/ManageMediaController.php
@@ -36,8 +36,11 @@ class ManageMediaController extends ManageMembersController {
 
     return [
       '#type' => 'markup',
-      '#markup' => $this->t("These available media types below have <em>@field</em> and it is configured to allow this content type.",
-        ['@field' => $field]),
+      '#markup' => $this->t("The following media types can be added because they have the <code>@field</code> field. <a href=@manage_media_page>Manage media types</a>.",
+        [
+          '@field' => $field,
+          '@manage_media_page' => '/admin/structure/media',
+        ]),
       'add_media' => $add_media_list,
     ];
   }

--- a/src/Controller/ManageMediaController.php
+++ b/src/Controller/ManageMediaController.php
@@ -25,7 +25,7 @@ class ManageMediaController extends ManageMembersController {
   public function addToNodePage(NodeInterface $node) {
     $field = IslandoraUtils::MEDIA_OF_FIELD;
 
-    return $this->generateTypeList(
+    $add_media_list = $this->generateTypeList(
       'media',
       'media_type',
       'entity.media.add_form',
@@ -33,6 +33,13 @@ class ManageMediaController extends ManageMembersController {
       $field,
       ['query' => ["edit[$field][widget][0][target_id]" => $node->id()]]
     );
+
+    return [
+      '#type' => 'markup',
+      '#markup' => $this->t("These available media types below have <em>@field</em> and it is configured to allow this content type.",
+        ['@field' => $field]),
+      'add_media' => $add_media_list,
+    ];
   }
 
   /**

--- a/src/Controller/ManageMediaController.php
+++ b/src/Controller/ManageMediaController.php
@@ -6,6 +6,7 @@ use Drupal\islandora\IslandoraUtils;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Routing\RouteMatch;
 use Drupal\node\Entity\Node;
+use Drupal\Core\Url;
 use Drupal\node\NodeInterface;
 
 /**
@@ -34,13 +35,18 @@ class ManageMediaController extends ManageMembersController {
       ['query' => ["edit[$field][widget][0][target_id]" => $node->id()]]
     );
 
+    $manage_link = Url::fromRoute('entity.media_type.collection')->toRenderArray();
+    $manage_link['#title'] = $this->t('Manage media types');
+    $manage_link['#type'] = 'link';
+    $manage_link['#prefix'] = ' ';
+    $manage_link['#suffix'] = '.';
+
     return [
       '#type' => 'markup',
-      '#markup' => $this->t("The following media types can be added because they have the <code>@field</code> field. <a href=@manage_media_page>Manage media types</a>.",
-        [
-          '@field' => $field,
-          '@manage_media_page' => '/admin/structure/media',
-        ]),
+      '#markup' => $this->t("The following media types can be added because they have the <code>@field</code> field.", [
+        '@field' => $field,
+      ]),
+      'manage_link' => $manage_link,
       'add_media' => $add_media_list,
     ];
   }

--- a/src/Controller/ManageMembersController.php
+++ b/src/Controller/ManageMembersController.php
@@ -88,7 +88,8 @@ class ManageMembersController extends EntityController {
    */
   public function addToNodePage(NodeInterface $node) {
     $field = IslandoraUtils::MEMBER_OF_FIELD;
-    return $this->generateTypeList(
+
+    $add_node_list = $this->generateTypeList(
       'node',
       'node_type',
       'node.add',
@@ -96,6 +97,13 @@ class ManageMembersController extends EntityController {
       $field,
       ['query' => ["edit[$field][widget][0][target_id]" => $node->id()]]
     );
+
+    return [
+      '#type' => 'markup',
+      '#markup' => $this->t("These available content types below have <em>@field</em> and it is configured to allow this content type.",
+        ['@field' => $field]),
+      'add_node' => $add_node_list,
+    ];
   }
 
   /**

--- a/src/Controller/ManageMembersController.php
+++ b/src/Controller/ManageMembersController.php
@@ -7,6 +7,7 @@ use Drupal\Core\Render\RendererInterface;
 use Drupal\Core\Entity\Controller\EntityController;
 use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\Core\Link;
+use Drupal\Core\Url;
 use Drupal\islandora\IslandoraUtils;
 use Drupal\node\NodeInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -98,13 +99,18 @@ class ManageMembersController extends EntityController {
       ['query' => ["edit[$field][widget][0][target_id]" => $node->id()]]
     );
 
+    $manage_link = Url::fromRoute('entity.node_type.collection')->toRenderArray();
+    $manage_link['#title'] = $this->t('Manage content types');
+    $manage_link['#type'] = 'link';
+    $manage_link['#prefix'] = ' ';
+    $manage_link['#suffix'] = '.';
+
     return [
       '#type' => 'markup',
-      '#markup' => $this->t("The following content types can be added because they have the <code>@field</code> field. <a href=@manage_content_types>Manage content types</a>.",
-        [
-          '@field' => $field,
-          '@manage_content_types' => '/admin/structure/types',
-        ]),
+      '#markup' => $this->t("The following content types can be added because they have the <code>@field</code> field.", [
+        '@field' => $field,
+      ]),
+      'manage_link' => $manage_link,
       'add_node' => $add_node_list,
     ];
   }

--- a/src/Controller/ManageMembersController.php
+++ b/src/Controller/ManageMembersController.php
@@ -100,8 +100,11 @@ class ManageMembersController extends EntityController {
 
     return [
       '#type' => 'markup',
-      '#markup' => $this->t("These available content types below have <em>@field</em> and it is configured to allow this content type.",
-        ['@field' => $field]),
+      '#markup' => $this->t("The following content types can be added because they have the <code>@field</code> field. <a href=@manage_content_types>Manage content types</a>.",
+        [
+          '@field' => $field,
+          '@manage_content_types' => '/admin/structure/types',
+        ]),
       'add_node' => $add_node_list,
     ];
   }

--- a/src/Form/AddChildrenForm.php
+++ b/src/Form/AddChildrenForm.php
@@ -229,7 +229,7 @@ class AddChildrenForm extends AddMediaForm {
    * @param \Drupal\Core\Routing\RouteMatch $route_match
    *   The current routing match.
    *
-   * @return \Drupal\Core\Access\AccessResultAllowed|\Drupal\Core\Access\AccessResultForbidden
+   * @return \Drupal\Core\Access\AccessResultInterface
    *   Whether we can or can't show the "thing".
    */
   public function access(RouteMatch $route_match) {

--- a/src/Form/AddChildrenWizard/AbstractBatchProcessor.php
+++ b/src/Form/AddChildrenWizard/AbstractBatchProcessor.php
@@ -1,0 +1,258 @@
+<?php
+
+namespace Drupal\islandora\Form\AddChildrenWizard;
+
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Datetime\DateFormatterInterface;
+use Drupal\Core\DependencyInjection\DependencySerializationTrait;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\Url;
+use Drupal\file\FileInterface;
+use Drupal\islandora\IslandoraUtils;
+use Drupal\media\MediaInterface;
+use Drupal\node\NodeInterface;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
+
+/**
+ * Abstract addition batch processor.
+ */
+abstract class AbstractBatchProcessor {
+
+  use FieldTrait;
+  use DependencySerializationTrait;
+  use StringTranslationTrait;
+
+  /**
+   * The entity type manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface|null
+   */
+  protected ?EntityTypeManagerInterface $entityTypeManager = NULL;
+
+  /**
+   * The database connection serivce.
+   *
+   * @var \Drupal\Core\Database\Connection|null
+   */
+  protected ?Connection $database;
+
+  /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountProxyInterface|null
+   */
+  protected ?AccountProxyInterface $currentUser;
+
+  /**
+   * The messenger service.
+   *
+   * @var \Drupal\Core\Messenger\MessengerInterface
+   */
+  protected MessengerInterface $messenger;
+
+  /**
+   * The date formatter service.
+   *
+   * @var \Drupal\Core\Datetime\DateFormatterInterface
+   */
+  protected DateFormatterInterface $dateFormatter;
+
+  /**
+   * Constructor.
+   */
+  public function __construct(
+    EntityTypeManagerInterface $entity_type_manager,
+    Connection $database,
+    AccountProxyInterface $current_user,
+    MessengerInterface $messenger,
+    DateFormatterInterface $date_formatter
+  ) {
+    $this->entityTypeManager = $entity_type_manager;
+    $this->database = $database;
+    $this->currentUser = $current_user;
+    $this->messenger = $messenger;
+    $this->dateFormatter = $date_formatter;
+  }
+
+  /**
+   * Implements callback_batch_operation() for our child addition batch.
+   */
+  public function batchOperation($delta, $info, array $values, &$context) {
+    $transaction = $this->database->startTransaction();
+
+    try {
+      $entities[] = $node = $this->getNode($info, $values);
+      $entities[] = $this->createMedia($node, $info, $values);
+
+      $context['results'] = array_merge_recursive($context['results'], [
+        'validation_violations' => $this->validationClassification($entities),
+      ]);
+      $context['results']['count'] = ($context['results']['count'] ?? 0) + 1;
+    }
+    catch (HttpExceptionInterface $e) {
+      $transaction->rollBack();
+      throw $e;
+    }
+    catch (\Exception $e) {
+      $transaction->rollBack();
+      throw new HttpException(500, $e->getMessage(), $e);
+    }
+  }
+
+  /**
+   * Loads the file indicated.
+   *
+   * @param mixed $info
+   *   Widget values.
+   *
+   * @return \Drupal\file\FileInterface|null
+   *   The loaded file.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  protected function getFile($info) : ?FileInterface {
+    return (is_array($info) && isset($info['target_id'])) ?
+      $this->entityTypeManager->getStorage('file')->load($info['target_id']) :
+      NULL;
+  }
+
+  /**
+   * Get the node to which to attach our media.
+   *
+   * @param mixed $info
+   *   Info from the widget used to create the request.
+   * @param array $values
+   *   Additional form inputs.
+   *
+   * @return \Drupal\node\NodeInterface
+   *   The node to which to attach the created media.
+   */
+  abstract protected function getNode($info, array $values) : NodeInterface;
+
+  /**
+   * Get a name to use for bulk-created assets.
+   *
+   * @param mixed $info
+   *   Widget values.
+   * @param array $values
+   *   Form values.
+   *
+   * @return string
+   *   An applicable name.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  protected function getName($info, array $values) : string {
+    $file = $this->getFile($info);
+    return $file ? $file->getFilename() : strtr('Bulk ingest, {date}', [
+      '{date}' => $this->dateFormatter->format(time(), 'long'),
+    ]);
+  }
+
+  /**
+   * Create a media referencing the given file, associated with the given node.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The node to which the media should be associated.
+   * @param mixed $info
+   *   The widget info for the media source field.
+   * @param array $values
+   *   Values from the wizard, which should contain at least:
+   *   - media_type: The machine name/ID of the media type as which to create
+   *     the media
+   *   - use: An array of the selected "media use" terms.
+   *
+   * @return \Drupal\media\MediaInterface
+   *   The created media entity.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  protected function createMedia(NodeInterface $node, $info, array $values) : MediaInterface {
+    $taxonomy_term_storage = $this->entityTypeManager->getStorage('taxonomy_term');
+
+    // Create a media with the file attached and also pointing at the node.
+    $field = $this->getField($values);
+
+    $media_values = array_merge(
+      [
+        'bundle' => $values['media_type'],
+        'name' => $this->getName($info, $values),
+        IslandoraUtils::MEDIA_OF_FIELD => $node,
+        IslandoraUtils::MEDIA_USAGE_FIELD => ($values['use'] ?
+          $taxonomy_term_storage->loadMultiple($values['use']) :
+          NULL),
+        'uid' => $this->currentUser->id(),
+        // XXX: Published... no constant?
+        'status' => 1,
+      ],
+      [
+        $field->getName() => [
+          $info,
+        ],
+      ]
+    );
+    $media = $this->entityTypeManager->getStorage('media')->create($media_values);
+    if ($media->save() !== SAVED_NEW) {
+      throw new \Exception("Failed to create media.");
+    }
+
+    return $media;
+  }
+
+  /**
+   * Helper to bulk process validatable entities.
+   *
+   * @param array $entities
+   *   An array of entities to scan for validation violations.
+   *
+   * @return array
+   *   An associative array mapping entity type IDs to entity IDs to a count
+   *   of validation violations found on then given entity.
+   */
+  protected function validationClassification(array $entities) {
+    $violations = [];
+
+    foreach ($entities as $entity) {
+      $entity_violations = $entity->validate();
+      if ($entity_violations->count() > 0) {
+        $violations[$entity->getEntityTypeId()][$entity->id()] = $entity_violations->count();
+      }
+    }
+
+    return $violations;
+  }
+
+  /**
+   * Implements callback_batch_finished() for our child addition batch.
+   */
+  public function batchProcessFinished($success, $results, $operations): void {
+    if ($success) {
+      foreach ($results['validation_violations'] ?? [] as $entity_type => $info) {
+        foreach ($info as $id => $count) {
+          $this->messenger->addWarning($this->formatPlural(
+            $count,
+            '1 validation error present in <a target="_blank" href=":uri">bulk created entity of type %type, with ID %id</a>.',
+            '@count validation errors present in <a target="_blank" href=":uri">bulk created entity of type %type, with ID %id</a>.',
+            [
+              '%type' => $entity_type,
+              ':uri' => Url::fromRoute("entity.{$entity_type}.canonical", [$entity_type => $id])->toString(),
+              '%id' => $id,
+            ]
+          ));
+        }
+      }
+    }
+    else {
+      $this->messenger->addError($this->t('Encountered an error when processing.'));
+    }
+  }
+
+}

--- a/src/Form/AddChildrenWizard/AbstractFileSelectionForm.php
+++ b/src/Form/AddChildrenWizard/AbstractFileSelectionForm.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace Drupal\islandora\Form\AddChildrenWizard;
+
+use Drupal\Core\Batch\BatchBuilder;
+use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Core\Field\FieldItemList;
+use Drupal\Core\Field\FieldStorageDefinitionInterface;
+use Drupal\Core\Field\WidgetInterface;
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\field\FieldStorageConfigInterface;
+use Drupal\media\MediaTypeInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Children addition wizard's second step.
+ */
+abstract class AbstractFileSelectionForm extends FormBase {
+
+  use WizardTrait;
+
+  const BATCH_PROCESSOR = 'abstract.abstract';
+
+  /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountProxyInterface|null
+   */
+  protected ?AccountProxyInterface $currentUser;
+
+  /**
+   * The batch processor service.
+   *
+   * @var \Drupal\islandora\Form\AddChildrenWizard\AbstractBatchProcessor|null
+   */
+  protected ?AbstractBatchProcessor $batchProcessor;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): self {
+    $instance = parent::create($container);
+
+    $instance->entityTypeManager = $container->get('entity_type.manager');
+    $instance->widgetPluginManager = $container->get('plugin.manager.field.widget');
+    $instance->entityFieldManager = $container->get('entity_field.manager');
+    $instance->currentUser = $container->get('current_user');
+
+    $instance->batchProcessor = $container->get(static::BATCH_PROCESSOR);
+
+    return $instance;
+  }
+
+  /**
+   * Helper; get the media type, based off discovering from form state.
+   *
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
+   *
+   * @return \Drupal\media\MediaTypeInterface
+   *   The target media type.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  protected function getMediaTypeFromFormState(FormStateInterface $form_state): MediaTypeInterface {
+    return $this->getMediaType($form_state->getTemporaryValue('wizard'));
+  }
+
+  /**
+   * Helper; get field instance, based off discovering from form state.
+   *
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
+   *
+   * @return \Drupal\Core\Field\FieldDefinitionInterface
+   *   The field definition.
+   */
+  protected function getFieldFromFormState(FormStateInterface $form_state): FieldDefinitionInterface {
+    $cached_values = $form_state->getTemporaryValue('wizard');
+
+    $field = $this->getField($cached_values);
+    $def = $field->getFieldStorageDefinition();
+    if ($def instanceof FieldStorageConfigInterface) {
+      $def->set('cardinality', FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED);
+    }
+    elseif ($def instanceof BaseFieldDefinition) {
+      $def->setCardinality(FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED);
+    }
+    else {
+      throw new \Exception('Unable to remove cardinality limit.');
+    }
+
+    return $field;
+  }
+
+  /**
+   * Helper; get widget for the field, based on discovering from form state.
+   *
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
+   *
+   * @return \Drupal\Core\Field\WidgetInterface
+   *   The widget.
+   */
+  protected function getWidgetFromFormState(FormStateInterface $form_state): WidgetInterface {
+    return $this->getWidget($this->getFieldFromFormState($form_state));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state): array {
+    // Using the media type selected in the previous step, grab the
+    // media bundle's "source" field, and create a multi-file upload widget
+    // for it, with the same kind of constraints.
+    $field = $this->getFieldFromFormState($form_state);
+    $items = FieldItemList::createInstance($field, $field->getName(), $this->getMediaTypeFromFormState($form_state)->getTypedData());
+
+    $form['#tree'] = TRUE;
+    $form['#parents'] = [];
+    $widget = $this->getWidgetFromFormState($form_state);
+    $form['files'] = $widget->form(
+      $items,
+      $form,
+      $form_state
+    );
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $cached_values = $form_state->getTemporaryValue('wizard');
+
+    $widget = $this->getWidgetFromFormState($form_state);
+    $builder = (new BatchBuilder())
+      ->setTitle($this->t('Bulk creating...'))
+      ->setInitMessage($this->t('Initializing...'))
+      ->setFinishCallback([$this->batchProcessor, 'batchProcessFinished']);
+    $values = $form_state->getValue($this->getField($cached_values)->getName());
+    $massaged_values = $widget->massageFormValues($values, $form, $form_state);
+    foreach ($massaged_values as $delta => $info) {
+      $builder->addOperation(
+        [$this->batchProcessor, 'batchOperation'],
+        [$delta, $info, $cached_values]
+      );
+    }
+    batch_set($builder->toArray());
+  }
+
+}

--- a/src/Form/AddChildrenWizard/AbstractForm.php
+++ b/src/Form/AddChildrenWizard/AbstractForm.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Drupal\islandora\Form\AddChildrenWizard;
+
+use Drupal\Core\DependencyInjection\ClassResolverInterface;
+use Drupal\Core\Form\FormBuilderInterface;
+use Drupal\Core\Render\RendererInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\Core\TempStore\SharedTempStoreFactory;
+use Drupal\ctools\Wizard\FormWizardBase;
+use Drupal\islandora\IslandoraUtils;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * Bulk children addition wizard base form.
+ */
+abstract class AbstractForm extends FormWizardBase {
+
+  const TEMPSTORE_ID = 'abstract.abstract';
+  const TYPE_SELECTION_FORM = MediaTypeSelectionForm::class;
+  const FILE_SELECTION_FORM = AbstractFileSelectionForm::class;
+
+  /**
+   * The Islandora Utils service.
+   *
+   * @var \Drupal\islandora\IslandoraUtils
+   */
+  protected IslandoraUtils $utils;
+
+  /**
+   * The current node ID.
+   *
+   * @var mixed|null
+   */
+  protected $nodeId;
+
+  /**
+   * The current route match.
+   *
+   * @var \Drupal\Core\Routing\RouteMatchInterface
+   */
+  protected RouteMatchInterface $currentRoute;
+
+  /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountProxyInterface
+   */
+  protected AccountProxyInterface $currentUser;
+
+  /**
+   * Constructor.
+   */
+  public function __construct(
+    SharedTempStoreFactory $tempstore,
+    FormBuilderInterface $builder,
+    ClassResolverInterface $class_resolver,
+    EventDispatcherInterface $event_dispatcher,
+    RouteMatchInterface $route_match,
+    RendererInterface $renderer,
+    $tempstore_id,
+    AccountProxyInterface $current_user,
+    $machine_name = NULL,
+    $step = NULL
+  ) {
+    parent::__construct($tempstore, $builder, $class_resolver, $event_dispatcher, $route_match, $renderer, $tempstore_id,
+      $machine_name, $step);
+
+    $this->nodeId = $this->routeMatch->getParameter('node');
+    $this->currentUser = $current_user;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getParameters() : array {
+    return array_merge(
+      parent::getParameters(),
+      [
+        'tempstore_id' => static::TEMPSTORE_ID,
+        'current_user' => \Drupal::service('current_user'),
+      ]
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getOperations($cached_values) {
+    $ops = [];
+
+    $ops['type_selection'] = [
+      'title' => $this->t('Type Selection'),
+      'form' => static::TYPE_SELECTION_FORM,
+      'values' => [
+        'node' => $this->nodeId,
+      ],
+    ];
+    $ops['file_selection'] = [
+      'title' => $this->t('Widget Input for Selected Type'),
+      'form' => static::FILE_SELECTION_FORM,
+      'values' => [
+        'node' => $this->nodeId,
+      ],
+    ];
+
+    return $ops;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getNextParameters($cached_values) {
+    return parent::getNextParameters($cached_values) + ['node' => $this->nodeId];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPreviousParameters($cached_values) {
+    return parent::getPreviousParameters($cached_values) + ['node' => $this->nodeId];
+  }
+
+}

--- a/src/Form/AddChildrenWizard/Access.php
+++ b/src/Form/AddChildrenWizard/Access.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Drupal\islandora\Form\AddChildrenWizard;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Access\AccessResultInterface;
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Routing\RouteMatch;
+use Drupal\islandora\IslandoraUtils;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Access checker.
+ *
+ * The _wizard/_form route enhancers do not really allow for access checking
+ * things, so let's roll it separately for now.
+ */
+class Access implements ContainerInjectionInterface {
+
+  /**
+   * The Islandora utils service.
+   *
+   * @var \Drupal\islandora\IslandoraUtils
+   */
+  protected IslandoraUtils $utils;
+
+  /**
+   * Constructor.
+   */
+  public function __construct(IslandoraUtils $utils) {
+    $this->utils = $utils;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) : self {
+    return new static(
+      $container->get('islandora.utils')
+    );
+  }
+
+  /**
+   * Check if the user can create any "Islandora" nodes and media.
+   *
+   * @param \Drupal\Core\Routing\RouteMatch $route_match
+   *   The current routing match.
+   *
+   * @return \Drupal\Core\Access\AccessResultInterface
+   *   Whether we can or cannot show the "thing".
+   */
+  public function childAccess(RouteMatch $route_match) : AccessResultInterface {
+    return AccessResult::allowedIf($this->utils->canCreateIslandoraEntity('node', 'node_type'))
+      ->andIf($this->mediaAccess($route_match));
+
+  }
+
+  /**
+   * Check if the user can create any "Islandora" media.
+   *
+   * @param \Drupal\Core\Routing\RouteMatch $route_match
+   *   The current routing match.
+   *
+   * @return \Drupal\Core\Access\AccessResultInterface
+   *   Whether we can or cannot show the "thing".
+   */
+  public function mediaAccess(RouteMatch $route_match) : AccessResultInterface {
+    return AccessResult::allowedIf($this->utils->canCreateIslandoraEntity('media', 'media_type'));
+  }
+
+}

--- a/src/Form/AddChildrenWizard/ChildBatchProcessor.php
+++ b/src/Form/AddChildrenWizard/ChildBatchProcessor.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Drupal\islandora\Form\AddChildrenWizard;
+
+use Drupal\islandora\IslandoraUtils;
+use Drupal\node\NodeInterface;
+
+/**
+ * Children addition batch processor.
+ */
+class ChildBatchProcessor extends AbstractBatchProcessor {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getNode($info, array $values) : NodeInterface {
+    $taxonomy_term_storage = $this->entityTypeManager->getStorage('taxonomy_term');
+    $node_storage = $this->entityTypeManager->getStorage('node');
+    $parent = $node_storage->load($values['node']);
+
+    // Create a node (with the filename?) (and also belonging to the target
+    // node).
+    /** @var \Drupal\node\NodeInterface $node */
+    $node = $node_storage->create([
+      'type' => $values['bundle'],
+      'title' => $this->getName($info, $values),
+      IslandoraUtils::MEMBER_OF_FIELD => $parent,
+      'uid' => $this->currentUser->id(),
+      'status' => NodeInterface::PUBLISHED,
+      IslandoraUtils::MODEL_FIELD => ($values['model'] ?
+        $taxonomy_term_storage->load($values['model']) :
+        NULL),
+    ]);
+
+    if ($node->save() !== SAVED_NEW) {
+      throw new \Exception("Failed to create node.");
+    }
+
+    return $node;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function batchProcessFinished($success, $results, $operations): void {
+    if ($success) {
+      $this->messenger->addMessage($this->formatPlural(
+        $results['count'],
+        'Added 1 child node.',
+        'Added @count child nodes.'
+      ));
+    }
+
+    parent::batchProcessFinished($success, $results, $operations);
+  }
+
+}

--- a/src/Form/AddChildrenWizard/ChildFileSelectionForm.php
+++ b/src/Form/AddChildrenWizard/ChildFileSelectionForm.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Drupal\islandora\Form\AddChildrenWizard;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+
+/**
+ * Children addition wizard's second step.
+ */
+class ChildFileSelectionForm extends AbstractFileSelectionForm {
+
+  public const BATCH_PROCESSOR = 'islandora.upload_children.batch_processor';
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'islandora_add_children_wizard_file_selection';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    parent::submitForm($form, $form_state);
+
+    $cached_values = $form_state->getTemporaryValue('wizard');
+    $form_state->setRedirectUrl(Url::fromUri("internal:/node/{$cached_values['node']}/members"));
+  }
+
+}

--- a/src/Form/AddChildrenWizard/ChildForm.php
+++ b/src/Form/AddChildrenWizard/ChildForm.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Drupal\islandora\Form\AddChildrenWizard;
+
+/**
+ * Bulk children addition wizard base form.
+ */
+class ChildForm extends AbstractForm {
+
+  const TEMPSTORE_ID = 'islandora.upload_children';
+  const TYPE_SELECTION_FORM = ChildTypeSelectionForm::class;
+  const FILE_SELECTION_FORM = ChildFileSelectionForm::class;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getMachineName() {
+    return strtr("islandora_add_children_wizard__{userid}__{nodeid}", [
+      '{userid}' => $this->currentUser->id(),
+      '{nodeid}' => $this->nodeId,
+    ]);
+  }
+
+}

--- a/src/Form/AddChildrenWizard/ChildTypeSelectionForm.php
+++ b/src/Form/AddChildrenWizard/ChildTypeSelectionForm.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace Drupal\islandora\Form\AddChildrenWizard;
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\islandora\IslandoraUtils;
+
+/**
+ * Children addition wizard's first step.
+ */
+class ChildTypeSelectionForm extends MediaTypeSelectionForm {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() : string {
+    return 'islandora_add_children_type_selection';
+  }
+
+  /**
+   * Memoization for ::getNodeBundleOptions().
+   *
+   * @var array|null
+   */
+  protected ?array $nodeBundleOptions = NULL;
+
+  /**
+   * Indicate presence of model field on node bundles.
+   *
+   * Populated as a side effect of ::getNodeBundleOptions().
+   *
+   * @var array|null
+   */
+  protected ?array $nodeBundleHasModelField = NULL;
+
+  /**
+   * Helper; get the node bundle options available to the current user.
+   *
+   * @return array
+   *   An associative array mapping node bundle machine names to their human-
+   *   readable labels.
+   */
+  protected function getNodeBundleOptions() : array {
+    if ($this->nodeBundleOptions === NULL) {
+      $this->nodeBundleOptions = [];
+      $this->nodeBundleHasModelField = [];
+
+      $access_handler = $this->entityTypeManager->getAccessControlHandler('node');
+      foreach ($this->entityTypeBundleInfo->getBundleInfo('node') as $bundle => $info) {
+        $access = $access_handler->createAccess(
+          $bundle,
+          NULL,
+          [],
+          TRUE
+        );
+        $this->cacheableMetadata->addCacheableDependency($access);
+        if (!$access->isAllowed()) {
+          continue;
+        }
+        $this->nodeBundleOptions[$bundle] = $info['label'];
+        $fields = $this->entityFieldManager->getFieldDefinitions('node', $bundle);
+        $this->nodeBundleHasModelField[$bundle] = array_key_exists(IslandoraUtils::MODEL_FIELD, $fields);
+      }
+    }
+
+    return $this->nodeBundleOptions;
+  }
+
+  /**
+   * Generates a mapping of taxonomy term IDs to their names.
+   *
+   * @return \Generator
+   *   The mapping of taxonomy term IDs to their names.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  protected function getModelOptions() : \Generator {
+    $terms = $this->entityTypeManager->getStorage('taxonomy_term')
+      ->loadTree('islandora_models', 0, NULL, TRUE);
+    foreach ($terms as $term) {
+      yield $term->id() => $term->getName();
+    }
+  }
+
+  /**
+   * Helper; map node bundles supporting the "has model" field, for #states.
+   *
+   * @return \Generator
+   *   Yields associative array mapping the string 'value' to the bundles which
+   *   have the given field.
+   */
+  protected function mapModelStates() : \Generator {
+    $this->getNodeBundleOptions();
+    foreach (array_keys(array_filter($this->nodeBundleHasModelField)) as $bundle) {
+      yield ['value' => $bundle];
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $this->cacheableMetadata = CacheableMetadata::createFromRenderArray($form)
+      ->addCacheContexts([
+        'url',
+        'url.query_args',
+      ]);
+    $cached_values = $form_state->getTemporaryValue('wizard');
+
+    $form['bundle'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Content Type'),
+      '#description' => $this->t('Each child created will have this content type.'),
+      '#empty_value' => '',
+      '#default_value' => $cached_values['bundle'] ?? '',
+      '#options' => $this->getNodeBundleOptions(),
+      '#required' => TRUE,
+    ];
+
+    $model_states = iterator_to_array($this->mapModelStates());
+    $form['model'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Model'),
+      '#description' => $this->t('Each child will be tagged with this model.'),
+      '#options' => iterator_to_array($this->getModelOptions()),
+      '#empty_value' => '',
+      '#default_value' => $cached_values['model'] ?? '',
+      '#states' => [
+        'visible' => [
+          ':input[name="bundle"]' => $model_states,
+        ],
+        'required' => [
+          ':input[name="bundle"]' => $model_states,
+        ],
+      ],
+    ];
+
+    $this->cacheableMetadata->applyTo($form);
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static function keysToSave() : array {
+    return array_merge(
+      parent::keysToSave(),
+      [
+        'bundle',
+        'model',
+      ]
+    );
+  }
+
+}

--- a/src/Form/AddChildrenWizard/FieldTrait.php
+++ b/src/Form/AddChildrenWizard/FieldTrait.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Drupal\islandora\Form\AddChildrenWizard;
+
+use Drupal\Core\Entity\EntityFieldManagerInterface;
+use Drupal\Core\Field\FieldDefinitionInterface;
+
+/**
+ * Field lookup helper trait.
+ */
+trait FieldTrait {
+
+  use MediaTypeTrait;
+
+  /**
+   * The entity field manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityFieldManagerInterface|null
+   */
+  protected ?EntityFieldManagerInterface $entityFieldManager = NULL;
+
+  /**
+   * Helper; get field instance, given our required values.
+   *
+   * @param array $values
+   *   See ::getMediaType() for which values are required.
+   *
+   * @return \Drupal\Core\Field\FieldDefinitionInterface
+   *   The target field.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  protected function getField(array $values): FieldDefinitionInterface {
+    $media_type = $this->getMediaType($values);
+    $media_source = $media_type->getSource();
+    $source_field = $media_source->getSourceFieldDefinition($media_type);
+
+    $fields = $this->entityFieldManager()->getFieldDefinitions('media', $media_type->id());
+
+    return $fields[$source_field->getFieldStorageDefinition()->getName()] ??
+      $media_source->createSourceField($media_type);
+  }
+
+  /**
+   * Lazy-initialization of the entity field manager service.
+   *
+   * @return \Drupal\Core\Entity\EntityFieldManagerInterface
+   *   The entity field manager service.
+   */
+  protected function entityFieldManager() : EntityFieldManagerInterface {
+    if ($this->entityFieldManager === NULL) {
+      $this->setEntityFieldManager(\Drupal::service('entity_field.manager'));
+    }
+    return $this->entityFieldManager;
+  }
+
+  /**
+   * Setter for entity field manager.
+   */
+  public function setEntityFieldManager(EntityFieldManagerInterface $entity_field_manager) : self {
+    $this->entityFieldManager = $entity_field_manager;
+    return $this;
+  }
+
+}

--- a/src/Form/AddChildrenWizard/MediaBatchProcessor.php
+++ b/src/Form/AddChildrenWizard/MediaBatchProcessor.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Drupal\islandora\Form\AddChildrenWizard;
+
+use Drupal\node\NodeInterface;
+
+/**
+ * Media addition batch processor.
+ */
+class MediaBatchProcessor extends AbstractBatchProcessor {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getNode($info, array $values) : NodeInterface {
+    return $this->entityTypeManager->getStorage('node')->load($values['node']);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function batchProcessFinished($success, $results, $operations): void {
+    if ($success) {
+      $this->messenger->addMessage($this->formatPlural(
+        $results['count'],
+        'Added 1 media.',
+        'Added @count media.'
+      ));
+    }
+
+    parent::batchProcessFinished($success, $results, $operations);
+  }
+
+}

--- a/src/Form/AddChildrenWizard/MediaFileSelectionForm.php
+++ b/src/Form/AddChildrenWizard/MediaFileSelectionForm.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Drupal\islandora\Form\AddChildrenWizard;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+
+/**
+ * Media addition wizard's second step.
+ */
+class MediaFileSelectionForm extends AbstractFileSelectionForm {
+
+  public const BATCH_PROCESSOR = 'islandora.upload_media.batch_processor';
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'islandora_add_media_wizard_file_selection';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    parent::submitForm($form, $form_state);
+
+    $cached_values = $form_state->getTemporaryValue('wizard');
+    $form_state->setRedirectUrl(Url::fromUri("internal:/node/{$cached_values['node']}/media"));
+  }
+
+}

--- a/src/Form/AddChildrenWizard/MediaForm.php
+++ b/src/Form/AddChildrenWizard/MediaForm.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Drupal\islandora\Form\AddChildrenWizard;
+
+/**
+ * Bulk children addition wizard base form.
+ */
+class MediaForm extends AbstractForm {
+
+  const TEMPSTORE_ID = 'islandora.upload_media';
+  const TYPE_SELECTION_FORM = MediaTypeSelectionForm::class;
+  const FILE_SELECTION_FORM = MediaFileSelectionForm::class;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getMachineName() {
+    return strtr("islandora_add_media_wizard__{userid}__{nodeid}", [
+      '{userid}' => $this->currentUser->id(),
+      '{nodeid}' => $this->nodeId,
+    ]);
+  }
+
+}

--- a/src/Form/AddChildrenWizard/MediaTypeSelectionForm.php
+++ b/src/Form/AddChildrenWizard/MediaTypeSelectionForm.php
@@ -1,0 +1,227 @@
+<?php
+
+namespace Drupal\islandora\Form\AddChildrenWizard;
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Entity\EntityFieldManagerInterface;
+use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\islandora\IslandoraUtils;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Children addition wizard's first step.
+ */
+class MediaTypeSelectionForm extends FormBase {
+
+  /**
+   * Cacheable metadata that is instantiated and used internally.
+   *
+   * @var \Drupal\Core\Cache\CacheableMetadata|null
+   */
+  protected ?CacheableMetadata $cacheableMetadata = NULL;
+
+  /**
+   * The entity type bundle info service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeBundleInfoInterface|null
+   */
+  protected ?EntityTypeBundleInfoInterface $entityTypeBundleInfo;
+
+  /**
+   * The entity type manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface|null
+   */
+  protected ?EntityTypeManagerInterface $entityTypeManager;
+
+  /**
+   * The entity field manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityFieldManagerInterface|null
+   */
+  protected ?EntityFieldManagerInterface $entityFieldManager;
+
+  /**
+   * The Islandora Utils service.
+   *
+   * @var \Drupal\islandora\IslandoraUtils|null
+   */
+  protected ?IslandoraUtils $utils;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) : self {
+    $instance = parent::create($container);
+
+    $instance->entityTypeBundleInfo = $container->get('entity_type.bundle.info');
+    $instance->entityTypeManager = $container->get('entity_type.manager');
+    $instance->entityFieldManager = $container->get('entity_field.manager');
+    $instance->utils = $container->get('islandora.utils');
+
+    return $instance;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() : string {
+    return 'islandora_add_media_type_selection';
+  }
+
+  /**
+   * Memoization for ::getMediaBundleOptions().
+   *
+   * @var array|null
+   */
+  protected ?array $mediaBundleOptions = NULL;
+
+  /**
+   * Indicate presence of usage field on media bundles.
+   *
+   * Populated as a side effect in ::getMediaBundleOptions().
+   *
+   * @var array|null
+   */
+  protected ?array $mediaBundleUsageField = NULL;
+
+  /**
+   * Helper; get options for media types.
+   *
+   * @return array
+   *   An associative array mapping the machine name of the media type to its
+   *   human-readable label.
+   */
+  protected function getMediaBundleOptions() : array {
+    if ($this->mediaBundleOptions === NULL) {
+      $this->mediaBundleOptions = [];
+      $this->mediaBundleUsageField = [];
+
+      $access_handler = $this->entityTypeManager->getAccessControlHandler('media');
+      foreach ($this->entityTypeBundleInfo->getBundleInfo('media') as $bundle => $info) {
+        if (!$this->utils->isIslandoraType('media', $bundle)) {
+          continue;
+        }
+        $access = $access_handler->createAccess(
+          $bundle,
+          NULL,
+          [],
+          TRUE
+        );
+        $this->cacheableMetadata->addCacheableDependency($access);
+        if (!$access->isAllowed()) {
+          continue;
+        }
+        $this->mediaBundleOptions[$bundle] = $info['label'];
+        $fields = $this->entityFieldManager->getFieldDefinitions('media', $bundle);
+        $this->mediaBundleUsageField[$bundle] = array_key_exists(IslandoraUtils::MEDIA_USAGE_FIELD, $fields);
+      }
+    }
+
+    return $this->mediaBundleOptions;
+  }
+
+  /**
+   * Helper; list the terms of the "islandora_media_use" vocabulary.
+   *
+   * @return \Generator
+   *   Generates term IDs as keys mapping to term names.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  protected function getMediaUseOptions() : \Generator {
+    /** @var \Drupal\taxonomy\TermInterface[] $terms */
+    $terms = $this->entityTypeManager->getStorage('taxonomy_term')
+      ->loadTree('islandora_media_use', 0, NULL, TRUE);
+
+    foreach ($terms as $term) {
+      yield $term->id() => $term->getName();
+    }
+  }
+
+  /**
+   * Helper; map media types supporting the usage field for use with #states.
+   *
+   * @return \Generator
+   *   Yields associative array mapping the string 'value' to the bundles which
+   *   have the given field.
+   */
+  protected function mapUseStates(): \Generator {
+    $this->getMediaBundleOptions();
+    foreach (array_keys(array_filter($this->mediaBundleUsageField)) as $bundle) {
+      yield ['value' => $bundle];
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $this->cacheableMetadata = CacheableMetadata::createFromRenderArray($form)
+      ->addCacheContexts([
+        'url',
+        'url.query_args',
+      ]);
+    $cached_values = $form_state->getTemporaryValue('wizard');
+
+    $form['media_type'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Media Type'),
+      '#description' => $this->t('Each media created will have this type.'),
+      '#empty_value' => '',
+      '#default_value' => $cached_values['media_type'] ?? '',
+      '#options' => $this->getMediaBundleOptions(),
+      '#required' => TRUE,
+    ];
+    $use_states = iterator_to_array($this->mapUseStates());
+    $form['use'] = [
+      '#type' => 'checkboxes',
+      '#title' => $this->t('Usage'),
+      '#description' => $this->t('Defined by <a target="_blank" href=":url">Portland Common Data Model: Use Extension</a>. "Original File" will trigger creation of derivatives.', [
+        ':url' => 'https://pcdm.org/2015/05/12/use',
+      ]),
+      '#options' => iterator_to_array($this->getMediaUseOptions()),
+      '#default_value' => $cached_values['use'] ?? [],
+      '#states' => [
+        'visible' => [
+          ':input[name="media_type"]' => $use_states,
+        ],
+        'required' => [
+          ':input[name="media_type"]' => $use_states,
+        ],
+      ],
+    ];
+
+    $this->cacheableMetadata->applyTo($form);
+    return $form;
+  }
+
+  /**
+   * Helper; enumerate keys to persist in form state.
+   *
+   * @return string[]
+   *   The keys to be persisted in our temp value in form state.
+   */
+  protected static function keysToSave() : array {
+    return [
+      'media_type',
+      'use',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $cached_values = $form_state->getTemporaryValue('wizard');
+    foreach (static::keysToSave() as $key) {
+      $cached_values[$key] = $form_state->getValue($key);
+    }
+    $form_state->setTemporaryValue('wizard', $cached_values);
+  }
+
+}

--- a/src/Form/AddChildrenWizard/MediaTypeTrait.php
+++ b/src/Form/AddChildrenWizard/MediaTypeTrait.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Drupal\islandora\Form\AddChildrenWizard;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\media\MediaTypeInterface;
+
+/**
+ * Media type lookup helper trait.
+ */
+trait MediaTypeTrait {
+
+  /**
+   * The entity type manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface|null
+   */
+  protected ?EntityTypeManagerInterface $entityTypeManager = NULL;
+
+  /**
+   * Helper; get media type, given our required values.
+   *
+   * @param array $values
+   *   An associative array which must contain at least:
+   *   - media_type: The machine name of the media type to load.
+   *
+   * @return \Drupal\media\MediaTypeInterface
+   *   The loaded media type.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  protected function getMediaType(array $values): MediaTypeInterface {
+    return $this->entityTypeManager()->getStorage('media_type')->load($values['media_type']);
+  }
+
+  /**
+   * Lazy-initialization of the entity type manager service.
+   *
+   * @return \Drupal\Core\Entity\EntityTypeManagerInterface
+   *   The entity type manager service.
+   */
+  protected function entityTypeManager() : EntityTypeManagerInterface {
+    if ($this->entityTypeManager === NULL) {
+      $this->setEntityTypeManager(\Drupal::service('entity_type.manager'));
+    }
+    return $this->entityTypeManager;
+  }
+
+  /**
+   * Setter for the entity type manager service.
+   */
+  public function setEntityTypeManager(EntityTypeManagerInterface $entity_type_manager) : self {
+    $this->entityTypeManager = $entity_type_manager;
+    return $this;
+  }
+
+}

--- a/src/Form/AddChildrenWizard/WizardTrait.php
+++ b/src/Form/AddChildrenWizard/WizardTrait.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Drupal\islandora\Form\AddChildrenWizard;
+
+use Drupal\Component\Plugin\PluginManagerInterface;
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Core\Field\WidgetInterface;
+
+/**
+ * Wizard/widget lookup helper trait.
+ */
+trait WizardTrait {
+
+  use FieldTrait;
+
+  /**
+   * The widget plugin manager service.
+   *
+   * @var \Drupal\Core\Field\WidgetPluginManager
+   */
+  protected PluginManagerInterface $widgetPluginManager;
+
+  /**
+   * Helper; get the base widget for the given field.
+   *
+   * @param \Drupal\Core\Field\FieldDefinitionInterface $field
+   *   The field for which get obtain the widget.
+   *
+   * @return \Drupal\Core\Field\WidgetInterface
+   *   The widget.
+   */
+  protected function getWidget(FieldDefinitionInterface $field): WidgetInterface {
+    return $this->widgetPluginManager->getInstance([
+      'field_definition' => $field,
+      'form_mode' => 'default',
+      'prepare' => TRUE,
+    ]);
+  }
+
+}

--- a/src/Plugin/Action/AbstractGenerateDerivativeMediaFile.php
+++ b/src/Plugin/Action/AbstractGenerateDerivativeMediaFile.php
@@ -5,6 +5,7 @@ namespace Drupal\islandora\Plugin\Action;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
+
 /**
  * Emits a Node for generating derivatives event.
  *
@@ -38,8 +39,8 @@ class AbstractGenerateDerivativeMediaFile extends AbstractGenerateDerivativeBase
    */
   protected function generateData(EntityInterface $entity) {
     $data = parent::generateData($entity);
-    if (get_class($entity) != 'Drupal\media\Entity\Media') { 
-      throw new \RuntimeException("Entity {$entity->getEntityTypeId()} {$entity->id()} is not a media", 500); 
+    if (get_class($entity) != 'Drupal\media\Entity\Media') {
+      throw new \RuntimeException("Entity {$entity->getEntityTypeId()} {$entity->id()} is not a media", 500);
     }
     $source_file = $this->mediaSource->getSourceFile($entity);
     if (!$source_file) {

--- a/src/Plugin/Action/AbstractGenerateDerivativeMediaFile.php
+++ b/src/Plugin/Action/AbstractGenerateDerivativeMediaFile.php
@@ -5,7 +5,6 @@ namespace Drupal\islandora\Plugin\Action;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
-
 /**
  * Emits a Node for generating derivatives event.
  *
@@ -39,8 +38,8 @@ class AbstractGenerateDerivativeMediaFile extends AbstractGenerateDerivativeBase
    */
   protected function generateData(EntityInterface $entity) {
     $data = parent::generateData($entity);
-    if (get_class($entity) != 'Drupal\media\Entity\Media') {
-      throw new \RuntimeException("Entity {$entity->getEntityTypeId()} {$entity->id()} is not a media", 500);
+    if (get_class($entity) != 'Drupal\media\Entity\Media') { 
+      throw new \RuntimeException("Entity {$entity->getEntityTypeId()} {$entity->id()} is not a media", 500); 
     }
     $source_file = $this->mediaSource->getSourceFile($entity);
     if (!$source_file) {

--- a/src/Plugin/Action/AbstractGenerateDerivativeMediaFile.php
+++ b/src/Plugin/Action/AbstractGenerateDerivativeMediaFile.php
@@ -40,7 +40,7 @@ class AbstractGenerateDerivativeMediaFile extends AbstractGenerateDerivativeBase
   protected function generateData(EntityInterface $entity) {
     $data = parent::generateData($entity);
     if (get_class($entity) != 'Drupal\media\Entity\Media') {
-      return;
+      throw new \RuntimeException("Entity {$entity->getEntityTypeId()} {$entity->id()} is not a media", 500);
     }
     $source_file = $this->mediaSource->getSourceFile($entity);
     if (!$source_file) {

--- a/src/Plugin/Condition/NodeIsIslandoraObject.php
+++ b/src/Plugin/Condition/NodeIsIslandoraObject.php
@@ -5,13 +5,14 @@ namespace Drupal\islandora\Plugin\Condition;
 use Drupal\Core\Condition\ConditionPluginBase;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Islandora\IslandoraUtils;
 
 /**
  * Checks whether node has fields that qualify it as an "Islandora" node.
  *
  * @Condition(
  *   id = "node_is_islandora_object",
- *   label = @Translation("Node is an Islandora object"),
+ *   label = @Translation("Node is an Islandora node"),
  *   context_definitions = {
  *     "node" = @ContextDefinition("entity:node", required = TRUE , label = @Translation("node"))
  *   }
@@ -20,13 +21,38 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class NodeIsIslandoraObject extends ConditionPluginBase implements ContainerFactoryPluginInterface {
 
   /**
+   * Islandora Utils.
+   *
+   * @var \Drupal\islandora\IslandoraUtils
+   */
+  protected $utils;
+
+  /**
+   * Constructs a Node is Islandora Condition plugin.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\islandora\IslandoraUtils $islandora_utils
+   *   Islandora utilities.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, IslandoraUtils $islandora_utils) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->utils = $islandora_utils;
+  }
+
+  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
     return new static(
       $configuration,
       $plugin_id,
-      $plugin_definition
+      $plugin_definition,
+      $container->get('islandora.utils')
     );
   }
 
@@ -38,8 +64,8 @@ class NodeIsIslandoraObject extends ConditionPluginBase implements ContainerFact
     if (!$node) {
       return FALSE;
     }
-    // Islandora objects have these two fields.
-    if ($node->hasField('field_model') && $node->hasField('field_member_of')) {
+    // Determine if node is Islandora.
+    if ($this->utils->isIslandoraType('node', $node->bundle())) {
       return TRUE;
     }
   }
@@ -49,10 +75,10 @@ class NodeIsIslandoraObject extends ConditionPluginBase implements ContainerFact
    */
   public function summary() {
     if (!empty($this->configuration['negate'])) {
-      return $this->t('The node is not an Islandora object.');
+      return $this->t('The node is not an Islandora node.');
     }
     else {
-      return $this->t('The node is an Islandora object.');
+      return $this->t('The node is an Islandora node.');
     }
   }
 

--- a/src/Plugin/views/filter/NodeIsIslandora.php
+++ b/src/Plugin/views/filter/NodeIsIslandora.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Drupal\islandora\Plugin\views\filter;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\views\Plugin\views\filter\FilterPluginBase;
+use Drupal\views\Plugin\ViewsHandlerManager;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\islandora\IslandoraUtils;
+use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
+
+/**
+ * Views Filter to show only Islandora nodes.
+ *
+ * @ingroup views_filter_handlers
+ *
+ * @ViewsFilter("islandora_node_is_islandora")
+ */
+class NodeIsIslandora extends FilterPluginBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * Views Handler Plugin Manager.
+   *
+   * @var \Drupal\views\Plugin\ViewsHandlerManager
+   */
+  protected $joinHandler;
+
+  /**
+   * Islandora Utils.
+   *
+   * @var \Drupal\islandora\IslandoraUtils
+   */
+  protected $utils;
+
+  /**
+   * The entity type bundle info service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeBundleInfoInterface
+   */
+  protected $entityTypeBundleInfo;
+
+  /**
+   * Constructs a Node is Islandora views filter plugin.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\views\Plugin\ViewsHandlerManager $join_handler
+   *   Views Handler Plugin Manager.
+   * @param \Drupal\islandora\IslandoraUtils $islandora_utils
+   *   Islandora utilities.
+   * @param \Drupal\Core\Entity\EntityTypeBundleInfoInterface $entity_type_bundle_info
+   *   The entity type bundle service.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, ViewsHandlerManager $join_handler, IslandoraUtils $islandora_utils, EntityTypeBundleInfoInterface $entity_type_bundle_info) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->joinHandler = $join_handler;
+    $this->utils = $islandora_utils;
+    $this->entityTypeBundleInfo = $entity_type_bundle_info;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration, $plugin_id, $plugin_definition,
+      $container->get('plugin.manager.views.join'),
+      $container->get('islandora.utils'),
+      $container->get('entity_type.bundle.info')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function defineOptions() {
+    return [
+      'negated' => ['default' => FALSE],
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildOptionsForm(&$form, FormStateInterface $form_state) {
+    $types = [];
+    foreach ($this->entityTypeBundleInfo->getBundleInfo('node') as $bundle_id => $bundle) {
+      if ($this->utils->isIslandoraType('node', $bundle_id)) {
+        $types[] = "{$bundle['label']} ($bundle_id)";
+      }
+    }
+    $types_list = implode(', ', $types);
+    $form['info'] = [
+      '#type' => 'item',
+      '#title' => 'Information',
+      '#description' => t("Configured Islandora bundles: @types", ['@types' => $types_list]),
+    ];
+    $form['negated'] = [
+      '#type' => 'checkbox',
+      '#title' => 'Negated',
+      '#description' => $this->t("Return nodes that <em>don't</em> have islandora fields"),
+      '#default_value' => $this->options['negated'],
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function adminSummary() {
+    $operator = ($this->options['negated']) ? "is not" : "is";
+    return "Node {$operator} an islandora node";
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function query() {
+    $types = [];
+    foreach (array_keys($this->entityTypeBundleInfo->getBundleInfo('node')) as $bundle_id) {
+      if ($this->utils->isIslandoraType('node', $bundle_id)) {
+        $types[] = $bundle_id;
+      }
+    }
+    $condition = ($this->options['negated']) ? 'NOT IN' : 'IN';
+    $query_base_table = $this->relationship ?: $this->view->storage->get('base_table');
+
+    $definition = [
+      'table' => 'node',
+      'type' => 'LEFT',
+      'field' => 'nid',
+      'left_table' => $query_base_table,
+      'left_field' => 'nid',
+    ];
+    $join = $this->joinHandler->createInstance('standard', $definition);
+    $node_table_alias = $this->query->addTable('node', $this->relationship, $join);
+    $this->query->addWhere($this->options['group'], "$node_table_alias.type", $types, $condition);
+  }
+
+}


### PR DESCRIPTION
**GitHub Issue**: [Slack conversation](https://islandora.slack.com/archives/CM5PPAV28/p1658594240757819) with C.Z.:

"How can I add my own media types to add media? If I add them, they will not show up under add media"

# What does this Pull Request do?

Tells you, when on the "add Media" and "add Members" page, that the bundles below are available because they have the magic field configured to this bundle.

# What's new?

Help text on the Add Children (`/node/{node}/members/add`) and Add Media (`/node/{node}/media/add`) pages.

# How should this be tested?

* does the text show up?
* do you have suggestions to make it better? 

Note: I tried to get "this bundle" (the bundle of the current node) to show up as the bundle's human readable name, but without loading a bunch of extra classes I could only get it to show the machine name of the bundle. So I didn't. If you think it's worth it, please send code.

# Documentation Status

* Does this change existing behaviour that's currently documented? no. 
* Does this change require new pages or sections of documentation? no but new screenshots might be nice.
* Who does this need to be documented for? it _is_ documentation.
* Associated documentation pull request(s): ___  or documentation issue ___ see above.

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties

