### PR TITLE
Remove double-slash from IIIF canvas Ids.

### DIFF
--- a/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
+++ b/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
@@ -136,7 +136,7 @@ class IIIFManifest extends StylePluginBase {
       $request_url = $this->request->getRequestUri();
       // Strip off the last URI component to get the base ID of the URL.
       // @todo assumming the view is a path like /node/1/manifest.json
-      $url_components = explode('/', $request_url);
+      $url_components = explode('/', trim($request_url, '/'));
       array_pop($url_components);
       $content_path = implode('/', $url_components);
       $iiif_base_id = $request_host . '/' . $content_path;


### PR DESCRIPTION
**GitHub Issue**: [\[BUG\] islandora_iiif generating incorrect canvas IDs ](https://github.com/Islandora/islandora/issues/939)



# What does this Pull Request do?

Fixes a bug where canvas Ids in IIIF manifests would have double slashes in the URL.

# What's new?

* Does this change add any new dependencies? No
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)?  No
* Could this change impact execution of existing code? Yes, if code was relying on the existing canvas URLs.

# How should this be tested?

A description of what steps someone could take to:
* Reproduce the problem you are fixing (if applicable)

See steps in issue. 

# Documentation Status

* Does this change existing behaviour that's currently documented? No
* Does this change require new pages or sections of documentation? No
* Who does this need to be documented for? N/A
* Associated documentation pull request(s): ___  or documentation issue ___

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers @bibliophileaxe 

 @adam-vessey 