### PR TITLE
bump jwt version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "drupal/file_replace": "^1.1",
     "drupal/filehash": "^2",
     "drupal/flysystem" : "^2.0@alpha",
-    "drupal/jwt": "^1.1",
+    "drupal/jwt": "^1.1 || ^2",
     "drupal/migrate_plus" : "^5.1 || ^6",
     "drupal/migrate_source_csv" : "^3.4",
     "drupal/prepopulate" : "^2.2",


### PR DESCRIPTION
**GitHub Issue**: N/A

# What does this Pull Request do?

Bumps Drupal JWT version.

# How should this be tested?

Passing tests _should_ be good enough, but...

* Bump your Drupal JWT version to 2.0: `composer require drupal/jwt:^2 islandora/islandora:dev-jwt-version-bump -W`. This should get you a non-vulnerable version of firebase/php-jwt (^6) in your lock file.
* Smoke test, does stuff still get into fedora or microservices get generated.

# Interested parties
@Islandora/committers, esp @rosiel 