### PR TITLE
Issue #941: Only add <br/> tags to plain text extracted text fields.

### DIFF
--- a/modules/islandora_text_extraction/islandora_text_extraction.module
+++ b/modules/islandora_text_extraction/islandora_text_extraction.module
@@ -40,8 +40,8 @@ function islandora_text_extraction_media_presave(MediaInterface $media) {
       $file = File::load($file_id);
       if ($file) {
         $data = file_get_contents($file->getFileUri());
-        // Check if it's already markup like hOCR
-        if (substr($data, 0, 4) == '<xml') {
+        // Check if it's already markup like hOCR.
+        if (substr($data, 0, 5) == '<?xml') {
           return;
         }
         $data = nl2br($data);

--- a/modules/islandora_text_extraction/islandora_text_extraction.module
+++ b/modules/islandora_text_extraction/islandora_text_extraction.module
@@ -40,6 +40,10 @@ function islandora_text_extraction_media_presave(MediaInterface $media) {
       $file = File::load($file_id);
       if ($file) {
         $data = file_get_contents($file->getFileUri());
+        // Check if it's already markup like hOCR
+        if (substr($data, 0, 4) == '<xml') {
+          return;
+        }
         $data = nl2br($data);
         $media->set('field_edited_text', $data);
         $media->field_edited_text->format = 'basic_html';

--- a/modules/islandora_text_extraction/src/Controller/MediaSourceController.php
+++ b/modules/islandora_text_extraction/src/Controller/MediaSourceController.php
@@ -108,9 +108,8 @@ class MediaSourceController extends ControllerBase {
         $this->getLogger('islandora')->warning("Field $destination_field is not defined in  Media Type {$media->bundle()}");
       }
       if ($media->hasField($destination_text_field)) {
-        // TODO: The request actually has a malformed parameter string, ?text_format=plain_text?connection_close=true.
-        // But that's a Tesseract issue.
-        if (substr($request->query->get('text_format'), 0, 10) == 'plain_text' ) {
+        // @todo The request actually has a malformed parameter string, ?text_format=plain_text?connection_close=true.
+        if (substr($request->query->get('text_format'), 0, 10) == 'plain_text') {
           $contents = nl2br($contents);
         }
         $media->{$destination_text_field}->setValue($contents);

--- a/modules/islandora_text_extraction/src/Controller/MediaSourceController.php
+++ b/modules/islandora_text_extraction/src/Controller/MediaSourceController.php
@@ -108,7 +108,12 @@ class MediaSourceController extends ControllerBase {
         $this->getLogger('islandora')->warning("Field $destination_field is not defined in  Media Type {$media->bundle()}");
       }
       if ($media->hasField($destination_text_field)) {
-        $media->{$destination_text_field}->setValue(nl2br($contents));
+        // TODO: The request actually has a malformed parameter string, ?text_format=plain_text?connection_close=true.
+        // But that's a Tesseract issue.
+        if (substr($request->query->get('text_format'), 0, 10) == 'plain_text' ) {
+          $contents = nl2br($contents);
+        }
+        $media->{$destination_text_field}->setValue($contents);
       }
       else {
         $this->getLogger('islandora')->warning("Field $destination_text_field is not defined in Media Type {$media->bundle()}");


### PR DESCRIPTION
**GitHub Issue**: [\[BUG\] islandora_text_extraction inserting <br/> tags even when it shouldn't](https://github.com/Islandora/islandora/issues/941)

# What does this Pull Request do?

Checks the text format of an incoming extracted text field value, and only adds br tags if it is plain text.

# What's new?

* Does this change add any new dependencies?  No
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)?  No
* Could this change impact execution of existing code? No

# How should this be tested?



Set up a media such a a File that can take a TIFF being uploaded.

Add a field with type Text (Long) (not plain).

Create a custom action based on the text extraction action type.  Pick the field you created just now, and select hOCR as the text format.

Add a context action so this action is fired when the media is uploaded.

Create a Page node and add a media of the type you created above. Upload a TIFF file with embedded text.

Observe that no extra br tags are inserted into the field when the action is fired after saving the media.

# Documentation Status

* Does this change existing behaviour that's currently documented? No
* Does this change require new pages or sections of documentation? No
* Who does this need to be documented for? N/A
* Associated documentation pull request(s): ___  or documentation issue ___

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
 @ajstanley  