### PR TITLE
Update MediaSourceService.php

### DIFF
--- a/src/MediaSource/MediaSourceService.php
+++ b/src/MediaSource/MediaSourceService.php
@@ -295,7 +295,7 @@ class MediaSourceService {
         $error_current_user = shell_exec('whoami');
         $sanitized_current_user = str_replace(array("\n", "\r"), '', $error_current_user);
         $error_message = "The destination directory does not exist, could not be created, or is not writable by $sanitized_current_user: $directory";
-        watchdog('media_source_service', $error_message, [], WATCHDOG_ERROR);
+        $this->logger->error($error_message);
         throw new HttpException(500, "An error occurred while processing your request. Please contact the website administrator.");
       }
 

--- a/src/MediaSource/MediaSourceService.php
+++ b/src/MediaSource/MediaSourceService.php
@@ -294,7 +294,9 @@ class MediaSourceService {
         $parent_directory = dirname($directory);
         $error_current_user = shell_exec('whoami');
         $sanitized_current_user = str_replace(array("\n", "\r"), '', $error_current_user);
-        throw new HttpException(500, "The destination directory does not exist, could not be created, or is not writable by $sanitized_current_user: $directory");
+        $error_message = "The destination directory does not exist, could not be created, or is not writable by $sanitized_current_user: $directory";
+        watchdog('media_source_service', $error_message, [], WATCHDOG_ERROR);
+        throw new HttpException(500, "An error occurred while processing your request. Please contact the website administrator.");
       }
 
       // Copy over the file content.

--- a/src/MediaSource/MediaSourceService.php
+++ b/src/MediaSource/MediaSourceService.php
@@ -290,17 +290,11 @@ class MediaSourceService {
 
       $directory = $this->fileSystem->dirname($content_location);
       
-      // Check if the directory is writable.
-      if (!is_writable(dirname($directory))) {
+      if (!$this->fileSystem->prepareDirectory($directory, FileSystemInterface::CREATE_DIRECTORY | FileSystemInterface::MODIFY_PERMISSIONS)) {
         $parent_directory = dirname($directory);
         $error_current_user = shell_exec('whoami');
         $sanitized_current_user = str_replace(array("\n", "\r"), '', $error_current_user);
-        throw new HttpException(500, "The user '$sanitized_current_user' does not have permissions to write to: '$parent_directory' . Error");
-      }
-
-
-      if (!$this->fileSystem->prepareDirectory($directory, FileSystemInterface::CREATE_DIRECTORY | FileSystemInterface::MODIFY_PERMISSIONS)) {
-        throw new HttpException(500, "The destination directory does not exist, could not be created, or is not writable: $directory");
+        throw new HttpException(500, "The destination directory does not exist, could not be created, or is not writable by $sanitized_current_user: $directory");
       }
 
       // Copy over the file content.

--- a/src/MediaSource/MediaSourceService.php
+++ b/src/MediaSource/MediaSourceService.php
@@ -289,8 +289,18 @@ class MediaSourceService {
       }
 
       $directory = $this->fileSystem->dirname($content_location);
+      
+      // Check if the directory is writable.
+      if (!is_writable(dirname($directory))) {
+        $parent_directory = dirname($directory);
+        $error_current_user = shell_exec('whoami');
+        $sanitized_current_user = str_replace(array("\n", "\r"), '', $error_current_user);
+        throw new HttpException(500, "The user '$sanitized_current_user' does not have permissions to write to: '$parent_directory' . Error");
+      }
+
+
       if (!$this->fileSystem->prepareDirectory($directory, FileSystemInterface::CREATE_DIRECTORY | FileSystemInterface::MODIFY_PERMISSIONS)) {
-        throw new HttpException(500, "The destination directory does not exist, could not be created, or is not writable");
+        throw new HttpException(500, "The destination directory does not exist, could not be created, or is not writable: $directory");
       }
 
       // Copy over the file content.

--- a/src/MediaSource/MediaSourceService.php
+++ b/src/MediaSource/MediaSourceService.php
@@ -289,11 +289,11 @@ class MediaSourceService {
       }
 
       $directory = $this->fileSystem->dirname($content_location);
-      
+
       if (!$this->fileSystem->prepareDirectory($directory, FileSystemInterface::CREATE_DIRECTORY | FileSystemInterface::MODIFY_PERMISSIONS)) {
         $parent_directory = dirname($directory);
         $error_current_user = shell_exec('whoami');
-        $sanitized_current_user = str_replace(array("\n", "\r"), '', $error_current_user);
+        $sanitized_current_user = str_replace(["\n", "\r"], '', $error_current_user);
         $error_message = "The destination directory does not exist, could not be created, or is not writable by $sanitized_current_user: $directory";
         $this->logger->error($error_message);
         throw new HttpException(500, "An error occurred while processing your request. Please contact the website administrator.");


### PR DESCRIPTION
I'm not sure if this is ideal or if it's just overwriting the existing check https://github.com/Islandora/islandora/blob/5585f89e9a7607cf0d92c70337c8286e16fc0523/src/MediaSource/MediaSourceService.php#L302

**GitHub Issue**: N/A

# What does this Pull Request do?
When the media script tries to write to a directory (like `public://`) and the path is not set or has the wrong permissions, the error message could provide more informative information and be less cryptic. 

# What's new?
* Checking if the directory is writeable by the PHP script.
* If it doesn't have permissions then it outputs the username that the script is running as and the directory it's trying to write to in the thrown error. 

# How should this be tested?
```shell
# Change the permissions to not allow nginx to write a new directory to the public folders.
chown -R 1000:nginx web/sites/default/files
# Clear your logs
drush watchdog:delete all -y
drush cr
```

### Trigger media script to generate derivative
Go to /admin/content and click the drop-down and select "Image - Generate a thumbnail from an original file" and in the list of content items check the box next to an object that has a **model** = **Image** 
![content_regen_tn](https://user-images.githubusercontent.com/2738244/219404544-5fb7c653-d71e-4e96-a92b-77cee170804c.png)

It really doesn't matter which derivative you generate. This just needs to create a file. You just create a new media or something. All that matters is that the media script is trying to write to the error logs when a file save/update fails due to permissions issues.

## To check that it worked
```shell
 # Run this to see the error message or go to /admin/reports/dblog
drush watchdog:show --extended

# output should include " user 'xxxx' does not have permissions to write to: 'xxxx' .
.... Symfony\Component\HttpKernel\Exception\HttpException: The user 'nginx' does not have permission to write to: 'public:' . Error .....
```
In this example, the directory resolves to `public://` instead of a real absolute path.

To reset back and test with the proper permissions to verify this doesn't trigger when it shouldn't
```shell
# clear the logs first
drush watchdog:delete all -y
# Change permissions back 
chown -R nginx:nginx web/sites/default/files
# You may need to reset your read/write permission
chmod -R 2775 web/sites/default/files
drush cr
```

An explanation for the above chmod command.
> The 2 means that the group id will be preserved for any new files created in this directory. What that means is that nginx(or whatever your HTTP user is) will always be the group on any files, thereby ensuring that web server and the user will both always have write permissions to any new files that are placed in this directory. The first 7 means that the owner (example) can R (Read) W (Write) and X (Execute) any files in here. The second 7 means that group (www-data) can also R W and X any files in this directory. Finally, the 5 means that other users can R and X files, but not write.

Now run the instructions above on "Trigger media script to generate derivative" and then check the error logs. There should be no error message.

# Documentation Status

* Does this change existing behaviour that's currently documented? No
* Does this change require new pages or sections of documentation? No
* Who does this need to be documented for? N/A
* Associated documentation pull request(s): _0_  or documentation issue _0_

# Additional Notes:
N/A

# Interested parties
@Islandora/committers
