### PR TITLE
Issue #947 Add tokens for Original File filename, extension.

### DIFF
--- a/islandora.tokens.inc
+++ b/islandora.tokens.inc
@@ -19,6 +19,18 @@ function islandora_token_info() {
     'name' => t('Islandora Tokens'),
     'description' => t('Tokens for Islandora objects.'),
   ];
+  $node['media-original-file:filename'] = [
+    'name' => t('Media: Original File filename without extension.'),
+    'description' => t('File name without extension of original uploaded file associated with Islandora Object via Media.'),
+  ];
+  $node['media-original-file:basename'] = [
+    'name' => t('Media: Original File filename with extension.'),
+    'description' => t('File name with extension of original uploaded file associated with Islandora Object via Media.'),
+  ];
+  $node['media-original-file:extension'] = [
+    'name' => t('Media: Original File extension.'),
+    'description' => t('File extension of original uploaded file associated with Islandora Object via Media.'),
+  ];
   $node['media-thumbnail-image:url'] = [
     'name' => t('Media: Thumbnail Image URL.'),
     'description' => t('URL of Thumbnail Image associated with Islandora Object via Media.'),
@@ -70,6 +82,23 @@ function islandora_tokens($type, $tokens, array $data, array $options, Bubbleabl
     $islandoraUtils = \Drupal::service('islandora.utils');
     foreach ($tokens as $name => $original) {
       switch ($name) {
+        case 'media-original-file:basename':
+        case 'media-original-file:filename':
+        case 'media-original-file:extension':
+          $term = $islandoraUtils->getTermForUri('http://pcdm.org/use#OriginalFile');
+          $media = $islandoraUtils->getMediaWithTerm($data['node'], $term);
+          // Is there media?
+          if ($media) {
+            $file = \Drupal::service('islandora.media_source_service')->getSourceFile($media);
+            if (!empty($file)) {
+              $path_info = pathinfo($file->createFileUrl());
+              $key = explode(':', $name)[1];
+              if (array_key_exists($key, $path_info)) {
+                $replacements[$original] = $path_info[$key];
+              }
+            }
+          }
+          break;
         case 'media-thumbnail-image:url':
         case 'media_thumbnail_image:url':
           $term = $islandoraUtils->getTermForUri('http://pcdm.org/use#ThumbnailImage');


### PR DESCRIPTION
**GitHub Issue**: [Add tokens to get Original File filename](https://github.com/Islandora/islandora/issues/947)

# What does this Pull Request do?

Adds tokens to get info about the original uploaded file to help with derivative file names.

# What's new?

Adds three new tokens

- media-original-file:basename
- media-original-file:filename
- media-original-file:extension

* Does this change add any new dependencies?  No
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)?  No
* Could this change impact execution of existing code? No

# How should this be tested?

1. Go to the Actions page and edit an existing Derivative action
2. in the field for file name path and name, add one of the new tokens
3. Upload a new media that will trigger the derivative you edited
4. The new name should have the token you added in it.

# Documentation Status

* Does this change existing behaviour that's currently documented? No
* Does this change require new pages or sections of documentation?
* Who does this need to be documented for? N/A - Tokens are self-documenting


# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
