### PR TITLE
Add hOCR option to Text Extraction Media Attachment action and IIIF Manifest

### DIFF
--- a/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
+++ b/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
@@ -313,6 +313,7 @@ class IIIFManifest extends StylePluginBase {
     $options = parent::defineOptions();
 
     $options['iiif_tile_field'] = ['default' => ''];
+    $options['iiif_ocr_file_field'] = ['default' => ''];
 
     return $options;
   }
@@ -367,6 +368,15 @@ class IIIFManifest extends StylePluginBase {
       // we have more than one option to choose from
       // otherwise could lock up the form when setting up a View.
       '#required' => count($field_options) > 0,
+    ];
+
+    $form['iiif_ocr_file_field'] = [
+      '#title' => $this->t('Structured OCR data file field'),
+      '#type' => 'checkboxes',
+      '#default_value' => $this->options['iiif_ocr_file_field'],
+      '#description' => $this->t('The source of structured OCR text for each entity.'),
+      '#options' => $field_options,
+      '#required' => FALSE,
     ];
   }
 

--- a/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
+++ b/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
@@ -191,7 +191,7 @@ class IIIFManifest extends StylePluginBase {
     $canvases = [];
     foreach (array_filter(array_values($this->options['iiif_tile_field'])) as $iiif_tile_field) {
       $viewsField = $this->view->field[$iiif_tile_field];
-      $iiif_ocr_file_field = !empty($this->options['iiif_ocr_file_field']) ? array_filter(array_values($this->options['iiif_ocr_file_field'])): array();
+      $iiif_ocr_file_field = !empty($this->options['iiif_ocr_file_field']) ? array_filter(array_values($this->options['iiif_ocr_file_field'])) : [];
       $ocrField = count($iiif_ocr_file_field) > 0 ? $this->view->field[$iiif_ocr_file_field[0]] : NULL;
       $entity = $viewsField->getEntity($row);
 
@@ -205,7 +205,7 @@ class IIIFManifest extends StylePluginBase {
             continue;
           }
 
-        $ocrs = $entity->{$ocrField->definition['field_name']};
+          $ocrs = $entity->{$ocrField->definition['field_name']};
 
           // Create the IIIF URL for this file
           // Visiting $iiif_url will resolve to the info.json for the image.

--- a/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
+++ b/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
@@ -189,7 +189,7 @@ class IIIFManifest extends StylePluginBase {
    */
   protected function getTileSourceFromRow(ResultRow $row, $iiif_address, $iiif_base_id) {
     $canvases = [];
-    foreach ($this->options['iiif_tile_field'] as $iiif_tile_field) {
+    foreach (array_filter(array_values($this->options['iiif_tile_field'])) as $iiif_tile_field) {
       $viewsField = $this->view->field[$iiif_tile_field];
       $entity = $viewsField->getEntity($row);
 

--- a/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
+++ b/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
@@ -191,6 +191,7 @@ class IIIFManifest extends StylePluginBase {
     $canvases = [];
     foreach (array_filter(array_values($this->options['iiif_tile_field'])) as $iiif_tile_field) {
       $viewsField = $this->view->field[$iiif_tile_field];
+      $ocrField = array_pop(array_filter(array_values($this->options['iiif_ocr_file_field'])));
       $entity = $viewsField->getEntity($row);
 
       if (isset($entity->{$viewsField->definition['field_name']})) {

--- a/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
+++ b/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
@@ -277,7 +277,7 @@ class IIIFManifest extends StylePluginBase {
             ],
           ];
 
-          if (isset($ocr)) {
+          if (isset($ocr) && $ocr != FALSE) {
             $tmp_canvas['seeAlso'] = [
               '@id' => $ocr->entity->createFileUrl(FALSE),
               'format' => 'text/vnd.hocr+html',

--- a/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
+++ b/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
@@ -197,15 +197,15 @@ class IIIFManifest extends StylePluginBase {
 
       if (isset($entity->{$viewsField->definition['field_name']})) {
 
-        /** @var \Drupal\Core\Field\FieldItemListInterface $images */ 
-        $images = $entity->{$viewsField->definition['field_name']}; 
-        foreach ($images as $image) {
+        /** @var \Drupal\Core\Field\FieldItemListInterface $images */
+        $images = $entity->{$viewsField->definition['field_name']};
+        foreach ($images as $i => $image) {
           if (!$image->entity->access('view')) {
             // If the user does not have permission to view the file, skip it.
             continue;
           }
 
-        $ocrs = $entity->{$ocrField->definition['field_name']}; 
+        $ocrs = $entity->{$ocrField->definition['field_name']};
 
           // Create the IIIF URL for this file
           // Visiting $iiif_url will resolve to the info.json for the image.

--- a/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
+++ b/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
@@ -191,13 +191,13 @@ class IIIFManifest extends StylePluginBase {
     $canvases = [];
     foreach (array_filter(array_values($this->options['iiif_tile_field'])) as $iiif_tile_field) {
       $viewsField = $this->view->field[$iiif_tile_field];
-      $iiif_ocr_file_field = array_filter(array_values($this->options['iiif_ocr_file_field']));
+      $iiif_ocr_file_field = !empty($this->options['iiif_ocr_file_field']) ? array_filter(array_values($this->options['iiif_ocr_file_field'])): array();
       $ocrField = count($iiif_ocr_file_field) > 0 ? $this->view->field[$iiif_ocr_file_field[0]] : NULL;
       $entity = $viewsField->getEntity($row);
 
       if (isset($entity->{$viewsField->definition['field_name']})) {
 
-        /** @var \Drupal\Core\Field\FieldItemListInterface $images */
+        /** @var \Drupal\Core\Field\FieldItemListInterface $images */ 
         $images = $entity->{$viewsField->definition['field_name']}; 
         foreach ($images as $image) {
           if (!$image->entity->access('view')) {
@@ -209,7 +209,7 @@ class IIIFManifest extends StylePluginBase {
 
           // Create the IIIF URL for this file
           // Visiting $iiif_url will resolve to the info.json for the image.
-          $ocr = isset($ocrs[$i]) ? $ocrs[$i] : NULL;
+          $ocr = isset($ocrs[$i]) ? $ocrs[$i] : FALSE;
           $file_url = $image->entity->createFileUrl(FALSE);
           $mime_type = $image->entity->getMimeType();
           $iiif_url = rtrim($iiif_address, '/') . '/' . urlencode($file_url);

--- a/modules/islandora_text_extraction/src/Plugin/Action/GenerateOCRDerivativeFile.php
+++ b/modules/islandora_text_extraction/src/Plugin/Action/GenerateOCRDerivativeFile.php
@@ -97,6 +97,7 @@ class GenerateOCRDerivativeFile extends AbstractGenerateDerivativeMediaFile {
       case 'hocr':
         $this->configuration['args'] = '-c tessedit_create_hocr=1 -c hocr_font_info=0';
         break;
+
       case 'plain_text':
         $his->configuration['args'] = '';
         break;

--- a/modules/islandora_text_extraction/src/Plugin/Action/GenerateOCRDerivativeFile.php
+++ b/modules/islandora_text_extraction/src/Plugin/Action/GenerateOCRDerivativeFile.php
@@ -8,7 +8,7 @@ use Drupal\Core\Url;
 use Drupal\islandora\Plugin\Action\AbstractGenerateDerivativeMediaFile;
 
 /**
- * Emits a Node for generating fits derivatives event.
+ * Generates OCR derivatives event.
  *
  * @Action(
  *   id = "generate_extracted_text_file",
@@ -29,6 +29,7 @@ class GenerateOCRDerivativeFile extends AbstractGenerateDerivativeMediaFile {
     $config['destination_media_type'] = 'file';
     $config['scheme'] = $this->config->get('default_scheme');
     $config['destination_text_field_name'] = '';
+    $config['text_format'] = 'plain_text';
     return $config;
   }
 
@@ -38,7 +39,7 @@ class GenerateOCRDerivativeFile extends AbstractGenerateDerivativeMediaFile {
   public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
     $map = $this->entityFieldManager->getFieldMapByFieldType('text_long');
     $file_fields = $map['media'];
-    $field_options = array_combine(array_keys($file_fields), array_keys($file_fields));
+    $field_options = ['none' => $this->t('None')] + array_combine(array_keys($file_fields), array_keys($file_fields));
     $form = parent::buildConfigurationForm($form, $form_state);
     $form['mimetype']['#description'] = $this->t('Mimetype to convert to (e.g. application/xml, etc...)');
     $form['mimetype']['#value'] = 'text/plain';
@@ -48,12 +49,22 @@ class GenerateOCRDerivativeFile extends AbstractGenerateDerivativeMediaFile {
     $last = array_slice($form, count($form) - $position + 1);
 
     $middle['destination_text_field_name'] = [
-      '#required' => TRUE,
+      '#required' => FALSE,
       '#type' => 'select',
       '#options' => $field_options,
       '#title' => $this->t('Destination Text field Name'),
       '#default_value' => $this->configuration['destination_text_field_name'],
       '#description' => $this->t('Text field on Media Type to hold extracted text.'),
+    ];
+    $middle['text_format'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Format'),
+      '#options' => [
+        'plain_text' => $this->t('Plain text'),
+        'hocr' => $this->t('hOCR text with positional data'),
+      ],
+      '#default_value' => $this->configuration['text_format'],
+      '#description' => $this->t("The type of text to be returned."),
     ];
     $form = array_merge($first, $middle, $last);
 
@@ -81,17 +92,28 @@ class GenerateOCRDerivativeFile extends AbstractGenerateDerivativeMediaFile {
   public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
     parent::submitConfigurationForm($form, $form_state);
     $this->configuration['destination_text_field_name'] = $form_state->getValue('destination_text_field_name');
+    $this->configuration['text_format'] = $form_state->getValue('text_format');
+    switch ($form_state->getValue('text_format')) {
+      case 'hocr':
+        $this->configuration['args'] = '-c tessedit_create_hocr=1 -c hocr_font_info=0';
+        break;
+      case 'plain_text':
+        $his->configuration['args'] = '';
+        break;
+    }
   }
 
   /**
    * Override this to return arbitrary data as an array to be json encoded.
    */
   protected function generateData(EntityInterface $entity) {
+
     $data = parent::generateData($entity);
     $route_params = [
       'media' => $entity->id(),
       'destination_field' => $this->configuration['destination_field_name'],
       'destination_text_field' => $this->configuration['destination_text_field_name'],
+      'text_format' => $this->configuration['text_format'],
     ];
     $data['destination_uri'] = Url::fromRoute('islandora_text_extraction.attach_file_to_media', $route_params)
       ->setAbsolute()

--- a/src/Plugin/Action/AbstractGenerateDerivativeMediaFile.php
+++ b/src/Plugin/Action/AbstractGenerateDerivativeMediaFile.php
@@ -5,6 +5,7 @@ namespace Drupal\islandora\Plugin\Action;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
+
 /**
  * Emits a Node for generating derivatives event.
  *
@@ -38,8 +39,8 @@ class AbstractGenerateDerivativeMediaFile extends AbstractGenerateDerivativeBase
    */
   protected function generateData(EntityInterface $entity) {
     $data = parent::generateData($entity);
-    if (get_class($entity) != 'Drupal\media\Entity\Media') { 
-      throw new \RuntimeException("Entity {$entity->getEntityTypeId()} {$entity->id()} is not a media", 500); 
+    if (get_class($entity) != 'Drupal\media\Entity\Media') {
+      throw new \RuntimeException("Entity {$entity->getEntityTypeId()} {$entity->id()} is not a media", 500);
     }
     $source_file = $this->mediaSource->getSourceFile($entity);
     if (!$source_file) {

--- a/src/Plugin/Action/AbstractGenerateDerivativeMediaFile.php
+++ b/src/Plugin/Action/AbstractGenerateDerivativeMediaFile.php
@@ -5,7 +5,6 @@ namespace Drupal\islandora\Plugin\Action;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
-
 /**
  * Emits a Node for generating derivatives event.
  *
@@ -39,8 +38,8 @@ class AbstractGenerateDerivativeMediaFile extends AbstractGenerateDerivativeBase
    */
   protected function generateData(EntityInterface $entity) {
     $data = parent::generateData($entity);
-    if (get_class($entity) != 'Drupal\media\Entity\Media') {
-      throw new \RuntimeException("Entity {$entity->getEntityTypeId()} {$entity->id()} is not a media", 500);
+    if (get_class($entity) != 'Drupal\media\Entity\Media') { 
+      throw new \RuntimeException("Entity {$entity->getEntityTypeId()} {$entity->id()} is not a media", 500); 
     }
     $source_file = $this->mediaSource->getSourceFile($entity);
     if (!$source_file) {


### PR DESCRIPTION
**GitHub Issue**: 

https://github.com/Islandora/documentation/issues/1580

# What does this Pull Request do?

Add option to generate hOCR derivatives to text extraction to file field derivative action.

# What's new?

The action type "Generate hOCR Extracted Text for Media Attachment" now has a drop down to select Plain Text or hOCR

Also added a select box for the field on the media to store resulting hOCR.


IIIF manifest is now populated with hOCR stream locations if they exist, in a seeAlso section as per https://github.com/dbmdz/mirador-textoverlay


* Does this change add any new dependencies?  No
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)?  No
* Could this change impact execution of existing code? No

# How should this be tested?

Test on either playbook or ISLE. For ISLE I've just successfully tested using a fresh site built with ```make starter_dev```

1. Go to Admin -> Structure -> Media Types and go to Manage Fields on the File type.
2. Add a File field called hOCR extracted Text which can hold files with extension xml
3. Ensure the new field is enabled in the Manage Display tab 
4. Go to Admin -> Actions and click Create New Advanced Action  with the Generate Extracted Text for Media Attachment action type.
5. Give the new action a name that mentions hOCR.
6. In Format field select hOCR Extracted Text with Positional Data 
7. For Destination File Field Name select the field you just created., and save the action.. Keep None for the destination text field.
8. Go to Admin -> Context UI -> Context and edit the Page Derivatives context
9. Click Add Reaction and choose 'Derive File for Existing Media'.
10. In the select box choose the action you created above and save.
11. Add a new Repository Item with type Paged Content
12. Add a child object of type Page
13. On that child object, add a Media of type File and populate it with a TIFF  that has text on it. **Check the Original File checkbox in Media Use** Do not add anything to the hOCR Extracted Text field you created.
14. Save the media.
15. After about a minute, the extracted text with positional data field should be populated. You can verify this directly.


Testing the Manifest additions:

1. Assuming above is done, go to Admin -> Structure -> Views and edit the IIIF Manifest view.
2. Click the Settings for the IIIF Manifest Display 
3. Choose the field you created under Structured OCR Data file Field
![image](https://user-images.githubusercontent.com/82412/188935212-d7ce3786-877a-4043-97c6-214407e4760d.png)
4. Save the view.
5. Go to the Paged Content node you created and add "/book-manifest" to the end of the URL.
6. Look for a seeAlso section in the XML that should contain a reference to the hOCR field with appropriate MIME Type and Description 

# Documentation Status

* Does this change existing behaviour that's currently documented?  No
* Does this change require new pages or sections of documentation? No (Forthcoming PR may require it)


# Additional Notes:
Any additional information that you think would be helpful when reviewing this

Working on supporting Mirador Text Overlay and eventually search results highlighting. This supports that initiative. 
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/8-x-committers
