### PR TITLE
Add (media/child) form improvements 2

### DIFF
--- a/src/Controller/ManageMediaController.php
+++ b/src/Controller/ManageMediaController.php
@@ -36,8 +36,11 @@ class ManageMediaController extends ManageMembersController {
 
     return [
       '#type' => 'markup',
-      '#markup' => $this->t("These available media types below have <em>@field</em> and it is configured to allow this content type.",
-        ['@field' => $field]),
+      '#markup' => $this->t("The following media types can be added because they have the <code>@field</code> field. <a href=@manage_media_page>Manage media types</a>.",
+        [
+          '@field' => $field,
+          '@manage_media_page' => '/admin/structure/media',
+        ]),
       'add_media' => $add_media_list,
     ];
   }

--- a/src/Controller/ManageMediaController.php
+++ b/src/Controller/ManageMediaController.php
@@ -25,7 +25,7 @@ class ManageMediaController extends ManageMembersController {
   public function addToNodePage(NodeInterface $node) {
     $field = IslandoraUtils::MEDIA_OF_FIELD;
 
-    return $this->generateTypeList(
+    $add_media_list = $this->generateTypeList(
       'media',
       'media_type',
       'entity.media.add_form',
@@ -33,6 +33,13 @@ class ManageMediaController extends ManageMembersController {
       $field,
       ['query' => ["edit[$field][widget][0][target_id]" => $node->id()]]
     );
+
+    return [
+      '#type' => 'markup',
+      '#markup' => $this->t("These available media types below have <em>@field</em> and it is configured to allow this content type.",
+        ['@field' => $field]),
+      'add_media' => $add_media_list,
+    ];
   }
 
   /**

--- a/src/Controller/ManageMediaController.php
+++ b/src/Controller/ManageMediaController.php
@@ -6,6 +6,7 @@ use Drupal\islandora\IslandoraUtils;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Routing\RouteMatch;
 use Drupal\node\Entity\Node;
+use Drupal\Core\Url;
 use Drupal\node\NodeInterface;
 
 /**
@@ -34,13 +35,18 @@ class ManageMediaController extends ManageMembersController {
       ['query' => ["edit[$field][widget][0][target_id]" => $node->id()]]
     );
 
+    $manage_link = Url::fromRoute('entity.media_type.collection')->toRenderArray();
+    $manage_link['#title'] = $this->t('Manage media types');
+    $manage_link['#type'] = 'link';
+    $manage_link['#prefix'] = ' ';
+    $manage_link['#suffix'] = '.';
+
     return [
       '#type' => 'markup',
-      '#markup' => $this->t("The following media types can be added because they have the <code>@field</code> field. <a href=@manage_media_page>Manage media types</a>.",
-        [
-          '@field' => $field,
-          '@manage_media_page' => '/admin/structure/media',
-        ]),
+      '#markup' => $this->t("The following media types can be added because they have the <code>@field</code> field.", [
+        '@field' => $field,
+      ]),
+      'manage_link' => $manage_link,
       'add_media' => $add_media_list,
     ];
   }

--- a/src/Controller/ManageMembersController.php
+++ b/src/Controller/ManageMembersController.php
@@ -88,7 +88,8 @@ class ManageMembersController extends EntityController {
    */
   public function addToNodePage(NodeInterface $node) {
     $field = IslandoraUtils::MEMBER_OF_FIELD;
-    return $this->generateTypeList(
+
+    $add_node_list = $this->generateTypeList(
       'node',
       'node_type',
       'node.add',
@@ -96,6 +97,13 @@ class ManageMembersController extends EntityController {
       $field,
       ['query' => ["edit[$field][widget][0][target_id]" => $node->id()]]
     );
+
+    return [
+      '#type' => 'markup',
+      '#markup' => $this->t("These available content types below have <em>@field</em> and it is configured to allow this content type.",
+        ['@field' => $field]),
+      'add_node' => $add_node_list,
+    ];
   }
 
   /**

--- a/src/Controller/ManageMembersController.php
+++ b/src/Controller/ManageMembersController.php
@@ -7,6 +7,7 @@ use Drupal\Core\Render\RendererInterface;
 use Drupal\Core\Entity\Controller\EntityController;
 use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\Core\Link;
+use Drupal\Core\Url;
 use Drupal\islandora\IslandoraUtils;
 use Drupal\node\NodeInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -98,13 +99,18 @@ class ManageMembersController extends EntityController {
       ['query' => ["edit[$field][widget][0][target_id]" => $node->id()]]
     );
 
+    $manage_link = Url::fromRoute('entity.node_type.collection')->toRenderArray();
+    $manage_link['#title'] = $this->t('Manage content types');
+    $manage_link['#type'] = 'link';
+    $manage_link['#prefix'] = ' ';
+    $manage_link['#suffix'] = '.';
+
     return [
       '#type' => 'markup',
-      '#markup' => $this->t("The following content types can be added because they have the <code>@field</code> field. <a href=@manage_content_types>Manage content types</a>.",
-        [
-          '@field' => $field,
-          '@manage_content_types' => '/admin/structure/types',
-        ]),
+      '#markup' => $this->t("The following content types can be added because they have the <code>@field</code> field.", [
+        '@field' => $field,
+      ]),
+      'manage_link' => $manage_link,
       'add_node' => $add_node_list,
     ];
   }

--- a/src/Controller/ManageMembersController.php
+++ b/src/Controller/ManageMembersController.php
@@ -100,8 +100,11 @@ class ManageMembersController extends EntityController {
 
     return [
       '#type' => 'markup',
-      '#markup' => $this->t("These available content types below have <em>@field</em> and it is configured to allow this content type.",
-        ['@field' => $field]),
+      '#markup' => $this->t("The following content types can be added because they have the <code>@field</code> field. <a href=@manage_content_types>Manage content types</a>.",
+        [
+          '@field' => $field,
+          '@manage_content_types' => '/admin/structure/types',
+        ]),
       'add_node' => $add_node_list,
     ];
   }


### PR DESCRIPTION
**Replaces #890** 

**GitHub Issue**: [Slack conversation](https://islandora.slack.com/archives/CM5PPAV28/p1658594240757819) with C.Z.:

"How can I add my own media types to add media? If I add them, they will not show up under add media"

# What does this Pull Request do?

Tells you, when on the "add Media" and "add Members" page, that the bundles below are available because they have the magic field configured to this bundle.

# What's new?

Help text on the Add Children (`/node/{node}/members/add`) and Add Media (`/node/{node}/media/add`) pages.

# How should this be tested?

* does the text show up?
* do you have suggestions to make it better? 

Note: I tried to get "this bundle" (the bundle of the current node) to show up as the bundle's human readable name, but without loading a bunch of extra classes I could only get it to show the machine name of the bundle. So I didn't. If you think it's worth it, please send code.

# Documentation Status

* Does this change existing behaviour that's currently documented? no. 
* Does this change require new pages or sections of documentation? no but new screenshots might be nice.
* Who does this need to be documented for? it _is_ documentation.
* Associated documentation pull request(s): ___  or documentation issue ___ see above.

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties

