### PR TITLE
Replace deprecated annotation 'context' with 'context_definitions'

### DIFF
--- a/src/Plugin/Condition/NodeReferencedByNode.php
+++ b/src/Plugin/Condition/NodeReferencedByNode.php
@@ -16,7 +16,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * @Condition(
  *   id = "node_referenced_by_node",
  *   label = @Translation("Node is referenced by other nodes"),
- *   context = {
+ *   context_definitions = {
  *     "node" = @ContextDefinition("entity:node", required = TRUE , label = @Translation("node"))
  *   }
  * )


### PR DESCRIPTION
# What does this Pull Request do?
Addresses a deprecation that was missed.

# What's new?
Just an extension of the work done in https://github.com/Islandora/islandora/pull/764.
The deprecated annotation resulted in the 'Node reference by node' Condition failing to work in an environment using Drupal 9.4.

# How should this be tested?
The 'Node referenced by node' Condition should now work as expected.

Honestly with how minimal this is, a full test case seems a little over-the-top. However, https://github.com/Islandora/islandora/pull/808 can be referenced for how to test the functionality of this Condition Plugin.

# Additional Notes:
There was a cleanup done for this deprecation in https://github.com/Islandora/islandora/pull/764 before the 'NodeReferencedByNode' condition was made, then the deprecated annotation must have just been missed in reviewing https://github.com/Islandora/islandora/pull/808.

# Interested parties
@Islandora/committers
