### PR TITLE
Fix/schemas

### DIFF
--- a/config/schema/islandora.schema.yml
+++ b/config/schema/islandora.schema.yml
@@ -166,6 +166,10 @@ condition.plugin.node_had_namespace:
     pid_field:
       type: ignore
       label: 'PID field'
+      
+field.formatter.settings.islandora_image:
+  type: field.formatter.settings.image
+  label: 'Islandora image field display format settings'
 
 condition.plugin.islandora_entity_bundle:
   type: condition.plugin

--- a/config/schema/islandora.schema.yml
+++ b/config/schema/islandora.schema.yml
@@ -87,6 +87,14 @@ condition.plugin.node_has_term:
     logic:
       type: string
       label: 'Logic (AND or OR)'
+    tids:
+      type: sequence
+      sequence:
+        type: mapping
+        mapping:
+          target_id:
+            type: integer
+            label: The target taxonomy term IDs
 
 condition.plugin.node_has_parent:
   type: condition.plugin
@@ -158,6 +166,72 @@ condition.plugin.node_had_namespace:
     pid_field:
       type: ignore
       label: 'PID field'
-field.formatter.settings.islandora_image:
-  type: field.formatter.settings.image
-  label: 'Islandora image field display format settings'
+
+condition.plugin.islandora_entity_bundle:
+  type: condition.plugin
+  mapping:
+    bundles:
+      type: sequence
+      sequence:
+        type: string
+
+condition.plugin.media_source_mimetype:
+  type: condition.plugin
+  mapping:
+    mimetype:
+      type: string
+
+reaction.plugin.alter_jsonld_type:
+  type: islandora.reaction_plugin_with_saved
+  mapping:
+    source_field:
+      type: string
+
+islandora.reaction_plugin_with_saved:
+  type: reaction.plugin
+  mapping:
+    saved:
+      type: boolean
+      label: Default config upstream; however, left undefined in the schema.
+
+reaction.plugin.islandora_map_uri_predicate:
+  type: islandora.reaction_plugin_with_saved
+  mapping:
+    drupal_uri_predicate:
+      type: string
+
+reaction.plugin.view_mode_alter:
+  type: islandora.reaction_plugin_with_saved
+  mapping:
+    mode:
+      type: string
+      label: The view mode to which to switch
+
+islandora.reaction.actions:
+  type: islandora.reaction_plugin_with_saved
+  mapping:
+    actions:
+      type: sequence
+      sequence:
+        type: string
+
+reaction.plugin.index:
+  type: islandora.reaction.actions
+
+reaction.plugin.delete:
+  type: islandora.reaction.actions
+
+reaction.plugin.derivative:
+  type: islandora.reaction.actions
+
+field.widget.settings.media_track:
+  type: field.widget.settings.file_generic
+
+field.field_settings.media_track:
+  type: field.field_settings.file
+  mapping:
+    languages:
+      type: string
+
+field.storage_settings.media_track:
+  type: field.storage_settings.file

--- a/modules/islandora_audio/config/schema/islandora_audio.schema.yml
+++ b/modules/islandora_audio/config/schema/islandora_audio.schema.yml
@@ -29,3 +29,6 @@ action.configuration.generate_audio_derivative:
     path:
       type: text
       label: 'File path with extension'
+
+field.formatter.settings.islandora_file_audio:
+  type: field.formatter.settings.file_audio

--- a/modules/islandora_iiif/config/schema/islandora_iiif.schema.yml
+++ b/modules/islandora_iiif/config/schema/islandora_iiif.schema.yml
@@ -5,3 +5,11 @@ islandora_iiif.settings:
     iiif_server:
       type: string
       label: 'IIIF Server Url'
+
+views.style.iiif_manifest:
+  type: views_style
+  mapping:
+    iiif_tile_field:
+      type: sequence
+      sequence:
+        - type: string

--- a/modules/islandora_iiif/config/schema/islandora_iiif.schema.yml
+++ b/modules/islandora_iiif/config/schema/islandora_iiif.schema.yml
@@ -12,4 +12,4 @@ views.style.iiif_manifest:
     iiif_tile_field:
       type: sequence
       sequence:
-        - type: string
+        type: string

--- a/modules/islandora_image/config/schema/islandora_image.schema.yml
+++ b/modules/islandora_image/config/schema/islandora_image.schema.yml
@@ -29,3 +29,7 @@ action.configuration.generate_image_derivative:
     path:
       type: text
       label: 'File path with extension'
+
+field.formatter.settings.islandora_image:
+  type: field.formatter.settings.image
+  label: 'Islandora image field display format settings'

--- a/modules/islandora_image/config/schema/islandora_image.schema.yml
+++ b/modules/islandora_image/config/schema/islandora_image.schema.yml
@@ -29,7 +29,3 @@ action.configuration.generate_image_derivative:
     path:
       type: text
       label: 'File path with extension'
-
-field.formatter.settings.islandora_image:
-  type: field.formatter.settings.image
-  label: 'Islandora image field display format settings'

--- a/modules/islandora_video/config/schema/islandora_video.schema.yml
+++ b/modules/islandora_video/config/schema/islandora_video.schema.yml
@@ -29,3 +29,6 @@ action.configuration.generate_video_derivative:
     path:
       type: text
       label: 'File path with extension'
+
+field.formatter.settings.islandora_file_video:
+  type: field.formatter.settings.file_video


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/2164

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What does this Pull Request do?

Fleshes out config schema.

# What's new?

A number of new config schemas being defined. Later exports may end up changing the types of values stored in exported YAML; for example: If something is now defined as a `boolean`, it should now be exported as a `true` or `false` whereas before it would've likely been the integers `1` or `0`... shouldn't really have any effect, just might cause a bit of noise in diffs as it happens.

* Does this change add any new dependencies? No.
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? No.
* Could this change impact execution of existing code? Unlikely.

# How should this be tested?

1. Install and enable the `config_inspector` module
2. Either:
    1. Run:
        ```
        drush config:inspect --only-error --detail
        ```
        or:
     2. Looks at the reports at `/admin/reports/config-inspector`

    to note the number of config errors present from the plugins defined in Islandora.
3. Grab the code
4. Clear cache
5. Re-run/Look at the config_inspector output, and see that the number of errors should be reduced. 

# Documentation Status

* Does this change existing behaviour that's currently documented?
* Does this change require new pages or sections of documentation?
* Who does this need to be documented for?
* Associated documentation pull request(s): ___  or documentation issue ___

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/8-x-committers
