### PR TITLE
Filehash Fixes and improve checksum view

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "islandora/jsonld": "^2",
     "stomp-php/stomp-php": "4.* || ^5",
     "drupal/jwt": "^1.0.0-beta5",
-    "drupal/filehash": "^1.1 || ^2",
+    "drupal/filehash": "^2",
     "drupal/prepopulate" : "^2.2",
     "drupal/eva" : "^2.0",
     "drupal/features" : "^3.7",

--- a/islandora.module
+++ b/islandora.module
@@ -181,7 +181,8 @@ function islandora_file_insert(FileInterface $file) {
  */
 function islandora_file_update(FileInterface $file) {
   // Exit early if unchanged.
-  if ($file->filehash != NULL && $file->original->filehash != NULL && $file->filehash['sha1'] == $file->original->filehash['sha1']) {
+  if ($file->hasField('sha1') && $file->original->hasField('sha1')
+    && $file->sha1->getString() == $file->original->sha1->getString()) {
     return;
   }
 

--- a/modules/islandora_core_feature/config/install/filehash.settings.yml
+++ b/modules/islandora_core_feature/config/install/filehash.settings.yml
@@ -18,7 +18,7 @@ algos:
   sha3_384: '0'
   sha3_512: '0'
 dedupe: 0
-rehash: false
-original: false
+rehash: true
+original: true
 dedupe_original: false
 mime_types: {  }

--- a/modules/islandora_core_feature/config/install/filehash.settings.yml
+++ b/modules/islandora_core_feature/config/install/filehash.settings.yml
@@ -1,5 +1,24 @@
 algos:
-  sha1: sha1
+  blake2b_128: '0'
+  blake2b_160: '0'
+  blake2b_224: '0'
+  blake2b_256: '0'
+  blake2b_384: '0'
+  blake2b_512: '0'
   md5: '0'
+  sha1: sha1
+  sha224: '0'
   sha256: '0'
+  sha384: '0'
+  sha512_224: '0'
+  sha512_256: '0'
+  sha512: '0'
+  sha3_224: '0'
+  sha3_256: '0'
+  sha3_384: '0'
+  sha3_512: '0'
 dedupe: 0
+rehash: false
+original: false
+dedupe_original: false
+mime_types: {  }

--- a/modules/islandora_core_feature/config/install/views.view.file_checksum.yml
+++ b/modules/islandora_core_feature/config/install/views.view.file_checksum.yml
@@ -1,14 +1,14 @@
 langcode: en
 status: true
 dependencies:
-  enforced:
-    module:
-      - islandora_core_feature
   module:
     - file
     - filehash
     - rest
     - serialization
+  enforced:
+    module:
+      - islandora_core_feature
 id: file_checksum
 label: 'File Checksum'
 module: views
@@ -16,71 +16,24 @@ description: 'Exposes a REST endpoint for getting the checksum of a File'
 tag: ''
 base_table: file_managed
 base_field: fid
-core: 8.x
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: none
-        options: {  }
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: mini
-        options:
-          items_per_page: 10
-          offset: 0
-          id: 0
-          total_pages: null
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-          tags:
-            previous: ‹‹
-            next: ››
-      style:
-        type: serializer
-      row:
-        type: 'entity:file'
-        options:
-          relationship: none
-          view_mode: default
       fields:
         sha1:
           id: sha1
-          table: filehash
+          table: file_managed
           field: sha1
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: file
+          entity_field: sha1
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -92,7 +45,7 @@ display:
             external: false
             replace_spaces: false
             path_case: none
-            trim_whitespace: false
+            trim_whitespace: true
             alt: ''
             rel: ''
             link_class: ''
@@ -106,7 +59,7 @@ display:
             more_link: false
             more_link_text: ''
             more_link_path: ''
-            strip_tags: false
+            strip_tags: true
             trim: false
             preserve_tags: ''
             html: false
@@ -122,13 +75,55 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          plugin_id: standard
-      filters: {  }
-      sorts: {  }
-      header: {  }
-      footer: {  }
+          click_sort_column: value
+          type: filehash
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      pager:
+        type: mini
+        options:
+          offset: 0
+          items_per_page: 10
+          total_pages: null
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: none
+        options: {  }
+      cache:
+        type: tag
+        options: {  }
       empty: {  }
-      relationships: {  }
+      sorts: {  }
       arguments:
         fid:
           id: fid
@@ -137,6 +132,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: file
+          entity_field: fid
+          plugin_id: file_fid
           default_action: 'not found'
           exception:
             value: all
@@ -151,8 +149,8 @@ display:
           summary_options:
             base_path: ''
             count: true
-            items_per_page: 25
             override: false
+            items_per_page: 25
           summary:
             sort_order: asc
             number_of_records: 0
@@ -164,31 +162,46 @@ display:
           validate_options: {  }
           break_phrase: false
           not: false
-          entity_type: file
-          entity_field: fid
-          plugin_id: file_fid
+      filters: {  }
+      style:
+        type: serializer
+      row:
+        type: 'entity:file'
+        options:
+          relationship: none
+          view_mode: default
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      header: {  }
+      footer: {  }
       display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:
+        - 'languages:language_content'
         - 'languages:language_interface'
         - request_format
         - url
         - url.query_args
       tags: {  }
   rest_export_1:
-    display_plugin: rest_export
     id: rest_export_1
     display_title: 'REST export'
+    display_plugin: rest_export
     position: 1
     display_options:
-      display_extenders: {  }
-      path: checksum/%file
       pager:
         type: some
         options:
-          items_per_page: 10
           offset: 0
+          items_per_page: 10
       style:
         type: serializer
         options:
@@ -198,6 +211,8 @@ display:
         type: data_field
         options:
           field_options: {  }
+      display_extenders: {  }
+      path: checksum/%file
       auth:
         - basic_auth
         - jwt_auth
@@ -205,7 +220,9 @@ display:
     cache_metadata:
       max-age: -1
       contexts:
+        - 'languages:language_content'
         - 'languages:language_interface'
         - request_format
         - url
       tags: {  }
+

--- a/modules/islandora_core_feature/config/install/views.view.file_checksum.yml
+++ b/modules/islandora_core_feature/config/install/views.view.file_checksum.yml
@@ -6,6 +6,7 @@ dependencies:
     - filehash
     - rest
     - serialization
+    - user
   enforced:
     module:
       - islandora_core_feature
@@ -88,6 +89,70 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+        original_sha1:
+          id: original_sha1
+          table: file_managed
+          field: original_sha1
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: file
+          entity_field: original_sha1
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: true
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: true
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: false
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: filehash
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
       pager:
         type: mini
         options:
@@ -117,8 +182,9 @@ display:
           sort_asc_label: Asc
           sort_desc_label: Desc
       access:
-        type: none
-        options: {  }
+        type: perm
+        options:
+          perm: 'view checksums'
       cache:
         type: tag
         options: {  }
@@ -190,6 +256,7 @@ display:
         - request_format
         - url
         - url.query_args
+        - user.permissions
       tags: {  }
   rest_export_1:
     id: rest_export_1
@@ -211,7 +278,18 @@ display:
         type: data_field
         options:
           field_options: {  }
-      display_extenders: {  }
+      display_extenders:
+        matomo:
+          enabled: false
+          keyword_gets: ''
+          keyword_behavior: first
+          keyword_concat_separator: ' '
+          category_behavior: none
+          category_gets: ''
+          category_concat_separator: ' '
+          category_fallback: ''
+          category_facets: {  }
+          category_facets_concat_separator: ', '
       path: checksum/%file
       auth:
         - basic_auth
@@ -224,5 +302,6 @@ display:
         - 'languages:language_interface'
         - request_format
         - url
+        - user.permissions
       tags: {  }
 


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1931 

Islandora requires the filehash module, and provides (in the core features) settings(!!) and a view that use it.

Since the update to filehash 2, the view has been broken. (Filehash 2 stores data in fields on files, so the plugin handler was different)

Also! Filehash 2 provides some great features:
* store the "original" checksum of the file (on the creation of the file entity)
* re-hash the checksum any time the file changes.

Is it the be-all-and-end-all of preservation fixity for a repository? No! lol, but we can do a lot more with it now than we could before.

# What does this Pull Request do?

Updates the settings and view to work with the new filehash module.

# What's new?

* Turn on features to re-hash files when changed, and store the hash of the original.
* For the view that exposes checksums at /checksum/{file_id}, include the original hash, and lock it down so that you need 'View checksums' permission to see the view (That permission had been defined, but seemingly never used?)
* Does this change add any new dependencies?  Changes dependencies - filehash 2.
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? Upgrade will involve regenerating filehashes.
* Could this change impact execution of existing code? I can't tell if the view's contents are used anywhere. Even if they are, I added an additional element and left what was in place.

# How should this be tested?

Load the starter site. (or try to update filehash to 2.x on the install profile?)
Go to the View "File checksums" and see it's missing a handler.
Load this PR.
Go to the Islandora Core Feature, in Features. 
Select views.view.file_checksum and filehash.settings, and import the changes.
Create some test files.
Go to the View. It should not be broken. Test at /checksums/1 (replace 1 with your file id) and see a JSON array containing checksums, including 'sha1` and `original_sha1`

<img width="508" alt="Screen Shot 2022-11-30 at 11 03 36 AM" src="https://user-images.githubusercontent.com/1943338/204833448-d8dc03ae-d9a4-4a6a-baa9-874b9a3e64fe.png">

Note: Derivatives will have empty original_sha1.  The derivative code `create`s the file empty, then `update`s it with the content. 

# Documentation Status

* Does this change existing behaviour that's currently documented? lol, not documented
* Does this change require new pages or sections of documentation? yeah, maybe
* Who does this need to be documented for? site builders
* Associated documentation pull request(s): ___  or documentation issue ___

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
