### PR TITLE
Issue #973 Add hooks to IIIF manifest Views Style plugin.

### DIFF
--- a/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
+++ b/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
@@ -94,7 +94,7 @@ class IIIFManifest extends StylePluginBase {
 
   /**
    * Module Handler for running hooks.
-   * 
+   *
    * @var \Drupal\Core\Extention\ModuleHandlerInterface
    */
   protected $moduleHandler;
@@ -314,7 +314,7 @@ class IIIFManifest extends StylePluginBase {
           // Give other modules a chance to alter the canvas.
           $alter_options = [
             'options' => $this->options,
-            'views_plugin' => $this
+            'views_plugin' => $this,
           ];
           $this->moduleHandler->alter('islandora_iiif_manifest_canvas', $tmp_canvas, $row, $alter_options);
 

--- a/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
+++ b/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
@@ -4,6 +4,7 @@ namespace Drupal\islandora_iiif\Plugin\views\style;
 
 use Drupal\views\Plugin\views\style\StylePluginBase;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use \Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Url;
@@ -90,11 +91,16 @@ class IIIFManifest extends StylePluginBase {
    * @var \Drupal\Core\Messenger\MessengerInterface
    */
   protected $messenger;
+  
+  /**
+   * @var \Drupal\Core\Extention\ModuleHandlerInterface;
+   */
+  protected $moduleHandler;
 
   /**
    * {@inheritdoc}
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, SerializerInterface $serializer, Request $request, ImmutableConfig $iiif_config, EntityTypeManagerInterface $entity_type_manager, FileSystemInterface $file_system, Client $http_client, MessengerInterface $messenger) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, SerializerInterface $serializer, Request $request, ImmutableConfig $iiif_config, EntityTypeManagerInterface $entity_type_manager, FileSystemInterface $file_system, Client $http_client, MessengerInterface $messenger, ModuleHandlerInterface $moduleHandler) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
 
     $this->serializer = $serializer;
@@ -104,6 +110,7 @@ class IIIFManifest extends StylePluginBase {
     $this->fileSystem = $file_system;
     $this->httpClient = $http_client;
     $this->messenger = $messenger;
+    $this->moduleHandler = $moduleHandler;
   }
 
   /**
@@ -120,8 +127,19 @@ class IIIFManifest extends StylePluginBase {
       $container->get('entity_type.manager'),
       $container->get('file_system'),
       $container->get('http_client'),
-      $container->get('messenger')
+      $container->get('messenger'),
+      $container->get('module_handler')
     );
+  }
+
+  /**
+   * Return the request property.
+   * 
+   * @return \Symfony\Component\HttpFoundation\Request
+   *   The Symfony request object
+   */
+  public function getRequest() {
+    return $this->request;
   }
 
   /**
@@ -169,6 +187,9 @@ class IIIFManifest extends StylePluginBase {
     unset($this->view->row_index);
 
     $content_type = 'json';
+
+    // Give other modules a chance to alter the manifest.
+    $this->moduleHandler->alter('islandora_iiif_manifest', $json, $this);
 
     return $this->serializer->serialize($json, $content_type, ['views_style_plugin' => $this]);
   }
@@ -288,11 +309,15 @@ class IIIFManifest extends StylePluginBase {
             ];
           }
 
+          // Give other modules a chance to alter the canvas
+          $alter_options = ['options' => $this->options, 'views_plugin' => $this];
+          $this->moduleHandler->alter('islandora_iiif_manifest_canvas', $tmp_canvas, $row, $alter_options);
+
           $canvases[] = $tmp_canvas;
         }
       }
     }
-
+    
     return $canvases;
   }
 

--- a/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
+++ b/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
@@ -4,7 +4,7 @@ namespace Drupal\islandora_iiif\Plugin\views\style;
 
 use Drupal\views\Plugin\views\style\StylePluginBase;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
-use \Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Url;
@@ -91,9 +91,11 @@ class IIIFManifest extends StylePluginBase {
    * @var \Drupal\Core\Messenger\MessengerInterface
    */
   protected $messenger;
-  
+
   /**
-   * @var \Drupal\Core\Extention\ModuleHandlerInterface;
+   * Module Handler for running hooks.
+   * 
+   * @var \Drupal\Core\Extention\ModuleHandlerInterface
    */
   protected $moduleHandler;
 
@@ -134,7 +136,7 @@ class IIIFManifest extends StylePluginBase {
 
   /**
    * Return the request property.
-   * 
+   *
    * @return \Symfony\Component\HttpFoundation\Request
    *   The Symfony request object
    */
@@ -309,15 +311,18 @@ class IIIFManifest extends StylePluginBase {
             ];
           }
 
-          // Give other modules a chance to alter the canvas
-          $alter_options = ['options' => $this->options, 'views_plugin' => $this];
+          // Give other modules a chance to alter the canvas.
+          $alter_options = [
+            'options' => $this->options,
+            'views_plugin' => $this
+          ];
           $this->moduleHandler->alter('islandora_iiif_manifest_canvas', $tmp_canvas, $row, $alter_options);
 
           $canvases[] = $tmp_canvas;
         }
       }
     }
-    
+
     return $canvases;
   }
 


### PR DESCRIPTION
**GitHub Issue**: [\[FEATURE\]  Add hooks to let other modules modify IIIF manifest](https://github.com/Islandora/islandora/issues/937)

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What does this Pull Request do?


Allows other modules to modify the IIIF manifests via Drupal hooks.

# What's new?

Two hooks, one to allow modules to modify the IIIF manifest after it is fully generated but before it is serialized to JSON. Another to modify each Views result row individually.

Also adds a getRequest() method to the plugin class so the request object protected variable can be accessed.

* Does this change add any new dependencies?  No
* Does this change require any other modifications to be made to the repository No
* Could this change impact execution of existing code? No

# How should this be tested?

In any .module file, create a function called [modulename]_islandora_iiif_manifest_alter(&$json, &$views_plugin). Clear your cache and see that the hook gets run.

# Documentation Status

* Does this change existing behaviour that's currently documented? No
* Does this change require new pages or sections of documentation? No
* Who does this need to be documented for? N/A
* Associated documentation pull request(s): ___  or documentation issue ___

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @adam-vessey  @Islandora/committers
