### PR TITLE
Issue-2152: Throw error instead of returning null data

### DIFF
--- a/src/Plugin/Action/AbstractGenerateDerivativeMediaFile.php
+++ b/src/Plugin/Action/AbstractGenerateDerivativeMediaFile.php
@@ -40,7 +40,7 @@ class AbstractGenerateDerivativeMediaFile extends AbstractGenerateDerivativeBase
   protected function generateData(EntityInterface $entity) {
     $data = parent::generateData($entity);
     if (get_class($entity) != 'Drupal\media\Entity\Media') {
-      return;
+      throw new \RuntimeException("Entity {$entity->getEntityTypeId()} {$entity->id()} is not a media", 500);
     }
     $source_file = $this->mediaSource->getSourceFile($entity);
     if (!$source_file) {


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/2152

See also https://github.com/asulibraries/islandora-repo/issues/550

# What does this Pull Request do?

Avoids WSOD when EmitEvent creates a StompHeaderEvent by issuing an error when `AbstractGenerateDerivateMediaFile::generateData()` is given an entity other than Media.

# What's new?

* Changes `AbstractGenerateDerivateMediaFile::generateData()` feature to throw an error instead of returning a Null when passed an entity other than a Media.
* Does this change add any new dependencies? No.
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? No.
* Could this change impact execution of existing code? Unlikely.

# How should this be tested?

Mostly, a smoke test, make sure your derivatives still work.

You need to add a Media-centered derivative action (instead of a Node-based one like those we provide by default) to get the WSOD this replaces with an error message.

# Documentation Status

* Does this change existing behavior that's currently documented? No.
* Does this change require new pages or sections of documentation? No.
* Who does this need to be documented for? N/A

# Interested parties
@Islandora/8-x-committers, maybe @wgilling?
