### PR TITLE
Unset pseudo field in display modes automatically

### DIFF
--- a/islandora.module
+++ b/islandora.module
@@ -423,7 +423,7 @@ function islandora_entity_extra_field_info() {
   if (!empty($pseudo_bundles)) {
     foreach ($pseudo_bundles as $key) {
       [$bundle, $content_entity] = explode(":", $key);
-      $extra_field[$content_entity][$bundle]['display']['field_gemini_uri'] = [
+      $extra_field[$content_entity][$bundle]['display'][IslandoraSettingsForm::GEMINI_PSEUDO_FIELD] = [
         'label' => t('Fedora URI'),
         'description' => t('The URI to the persistent'),
         'weight' => 100,

--- a/src/Form/IslandoraSettingsForm.php
+++ b/src/Form/IslandoraSettingsForm.php
@@ -2,8 +2,10 @@
 
 namespace Drupal\islandora\Form;
 
+use Drupal\Core\Cache\Cache;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Site\Settings;
@@ -39,6 +41,7 @@ class IslandoraSettingsForm extends ConfigFormBase {
     'month',
     'year',
   ];
+  const GEMINI_PSEUDO_FIELD = 'field_gemini_uri';
 
   /**
    * To list the available bundle types.
@@ -55,20 +58,31 @@ class IslandoraSettingsForm extends ConfigFormBase {
   private $brokerPassword;
 
   /**
+   * The entity type manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  private $entityTypeManager;
+
+  /**
    * Constructs a \Drupal\system\ConfigFormBase object.
    *
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
    *   The factory for configuration objects.
    * @param \Drupal\Core\Entity\EntityTypeBundleInfoInterface $entity_type_bundle_info
    *   The EntityTypeBundleInfo service.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The EntityTypeManager service.
    */
   public function __construct(
     ConfigFactoryInterface $config_factory,
-    EntityTypeBundleInfoInterface $entity_type_bundle_info
+    EntityTypeBundleInfoInterface $entity_type_bundle_info,
+    EntityTypeManagerInterface $entity_type_manager
   ) {
     $this->setConfigFactory($config_factory);
     $this->entityTypeBundleInfo = $entity_type_bundle_info;
     $this->brokerPassword = $this->config(self::CONFIG_NAME)->get(self::BROKER_PASSWORD);
+    $this->entityTypeManager = $entity_type_manager;
   }
 
   /**
@@ -78,6 +92,7 @@ class IslandoraSettingsForm extends ConfigFormBase {
     return new static(
           $container->get('config.factory'),
           $container->get('entity_type.bundle.info'),
+          $container->get('entity_type.manager')
       );
   }
 
@@ -308,7 +323,7 @@ class IslandoraSettingsForm extends ConfigFormBase {
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $config = $this->configFactory->getEditable(self::CONFIG_NAME);
 
-    $pseudo_types = array_filter($form_state->getValue(self::GEMINI_PSEUDO));
+    $new_pseudo_types = array_filter($form_state->getValue(self::GEMINI_PSEUDO));
 
     $broker_password = $form_state->getValue(self::BROKER_PASSWORD);
 
@@ -326,15 +341,53 @@ class IslandoraSettingsForm extends ConfigFormBase {
       }
     }
 
+    // Check for types being unset and remove the field from them first.
+    $current_pseudo_types = $config->get(self::GEMINI_PSEUDO);
+    $this->updateEntityViewConfiguration($current_pseudo_types, $new_pseudo_types);
+
     $config
       ->set(self::BROKER_URL, $form_state->getValue(self::BROKER_URL))
       ->set(self::JWT_EXPIRY, $form_state->getValue(self::JWT_EXPIRY))
       ->set(self::UPLOAD_FORM_LOCATION, $form_state->getValue(self::UPLOAD_FORM_LOCATION))
       ->set(self::UPLOAD_FORM_ALLOWED_MIMETYPES, $form_state->getValue(self::UPLOAD_FORM_ALLOWED_MIMETYPES))
-      ->set(self::GEMINI_PSEUDO, $pseudo_types)
+      ->set(self::GEMINI_PSEUDO, $new_pseudo_types)
       ->save();
 
     parent::submitForm($form, $form_state);
   }
 
+  /**
+   * Removes the Fedora Pseudo field from any entity bundles that have be unselected.
+   *
+   * @param array $current_config
+   *   The current set of entity type & bundle to have the pseudo field, format {bundle}:{entity_type}
+   * @param array $new_config
+   *   The new set of entity type & bundle to have the pseudo field, format {bundle}:{entity_type}
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  private function updateEntityViewConfiguration(array $current_config, array $new_config) {
+    $cache_tags = [];
+    $removed = array_diff($current_config, $new_config);
+    $entity_view_display = $this->entityTypeManager->getStorage('entity_view_display');
+    // types being removed
+    foreach ($removed as $bundle_type) {
+      [$bundle, $type_id] = explode(":", $bundle_type);
+      $results = $entity_view_display->getQuery()
+        ->condition('bundle', $bundle)
+        ->condition('targetEntityType', $type_id)
+        ->exists('content.' . self::GEMINI_PSEUDO_FIELD . '.region')
+        ->execute();
+      $entities = $entity_view_display->loadMultiple($results);
+      foreach ($entities as $entity) {
+        $entity->removeComponent(self::GEMINI_PSEUDO_FIELD);
+        $entity->save();
+        $cache_tags = array_merge($cache_tags, $entity->getCacheTags());
+      }
+    }
+    $entity_view_display->resetCache();
+    Cache::invalidateTags($cache_tags);
+  }
 }

--- a/src/Form/IslandoraSettingsForm.php
+++ b/src/Form/IslandoraSettingsForm.php
@@ -357,22 +357,23 @@ class IslandoraSettingsForm extends ConfigFormBase {
   }
 
   /**
-   * Removes the Fedora Pseudo field from any entity bundles that have be unselected.
+   * Removes the Fedora URI field from entity bundles that have be unselected.
    *
    * @param array $current_config
-   *   The current set of entity type & bundle to have the pseudo field, format {bundle}:{entity_type}
+   *   The current set of entity types & bundles to have the pseudo field,
+   *   format {bundle}:{entity_type}.
    * @param array $new_config
-   *   The new set of entity type & bundle to have the pseudo field, format {bundle}:{entity_type}
+   *   The new set of entity types & bundles to have the pseudo field, format
+   *   {bundle}:{entity_type}.
    *
    * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    * @throws \Drupal\Core\Entity\EntityStorageException
    */
   private function updateEntityViewConfiguration(array $current_config, array $new_config) {
-    $cache_tags = [];
     $removed = array_diff($current_config, $new_config);
+    $added = array_diff($new_config, $current_config);
     $entity_view_display = $this->entityTypeManager->getStorage('entity_view_display');
-    // types being removed
     foreach ($removed as $bundle_type) {
       [$bundle, $type_id] = explode(":", $bundle_type);
       $results = $entity_view_display->getQuery()
@@ -384,10 +385,13 @@ class IslandoraSettingsForm extends ConfigFormBase {
       foreach ($entities as $entity) {
         $entity->removeComponent(self::GEMINI_PSEUDO_FIELD);
         $entity->save();
-        $cache_tags = array_merge($cache_tags, $entity->getCacheTags());
       }
     }
-    $entity_view_display->resetCache();
-    Cache::invalidateTags($cache_tags);
+    if (count($removed) > 0 || count($added) > 0) {
+      // If we added or cleared a type then clear the extra_fields cache.
+      // @see Drupal/Core/Entity/EntityFieldManager::getExtraFields
+      Cache::invalidateTags(["entity_field_info"]);
+    }
   }
+
 }


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1523

# What does this Pull Request do?

Any entity/bundle types that have the Fedora URI field removed from them are now used to
* query for all entity view displays that contain the pseudo field in the content (read: visible)
* remove the pseudo field from these entity view displays

# What's new?

* Does this change add any new dependencies? No
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? No
* Could this change impact execution of existing code? No

# How should this be tested?

1. Configure an entity bundle's field display to show the Fedora URI. (Admin -> Structure -> Content Type -> Repository Item -> Manage Display)
1. Create some of these types.
1. See they have the Fedora URI
1. Unselect the entity bundle on the Islandora Core Settings form and Save
1. See the entities no longer have the Fedora URI.
1. See that (unfortunately) the Fedora URI is now in the disabled section of the entity field display form (**see below**)

**Note**: My understanding of Drupal 8/9 cache is not strong and I cannot figure out how to determine what to "clear" to get the Fedora URI to disappear from the (now) unselected entity/bundles on the page described in step 1 above. Only a full cache clear seems to have the desired impact. I'd appreciate some help with that.

# Documentation Status

* Does this change existing behaviour that's currently documented? no
* Does this change require new pages or sections of documentation? not really
* Who does this need to be documented for?
* Associated documentation pull request(s): ___  or documentation issue ___

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers ( @rosiel, @mjordan & @seth-shaw-asu )
