### PR TITLE
Update maintainer and sponsor info

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,12 +91,11 @@ Having problems or solved a problem? Check out the Islandora google groups for a
 
 Current maintainers:
 
-* [Islandora Technical Advisory Group]([https://github.com/dannylamb](https://github.com/Islandora/islandora-community/wiki/Technical-Advisory-Group-%28TAG%29))
+* [Islandora Technical Advisory Group](https://github.com/Islandora/islandora-community/wiki/Technical-Advisory-Group-%28TAG%29)
 
 ## Sponsors
 
-* American Philosophical Society
-
+* [American Philosophical Society](https://www.amphilsoc.org/)
 * [Born-Digital, Inc.](https://www.born-digital.com/)
 * [discoverygarden inc.](https://www.discoverygarden.ca/)
 * [LYRASIS](https://www.lyrasis.org/)

--- a/README.md
+++ b/README.md
@@ -91,21 +91,22 @@ Having problems or solved a problem? Check out the Islandora google groups for a
 
 Current maintainers:
 
-* [Danny Lamb](https://github.com/dannylamb)
+* [Islandora Technical Advisory Group]([https://github.com/dannylamb](https://github.com/Islandora/islandora-community/wiki/Technical-Advisory-Group-%28TAG%29))
 
 ## Sponsors
 
-* UPEI
-* discoverygarden inc.
-* LYRASIS
-* McMaster University
-* University of Limerick
-* York University
-* University of Manitoba
-* Simon Fraser University
-* PALS
 * American Philosophical Society
-* Common Media Inc.
+
+* [Born-Digital, Inc.](https://www.born-digital.com/)
+* [discoverygarden inc.](https://www.discoverygarden.ca/)
+* [LYRASIS](https://www.lyrasis.org/)
+* [McMaster University](https://www.mcmaster.ca/)
+* [PALS](https://www.mnpals.org/)
+* [University of Limerick](https://www.ul.ie/)
+* [University of Manitoba](https://umanitoba.ca/)
+* [UPEI](https://www.upei.ca/)
+* [Simon Fraser University](https://www.sfu.ca/)
+* [York University](https://www.yorku.ca/)
 
 ## Development
 


### PR DESCRIPTION
Maintainer switched to TAG; Sponsors sorted, one correction, and links added