### PR TITLE
Eliminate warnings when using NodeHasMediaUse views filter.

### DIFF
--- a/src/Plugin/views/filter/NodeHasMediaUse.php
+++ b/src/Plugin/views/filter/NodeHasMediaUse.php
@@ -18,10 +18,10 @@ class NodeHasMediaUse extends FilterPluginBase {
    * {@inheritdoc}
    */
   protected function defineOptions() {
-    return [
-      'use_uri' => ['default' => NULL],
-      'negated' => ['default' => FALSE],
-    ];
+    $options = parent::defineOptions();
+    $options['use_uri'] = ['default' => NULL];
+    $options['negated'] = ['default' => FALSE];
+    return $options;
   }
 
   /**


### PR DESCRIPTION
# What does this Pull Request do?

It eliminates these warnings when using the "node has media use" filter in views:

```
    Warning: Undefined array key "operator" in Drupal\views\Plugin\views\filter\FilterPluginBase->init() (line 95 of core/modules/views/src/Plugin/views/filter/FilterPluginBase.php).
    Warning: Undefined array key "value" in Drupal\views\Plugin\views\filter\FilterPluginBase->init() (line 96 of core/modules/views/src/Plugin/views/filter/FilterPluginBase.php).
    Warning: Undefined array key "group_info" in Drupal\views\Plugin\views\filter\FilterPluginBase->init() (line 97 of core/modules/views/src/Plugin/views/filter/FilterPluginBase.php).
    Warning: Trying to access array offset on value of type null in Drupal\views\Plugin\views\filter\FilterPluginBase->init() (line 97 of core/modules/views/src/Plugin/views/filter/FilterPluginBase.php).
```

# What's new?

This PR makes a small change to in NodeHasMediaUse::defineOptions to call its parent to populate the options array.  The parent defines the expected properties, and all warnings go away.

# How should this be tested?

A description of what steps someone could take to:
* Create a simple view which uses this filter.  I don't know if it makes a different, but in my case I created a view to find missing derivatives, so I am negating the condition.
* confirm that the view is producing accurate results (e.g. that the filter is still working as expected) and that no warnings are showing.  The warnings show up for me when editing the view as well as when using it.

# Interested parties
@Islandora/committers
