### PR TITLE
Fix warning by checking whether key is set.

### DIFF
--- a/islandora.module
+++ b/islandora.module
@@ -515,7 +515,7 @@ function islandora_preprocess_views_view_table(&$variables) {
 
   // Check for a weight selector field.
   foreach ($variables['view']->field as $field_key => $field) {
-    if (isset($field->options['plugin_id']) && $field->options['plugin_id'] == 'integer_weight_selector') {
+    if ($field->getPluginId() == 'integer_weight_selector') {
 
       // Check if the weight selector is on the first column.
       $is_first_column = array_search($field_key, array_keys($variables['view']->field)) > 0 ? FALSE : TRUE;

--- a/islandora.module
+++ b/islandora.module
@@ -515,7 +515,7 @@ function islandora_preprocess_views_view_table(&$variables) {
 
   // Check for a weight selector field.
   foreach ($variables['view']->field as $field_key => $field) {
-    if ($field->options['plugin_id'] == 'integer_weight_selector') {
+    if (isset($field->options['plugin_id']) && $field->options['plugin_id'] == 'integer_weight_selector') {
 
       // Check if the weight selector is on the first column.
       $is_first_column = array_search($field_key, array_keys($variables['view']->field)) > 0 ? FALSE : TRUE;


### PR DESCRIPTION
# What does this Pull Request do?

We are adding the drupal/flag module to our Islandora instance to allow end users to create bookmarks (favourites) for repository items.

We see the warning "Warning: Undefined array key "plugin_id" in islandora_preprocess_views_view_table() (line 523 of modules/contrib/islandora/islandora.module)" when accessing a view that the drupal/flag module provides.

This PR eliminates this warning by checking for the array key using isset() before trying to use it.

# How should this be tested?

The code modified is related to the "integer weight field" functionality.  Test that nothing is broken by testing the "Re-order children" page.

# Interested parties
@Islandora/committers
