### PR TITLE
Issue #2170: Sort "manage members" View results by field_weight

### DIFF
--- a/modules/islandora_core_feature/config/install/views.view.manage_members.yml
+++ b/modules/islandora_core_feature/config/install/views.view.manage_members.yml
@@ -1,15 +1,17 @@
 langcode: en
 status: true
 dependencies:
-  enforced:
-    module:
-      - islandora_core_feature
   module:
     - jsonld
     - node
     - rest
     - serialization
     - user
+  enforced:
+    module:
+      - islandora_core_feature
+_core:
+  default_config_hash: Zwu8JUsBiYaxPko_9DbJJhA-ZZSGOm81I9XtT9NH3M4
 id: manage_members
 label: 'Manage members'
 module: views
@@ -17,61 +19,14 @@ description: 'Manage members belonging to a piece of content'
 tag: ''
 base_table: node_field_data
 base_field: nid
-core: 8.x
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
-        options:
-          perm: 'manage members'
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: mini
-        options:
-          items_per_page: 10
-          offset: 0
-          id: 0
-          total_pages: null
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-          tags:
-            previous: ‹‹
-            next: ››
-      style:
-        type: table
-      row:
-        type: fields
+      title: 'Manage members'
       fields:
         node_bulk_form:
           id: node_bulk_form
@@ -80,6 +35,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          plugin_id: node_bulk_form
           label: 'Node operations bulk form'
           exclude: false
           alter:
@@ -124,33 +81,27 @@ display:
           action_title: Action
           include_exclude: exclude
           selected_actions: {  }
-          entity_type: node
-          plugin_id: node_bulk_form
         title:
           id: title
           table: node_field_data
           field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
           entity_type: node
           entity_field: title
+          plugin_id: field
+          label: Title
+          exclude: false
           alter:
             alter_text: false
             make_link: false
             absolute: false
-            trim: false
             word_boundary: false
             ellipsis: false
             strip_tags: false
+            trim: false
             html: false
-          hide_empty: false
-          empty_zero: false
-          settings:
-            link_to_entity: true
-          plugin_id: field
-          relationship: none
-          group_type: group
-          admin_label: ''
-          label: Title
-          exclude: false
           element_type: ''
           element_class: ''
           element_label_type: ''
@@ -160,9 +111,13 @@ display:
           element_wrapper_class: ''
           element_default_classes: true
           empty: ''
+          hide_empty: false
+          empty_zero: false
           hide_alter_empty: true
           click_sort_column: value
           type: string
+          settings:
+            link_to_entity: true
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -180,6 +135,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          plugin_id: entity_operations
           label: 'Operations links'
           exclude: false
           alter:
@@ -222,15 +179,56 @@ display:
           empty_zero: false
           hide_alter_empty: true
           destination: false
-          entity_type: node
-          plugin_id: entity_operations
-      filters: {  }
-      sorts: {  }
-      title: 'Manage members'
-      header: {  }
-      footer: {  }
+      pager:
+        type: mini
+        options:
+          offset: 0
+          items_per_page: 10
+          total_pages: null
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'manage members'
+      cache:
+        type: tag
+        options: {  }
       empty: {  }
-      relationships: {  }
+      sorts:
+        field_weight_value:
+          id: field_weight_value
+          table: node__field_weight
+          field: field_weight_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
       arguments:
         field_member_of_target_id:
           id: field_member_of_target_id
@@ -239,6 +237,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: numeric
           default_action: default
           exception:
             value: all
@@ -252,8 +251,8 @@ display:
           summary_options:
             base_path: ''
             count: true
-            items_per_page: 25
             override: false
+            items_per_page: 25
           summary:
             sort_order: asc
             number_of_records: 0
@@ -263,17 +262,32 @@ display:
             type: 'entity:node'
             fail: 'not found'
           validate_options:
-            operation: view
-            multiple: 0
             bundles: {  }
             access: false
+            operation: view
+            multiple: 0
           break_phrase: false
           not: false
-          plugin_id: numeric
-      display_extenders: {  }
+      filters: {  }
       filter_groups:
         operator: AND
         groups: {  }
+      style:
+        type: table
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
     cache_metadata:
       max-age: 0
       contexts:
@@ -285,9 +299,9 @@ display:
         - user.permissions
       tags: {  }
   page_1:
-    display_plugin: page
     id: page_1
     display_title: Page
+    display_plugin: page
     position: 1
     display_options:
       display_extenders: {  }
@@ -296,11 +310,11 @@ display:
         type: tab
         title: Children
         description: ''
-        expanded: false
-        parent: ''
         weight: 0
-        context: '0'
+        expanded: false
         menu_name: main
+        parent: ''
+        context: '0'
     cache_metadata:
       max-age: 0
       contexts:
@@ -312,13 +326,11 @@ display:
         - user.permissions
       tags: {  }
   rest_export_1:
-    display_plugin: rest_export
     id: rest_export_1
     display_title: 'REST export'
+    display_plugin: rest_export
     position: 1
     display_options:
-      display_extenders: {  }
-      path: node/%node/members
       style:
         type: serializer
         options:
@@ -326,6 +338,8 @@ display:
           formats:
             jsonld: jsonld
             json: json
+      display_extenders: {  }
+      path: node/%node/members
       auth:
         - basic_auth
         - jwt_auth


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/2170

# What does this Pull Request do?

Adds a sort (by `field_weight`, ascending) to the Manage Members View.

# What's new?

Added a Sort Criteria to all displays in the Manage Members View, depicted in the View admin GUI as:

![image](https://user-images.githubusercontent.com/403918/190541481-194906ea-0089-4216-80b9-251d611a1b34.png)

* Does this change add any new dependencies? 

No

* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? 

No

* Could this change impact execution of existing code?

No

# How should this be tested?

1. Check out this branch.
1. Create an object and a couple of children/member objects, assigning each a desired weight under the System fieldset in their add/edit form.
1. Click on the parent object's Members tab to see how they sort.
2. Modify the weight on one or more of the children.
3. Revisit the parent's Members tab. The children should sort using to their newly assigned weight values, in ascending order.

# Documentation Status

* Does this change existing behaviour that's currently documented?

No

* Does this change require new pages or sections of documentation?

No

* Who does this need to be documented for?

n/a


# Additional Notes:

I exported this View YAML using /admin/config/development/configuration/single/export (Drupal 9.4.3). There seem to be more changes in the YAML than I expected.

# Interested parties
@Islandora/committers
    