### PR TITLE
Fix errors when OCR field not set.

### DIFF
--- a/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
+++ b/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
@@ -205,11 +205,13 @@ class IIIFManifest extends StylePluginBase {
             continue;
           }
 
-          $ocrs = $entity->{$ocrField->definition['field_name']};
+          if (!is_null($ocrField)) {
+            $ocrs = $entity->{$ocrField->definition['field_name']};
+            $ocr = isset($ocrs[$i]) ? $ocrs[$i] : FALSE;
+          }
 
           // Create the IIIF URL for this file
           // Visiting $iiif_url will resolve to the info.json for the image.
-          $ocr = isset($ocrs[$i]) ? $ocrs[$i] : FALSE;
           $file_url = $image->entity->createFileUrl(FALSE);
           $mime_type = $image->entity->getMimeType();
           $iiif_url = rtrim($iiif_address, '/') . '/' . urlencode($file_url);


### PR DESCRIPTION
**GitHub Issue**: n/a

# What does this Pull Request do?

Fixes Drupal Error Log messages:

```
Notice: Trying to get property 'definition' of non-object in Drupal\islandora_iiif\Plugin\views\style
\IIIFManifest->getTileSourceFromRow() (line 208 of /var/www/html/drupal/web/modules/contrib/islandora/modules
/islandora_iiif/src/Plugin/views/style/IIIFManifest.php) 
```

# What's new?

Do a check that `$ocrfield` isn't null before asking for its `->definition`.

* Does this change add any new dependencies?  no
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)?  no
* Could this change impact execution of existing code? no

# How should this be tested?

Make some content that can show up in an IIIF viewer using a manifest. Don't set up OCR (I didn't know you could set up OCR!) This also works if you go to  the IIIF Manifest view, and use the preview function. Render the view (or click Preview) and you get errors in the logs like the one above.

With this PR: no errors.

# Documentation Status

* Does this change existing behaviour that's currently documented? no
* Does this change require new pages or sections of documentation? no
* Who does this need to be documented for? no
* Associated documentation pull request(s): ___  or documentation issue ___ n/a

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
