### PR TITLE
fix for deprecated Symfony Event class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "drupal/file_replace": "^1.1",
     "drupal/filehash": "^2",
     "drupal/flysystem" : "^2.0@alpha",
-    "drupal/jwt": "^1.0",
+    "drupal/jwt": "^1.1",
     "drupal/migrate_plus" : "^5.1 || ^6",
     "drupal/migrate_source_csv" : "^3.4",
     "drupal/prepopulate" : "^2.2",

--- a/src/Event/StompHeaderEvent.php
+++ b/src/Event/StompHeaderEvent.php
@@ -6,7 +6,7 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Session\AccountInterface;
 
 use Symfony\Component\HttpFoundation\ParameterBag;
-use Symfony\Component\EventDispatcher\Event;
+use Drupal\Component\EventDispatcher\Event;
 
 /**
  * Event used to build headers for STOMP.

--- a/src/EventGenerator/EmitEvent.php
+++ b/src/EventGenerator/EmitEvent.php
@@ -160,8 +160,8 @@ abstract class EmitEvent extends ConfigurableActionBase implements ContainerFact
       $data = $this->generateData($entity);
 
       $event = $this->eventDispatcher->dispatch(
-        StompHeaderEvent::EVENT_NAME,
-        new StompHeaderEvent($entity, $user, $data, $this->getConfiguration())
+        new StompHeaderEvent($entity, $user, $data, $this->getConfiguration()),
+        StompHeaderEvent::EVENT_NAME
       );
 
       $message = new Message(


### PR DESCRIPTION
**GitHub Issue**: #927 

# What does this Pull Request do?

Updates deprecated Symfony Event class with the new Drupal one and updates the argument order for the dispatch function as specified in https://www.drupal.org/node/3159012.

# What's new?

* Does this change add any new dependencies? No, although it now uses the JWT module's 1.1 release.
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? No.
* Could this change impact execution of existing code? No.

# How should this be tested?

## Short version

Smoke test. Does anything break?

## Longer version

1. `composer require webprofiler`
2. `drush en -y webprofiler`
3. `drush cr` = 💥
4. Apply PR
5. `drush cr` = 👍 (unless you have other modules enabled with the same problem)

# Documentation Status

* Does this change existing behaviour that's currently documented? No.
* Does this change require new pages or sections of documentation? No.
* Who does this need to be documented for? No one.

# Interested parties
@Islandora/committers
