### PR TITLE
Allow media to use integer weight selector.

### DIFF
--- a/islandora.views.inc
+++ b/islandora.views.inc
@@ -9,19 +9,21 @@
  * Implements hook_views_data_alter().
  */
 function islandora_views_data_alter(&$data) {
-  // For now only support Nodes.
-  $fields = \Drupal::service('entity_field.manager')->getFieldStorageDefinitions('node');
-  foreach ($fields as $field => $field_storage_definition) {
-    if ($field_storage_definition->getType() == 'integer' && strpos($field, "field_") === 0) {
-      $prefixed_field = 'node__' . $field;
-      if (isset($data[$prefixed_field])) {
-        $data[$prefixed_field][$field . '_value']['field'] = $data[$prefixed_field][$field]['field'];
-        $data[$prefixed_field][$field]['title'] = t('Integer Weight Selector (@field)', [
-          '@field' => $field,
-        ]);
-        $data[$prefixed_field][$field]['help'] = t('Provides a drag-n-drop reordering of integer-based weight fields.');
-        $data[$prefixed_field][$field]['title short'] = t('Integer weight selector');
-        $data[$prefixed_field][$field]['field']['id'] = 'integer_weight_selector';
+  // For now only support Nodes and Media.
+  foreach (['node', 'media'] as $entity_type) {
+    $fields = \Drupal::service('entity_field.manager')->getFieldStorageDefinitions($entity_type);
+    foreach ($fields as $field => $field_storage_definition) {
+      if ($field_storage_definition->getType() == 'integer' && strpos($field, "field_") === 0) {
+        $prefixed_field = $entity_type . '__' . $field;
+        if (isset($data[$prefixed_field])) {
+          $data[$prefixed_field][$field . '_value']['field'] = $data[$prefixed_field][$field]['field'];
+          $data[$prefixed_field][$field]['title'] = t('Integer Weight Selector (@field)', [
+            '@field' => $field,
+          ]);
+          $data[$prefixed_field][$field]['help'] = t('Provides a drag-n-drop reordering of integer-based weight fields.');
+          $data[$prefixed_field][$field]['title short'] = t('Integer weight selector');
+          $data[$prefixed_field][$field]['field']['id'] = 'integer_weight_selector';
+        }
       }
     }
   }


### PR DESCRIPTION
**GitHub Issue**: #893 

# What does this Pull Request do?

Lets integer weight selector work on media.

# What's new?

See above.

* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# How should this be tested?

Add a "Number (integer)" field to some Media as e.g `field_weight`.
Create a view of Media.
Unlike a view of nodes, where you can add "Integer Weight Selector (field_weight)" as a field, you can only add `field_weight` raw.
With this PR, you can add an Integer Weight Selector to your view.
And, when you re-order the media in your view and click "save", you will edit their field_weight values.

# Documentation Status

* Does this change existing behaviour that's currently documented? It's baked into Core Islandora, and powers the Reorder Children view that is part of Islandora Core Feature. Does it need to be documented (open question)?
* Does this change require new pages or sections of documentation?
* Who does this need to be documented for?
* Associated documentation pull request(s): ___  or documentation issue ___

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/8-x-committers
