### PR TITLE
Issue #946: IIIF Manifest can Retrieve hOCR from a sibling media via Media Use tag

### DIFF
--- a/modules/islandora_iiif/README.md
+++ b/modules/islandora_iiif/README.md
@@ -1,4 +1,4 @@
-# Islandora IIIF 
+# Islandora IIIF
 
 [![Minimum PHP Version](https://img.shields.io/badge/php-%3E%3D%207.2-8892BF.svg?style=flat-square)](https://php.net/)
 [![Contribution Guidelines](http://img.shields.io/badge/CONTRIBUTING-Guidelines-blue.svg)](./CONTRIBUTING.md)
@@ -11,7 +11,7 @@ Provides IIIF manifests using views.
 ## Requirements
 
 - `islandora` and `islandora_core_feature`
-- A IIIF image server (such as Cantaloupe) 
+- A IIIF image server (such as Cantaloupe)
 
 ## Installation
 
@@ -31,6 +31,14 @@ $ drush en islandora_iiif
 You can set the following configuration at `admin/config/islandora/iiif`:
 - IIIF Image server location
   - The URL to your IIIF image server (without trailing slash).
+
+### Views Style Plugin
+
+This module implements a Views Style plugin. It provides the following settings:
+
+1. Tile Source: A field that was added to the views list of fields with the image to be served. This should be a File or Image type field on a Media.
+2. Structured Text field: This lets you specify a file field on the same entity as above where OCR text with positional data, e.g., hOCR can be found.
+3. Structured Text term: The Islandora term with a Media Use URI where the structured OCR text can be found. This is another option to the above for storing this data in a separate media related to the parent node, rather than on the same media.
 
 ## Documentation
 

--- a/modules/islandora_iiif/README.md
+++ b/modules/islandora_iiif/README.md
@@ -37,9 +37,7 @@ You can set the following configuration at `admin/config/islandora/iiif`:
 This module implements a Views Style plugin. It provides the following settings:
 
 1. Tile Source: A field that was added to the views list of fields with the image to be served. This should be a File or Image type field on a Media.
-2. Structured Text field: This lets you specify a file field on the same entity as above where OCR text with positional data, e.g., hOCR can be found.
-3. Structured Text term: The Islandora term with a Media Use URI where the structured OCR text can be found. This is another option to the above for storing this data in a separate media related to the parent node, rather than on the same media.
-
+2. Structured Text field: This lets you specify a file field   where OCR text with positional data, e.g., hOCR can be found.
 ## Documentation
 
 Official documentation is available on the [Islandora 8 documentation site](https://islandora.github.io/documentation/).

--- a/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
+++ b/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
@@ -324,8 +324,10 @@ class IIIFManifest extends StylePluginBase {
    *
    * @param \Drupal\Core\Entity\EntityInterface $entity
    *   The entity at the current row.
+  * @param int $delta
+  *.  The delta in case there are multiple canvases on one media.
   *
-   * return String|FALSE
+   * @return String|FALSE
    *   The absolute URL of the current row's structured text,
    *   or FALSE if none.
    */
@@ -459,4 +461,5 @@ class IIIFManifest extends StylePluginBase {
   public function getFormats() {
     return ['json' => 'json'];
   }
+
 }

--- a/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
+++ b/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
@@ -324,14 +324,15 @@ class IIIFManifest extends StylePluginBase {
    *
    * @param \Drupal\Core\Entity\EntityInterface $entity
    *   The entity at the current row.
-  * @param int $delta
-  *.  The delta in case there are multiple canvases on one media.
-  *
-   * @return String|FALSE
+   *  @param \Drupal\views\ResultRow $row
+   *   Result row.  * @param int $delta
+   *   The delta in case there are multiple canvases on one media.
+   *
+   * @return string|false
    *   The absolute URL of the current row's structured text,
    *   or FALSE if none.
    */
-  protected function getOcrUrl(EntityInterface $entity, $row, $delta) {
+  protected function getOcrUrl(EntityInterface $entity, ResultRow $row, $delta) {
     $ocr_url = FALSE;
     $iiif_ocr_file_field = !empty($this->options['iiif_ocr_file_field']) ? array_filter(array_values($this->options['iiif_ocr_file_field'])) : [];
     $ocrField = count($iiif_ocr_file_field) > 0 ? $this->view->field[$iiif_ocr_file_field[0]] : NULL;

--- a/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
+++ b/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
@@ -35,7 +35,7 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class IIIFManifest extends StylePluginBase {
 
-/**
+  /**
    * Islandora utility functions.
    *
    * @var \Drupal\islandora\IslandoraUtils
@@ -233,7 +233,7 @@ class IIIFManifest extends StylePluginBase {
           $annotation_id = $iiif_base_id . '/annotation/' . $entity->id();
 
           [$width, $height] = $this->getCanvasDimensions($iiif_url, $image, $mime_type);
-          
+
           $tmp_canvas = [
             // @see https://iiif.io/api/presentation/2.1/#canvas
             '@id' => $canvas_id,
@@ -283,13 +283,14 @@ class IIIFManifest extends StylePluginBase {
 
   /**
    * Try to fetch the IIIF metadata for the image.
-   * 
+   *
    * @param string $iiif_url
-   *   Base URL of the canvas
-   * @param FieldItemInterface $image
+   *   Base URL of the canvas.
+   * @param \Drupal\Core\Field\FieldItemInterface $image
    *   The image field.
    * @param string $mime_type
    *   The mime type of the image.
+   *
    * @return [string]
    *   The width and height of the image.
    */
@@ -326,16 +327,16 @@ class IIIFManifest extends StylePluginBase {
   }
 
   /**
-   * Retrieves a URL text with positional data such as hOCR
-   * 
-   * @param EntityInterface $entity
+   * Retrieves a URL text with positional data such as hOCR.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
    *   The entity at the current row.
    * @param \Drupal\taxonomy\TermInterface|null $structured_text_term
    *   The term that structured text media references, if any.
-   
+  *
    * return String|FALSE
-   *   The absolute URL of the current row's structured text, 
-   * or FALSE if none.
+   *   The absolute URL of the current row's structured text,
+   *   or FALSE if none.
    */
   protected function getOcrUrl(EntityInterface $entity, $structured_text_term) {
     $ocr_url = FALSE;
@@ -350,7 +351,7 @@ class IIIFManifest extends StylePluginBase {
         $ocr_url = $ocr->entity->createFileUrl(FALSE);
       }
     }
-    else if ($structured_text_term) {
+    elseif ($structured_text_term) {
       $parent_node = $this->utils->getParentNode($entity);
       $ocr_entity_array = $this->utils->getMediaReferencingNodeAndTerm($parent_node, $structured_text_term);
       $ocr_entity_id = is_array($ocr_entity_array) ? array_shift($ocr_entity_array) : NULL;
@@ -485,8 +486,19 @@ class IIIFManifest extends StylePluginBase {
    */
   public function getFormats() {
     return ['json' => 'json'];
-  }  
+  }
 
+  /**
+   * Submit handler for options form.
+   * Used to store the structured text media term by URL instead of Ttid.
+   *
+   * @param array $form
+   * The form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   * The form state object.
+   *
+   * @return void
+   */
   public function submitOptionsForm(&$form, FormStateInterface $form_state) {
     $style_options = $form_state->getValue('style_options');
     $tid = $style_options['structured_text_term'];

--- a/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
+++ b/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
@@ -10,7 +10,6 @@ use Drupal\Core\Field\FieldItemInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Url;
-use Drupal\islandora\IslandoraUtils;
 use Drupal\views\Plugin\views\style\StylePluginBase;
 use Drupal\views\ResultRow;
 use GuzzleHttp\Client;
@@ -34,13 +33,6 @@ use Symfony\Component\HttpFoundation\Request;
  * )
  */
 class IIIFManifest extends StylePluginBase {
-
-  /**
-   * Islandora utility functions.
-   *
-   * @var \Drupal\islandora\IslandoraUtils
-   */
-  protected $utils;
 
   /**
    * {@inheritdoc}
@@ -104,7 +96,7 @@ class IIIFManifest extends StylePluginBase {
   /**
    * {@inheritdoc}
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, SerializerInterface $serializer, Request $request, ImmutableConfig $iiif_config, EntityTypeManagerInterface $entity_type_manager, FileSystemInterface $file_system, Client $http_client, MessengerInterface $messenger, IslandoraUtils $utils) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, SerializerInterface $serializer, Request $request, ImmutableConfig $iiif_config, EntityTypeManagerInterface $entity_type_manager, FileSystemInterface $file_system, Client $http_client, MessengerInterface $messenger) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
 
     $this->serializer = $serializer;
@@ -114,8 +106,6 @@ class IIIFManifest extends StylePluginBase {
     $this->fileSystem = $file_system;
     $this->httpClient = $http_client;
     $this->messenger = $messenger;
-    $this->utils = $utils;
-
   }
 
   /**
@@ -132,8 +122,7 @@ class IIIFManifest extends StylePluginBase {
       $container->get('entity_type.manager'),
       $container->get('file_system'),
       $container->get('http_client'),
-      $container->get('messenger'),
-      $container->get('islandora.utils')
+      $container->get('messenger')
     );
   }
 

--- a/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
+++ b/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
@@ -324,8 +324,9 @@ class IIIFManifest extends StylePluginBase {
    *
    * @param \Drupal\Core\Entity\EntityInterface $entity
    *   The entity at the current row.
-   *  @param \Drupal\views\ResultRow $row
-   *   Result row.  * @param int $delta
+   * @param \Drupal\views\ResultRow $row
+   *   Result row.
+   * @param int $delta
    *   The delta in case there are multiple canvases on one media.
    *
    * @return string|false


### PR DESCRIPTION
**GitHub Issue**: ([IIIF manifests should get hOCR from related media with a given tag #](https://github.com/Islandora/islandora/issues/946)

Related PR:  https://github.com/Islandora/islandora/pull/945

# What does this Pull Request do?

Allows IIIF Manifest to retrieve hOCR from a sibling media based on its media use ta or any other Views relationship

# What's new?

Currently hOCR can be retrieved from a field on the same media as the canvas image. This PR removes the assumption that both fields come from the same media.

* Does this change add any new dependencies?  No
* Does this change require any other modifications to be made to the repository No
* Could this change impact execution of existing code? No

# How should this be tested??

From a new instance of the starter site, e.g. 'make starter_dev' in ISLE-DC:

1. Back up your existing site config if you want to return to it with 'make config:export', then copy the files in codebase/config/sync to a temporary folder.
2. Run composer require islandora/islandora_mirador "islandora/islandora:dev-946-hocr-media as 2.7.x-dev". If composer gives you trouble you may need to chmod -R u+w web/sites/default and / or generate a GitHub API token. Alternatively you can just check out this issue branch manually. 
3. I've attached a zip file with configs  for setting up what you need to test this change.  Import the attached configs:
[config-import.zip](https://github.com/Islandora/islandora/files/11740739/config-import.zip)
  3.1. Unzip the file into your codebase folder so it is accessible inside ISLE-DC, e.g., to codebase/config. The files will be in a folder called 'config-import'./
  3.2. Inside Docker's Drupal image, run the command: ```drush config:import --partial --source=/var/www/drupal/config/config-import```
3. create a new term in the Media Use taxonomy  with URL set to https://discoverygarden.ca/use#hocr (likely to be the future one we use.)

We should now be able to test hOCR generateion:

1. Add a Repository Item with Model 'Paged Content'
2. Upload one or more TIFFs with text on them as children, using Model 'Page', media type 'File' and media use 'Original File'.
3. You can monitor hOCR derivative generation with the logger, ```docker compose logs -f hypercube```
4. After derivatives are generated you should see 'hOCR Extracted Text' media as part of the items on the Media tab.

Next test the IIIF Manifest:

1. Go to Admin > Structure > Views and edit the IIIF Manifest view
2. Look at the relationships to see how an hOCR media is retrieved based on its relationship to a term and thus associated with the media that has the canvas image. Take a minute to admire how powerful Views is.
3. Append '/manifest' to the URL of the Paged Content node you created earlier. This should print a manifest including "SeeAlso" entries where the hOCR URLs are included.
4. The node page itself should include a Mirador viewer with the Text Overlay plugin enabled. Text should be slectable. You can turn this off via Mirador's UI in the top-right. If the text selection buttons don't appear, try clearing Drupal's cache.

![image](https://github.com/Islandora/islandora/assets/82412/6f07e3fb-e054-43cb-8df0-15cc2674c11e)

The part of this PR that is new is the Views Plugin setting. The rest is already in Islandora.
The exported views config linked above is a good starting point for a starter site example.

# Documentation Status

* Does this change existing behaviour that's currently documented?
* Does this change require new pages or sections of documentation? README updated 
* Who does this need to be documented for?
* Associated documentation pull request(s): ___  or documentation issue ___

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
