### PR TITLE
Upgrade the EVA to 3.0.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "drupal/jwt": "^1.0.0-beta5",
     "drupal/filehash": "^1.1 || ^2",
     "drupal/prepopulate" : "^2.2",
-    "drupal/eva" : "^2.0",
+    "drupal/eva" : "^3.0",
     "drupal/features" : "^3.7",
     "drupal/migrate_plus" : "^5.1",
     "drupal/migrate_source_csv" : "^3.4",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "drupal/prepopulate" : "^2.2",
     "drupal/eva" : "^3.0",
     "drupal/features" : "^3.7",
-    "drupal/migrate_plus" : "^5.1",
+    "drupal/migrate_plus" : "^5.1 || ^6",
     "drupal/migrate_source_csv" : "^3.4",
     "drupal/token" : "^1.3",
     "drupal/flysystem" : "^2.0@alpha",


### PR DESCRIPTION
**GitHub Issue**:
* https://github.com/Islandora/documentation/issues/2186

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What does this Pull Request do?

Upgrades the eva module to the supported version (3). 

# What's new?
A in-depth description of the changes made by this PR. Technical details and
 possible side effects.

* Changes EVA from ^2.0 to ^3.0
* Does this change add any new dependencies?  no
* Does this change require any other modifications to be made to the repository 
 (i.e. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# How should this be tested?

Load the starter site. (I'm not sure you can update individual modules when using the Install Profile? Also it's tied to Defaults)
Update your islandora to this branch.
You should no longer get the Drupal error message that one of your modules is not supported.

# Documentation Status

n/a

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
