### PR TITLE
Bring back hOCR term config item in IIIF Manifest Views style.

### DIFF
--- a/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
+++ b/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
@@ -363,7 +363,7 @@ class IIIFManifest extends StylePluginBase {
    * @param \Drupal\taxonomy\TermInterface|null $structured_text_term
    *   The term that structured text media references, if any.
    *
-   * @return String|FALSE
+   * @return string|false
    *   The absolute URL of the current row's structured text,
    *   or FALSE if none.
    */
@@ -523,9 +523,9 @@ class IIIFManifest extends StylePluginBase {
    * Used to store the structured text media term by URL instead of Ttid.
    *
    * @param array $form
-  *.   The form.
+   *   The form.
    * @param \Drupal\Core\Form\FormStateInterface $form_state
-   *.  The form state object.
+   *   The form state object.
    */
   // @codingStandardsIgnoreStart
   public function submitOptionsForm(&$form, FormStateInterface $form_state) {

--- a/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
+++ b/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
@@ -11,6 +11,7 @@ use Drupal\Core\Field\FieldItemInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Url;
+use Drupal\islandora\IslandoraUtils;
 use Drupal\views\Plugin\views\style\StylePluginBase;
 use Drupal\views\ResultRow;
 use GuzzleHttp\Client;
@@ -34,6 +35,13 @@ use Symfony\Component\HttpFoundation\Request;
  * )
  */
 class IIIFManifest extends StylePluginBase {
+
+  /**
+   * Islandora utility functions.
+   *
+   * @var \Drupal\islandora\IslandoraUtils
+   */
+  protected $utils;
 
   /**
    * {@inheritdoc}
@@ -104,7 +112,7 @@ class IIIFManifest extends StylePluginBase {
   /**
    * {@inheritdoc}
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, SerializerInterface $serializer, Request $request, ImmutableConfig $iiif_config, EntityTypeManagerInterface $entity_type_manager, FileSystemInterface $file_system, Client $http_client, MessengerInterface $messenger, ModuleHandlerInterface $moduleHandler) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, SerializerInterface $serializer, Request $request, ImmutableConfig $iiif_config, EntityTypeManagerInterface $entity_type_manager, FileSystemInterface $file_system, Client $http_client, MessengerInterface $messenger, ModuleHandlerInterface $moduleHandler, IslandoraUtils $utils) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
 
     $this->serializer = $serializer;
@@ -115,6 +123,7 @@ class IIIFManifest extends StylePluginBase {
     $this->httpClient = $http_client;
     $this->messenger = $messenger;
     $this->moduleHandler = $moduleHandler;
+    $this->utils = $utils;
   }
 
   /**
@@ -132,7 +141,8 @@ class IIIFManifest extends StylePluginBase {
       $container->get('file_system'),
       $container->get('http_client'),
       $container->get('messenger'),
-      $container->get('module_handler')
+      $container->get('module_handler'),
+      $container->get('islandora.utils')
     );
   }
 
@@ -163,6 +173,11 @@ class IIIFManifest extends StylePluginBase {
       $content_path = implode('/', $url_components);
       $iiif_base_id = $request_host . '/' . $content_path;
 
+      /**
+       * @var \Drupal\taxonomy\TermInterface|null
+       */
+      $structured_text_term = $this->utils->getTermForUri($this->options['structured_text_term_uri']);
+
       // @see https://iiif.io/api/presentation/2.1/#manifest
       $json += [
         '@type' => 'sc:Manifest',
@@ -182,7 +197,7 @@ class IIIFManifest extends StylePluginBase {
       // For each row in the View result.
       foreach ($this->view->result as $row) {
         // Add the IIIF URL to the image to print out as JSON.
-        $canvases = $this->getTileSourceFromRow($row, $iiif_address, $iiif_base_id);
+        $canvases = $this->getTileSourceFromRow($row, $iiif_address, $iiif_base_id, $structured_text_term);
         foreach ($canvases as $tile_source) {
           $json['sequences'][0]['canvases'][] = $tile_source;
         }
@@ -208,11 +223,13 @@ class IIIFManifest extends StylePluginBase {
    * @param string $iiif_base_id
    *   The URL for the request, minus the last part of the URL,
    *   which is likely "manifest".
+   * @param \Drupal\taxonomy\TermInterface|null $structured_text_term
+   *   The term that structured text media references, if any.
    *
    * @return array
    *   List of IIIF URLs to display in the Openseadragon viewer.
    */
-  protected function getTileSourceFromRow(ResultRow $row, $iiif_address, $iiif_base_id) {
+  protected function getTileSourceFromRow(ResultRow $row, $iiif_address, $iiif_base_id, $structured_text_term) {
     $canvases = [];
     foreach (array_filter(array_values($this->options['iiif_tile_field'])) as $iiif_tile_field) {
       $viewsField = $this->view->field[$iiif_tile_field];
@@ -269,7 +286,7 @@ class IIIFManifest extends StylePluginBase {
             ],
           ];
 
-          if ($ocr_url = $this->getOcrUrl($entity, $row, $i)) {
+          if ($ocr_url = $this->getOcrUrl($entity, $structured_text_term)) {
             $tmp_canvas['seeAlso'] = [
               '@id' => $ocr_url,
               'format' => 'text/vnd.hocr+html',
@@ -343,28 +360,36 @@ class IIIFManifest extends StylePluginBase {
    *
    * @param \Drupal\Core\Entity\EntityInterface $entity
    *   The entity at the current row.
-   * @param \Drupal\views\ResultRow $row
-   *   Result row.
-   * @param int $delta
-   *   The delta in case there are multiple canvases on one media.
-   *
-   * @return string|false
+   * @param \Drupal\taxonomy\TermInterface|null $structured_text_term
+   *   The term that structured text media references, if any.
+  *
+   * return String|FALSE
    *   The absolute URL of the current row's structured text,
    *   or FALSE if none.
    */
-  protected function getOcrUrl(EntityInterface $entity, ResultRow $row, $delta) {
+  protected function getOcrUrl(EntityInterface $entity, $structured_text_term) {
     $ocr_url = FALSE;
     $iiif_ocr_file_field = !empty($this->options['iiif_ocr_file_field']) ? array_filter(array_values($this->options['iiif_ocr_file_field'])) : [];
     $ocrField = count($iiif_ocr_file_field) > 0 ? $this->view->field[$iiif_ocr_file_field[0]] : NULL;
     if ($ocrField) {
-      $ocr_entity = $ocrField->getEntity($row);
+      $ocr_entity = $entity;
       $ocr_field_name = $ocrField->definition['field_name'];
-      if (!is_null($ocr_field_name)) {
+      if (!is_null($ocrField_name)) {
         $ocrs = $ocr_entity->{$ocr_field_name};
-        $ocr = isset($ocrs[$delta]) ? $ocrs[$delta] : FALSE;
-        if ($ocr) {
-          $ocr_url = $ocr->entity->createFileUrl(FALSE);
-        }
+        $ocr = isset($ocrs[$i]) ? $ocrs[$i] : FALSE;
+        $ocr_url = $ocr->entity->createFileUrl(FALSE);
+      }
+    }
+    elseif ($structured_text_term) {
+      $parent_node = $this->utils->getParentNode($entity);
+      $ocr_entity_array = $this->utils->getMediaReferencingNodeAndTerm($parent_node, $structured_text_term);
+      $ocr_entity_id = is_array($ocr_entity_array) ? array_shift($ocr_entity_array) : NULL;
+      $ocr_entity = $ocr_entity_id ? $this->entityTypeManager->getStorage('media')->load($ocr_entity_id) : NULL;
+      if ($ocr_entity) {
+        $ocr_file_source = $ocr_entity->getSource();
+        $ocr_fid = $ocr_file_source->getSourceFieldValue($ocr_entity);
+        $ocr_file = $this->entityTypeManager->getStorage('file')->load($ocr_fid);
+        $ocr_url = $ocr_file->createFileUrl(FALSE);
       }
     }
 
@@ -467,10 +492,19 @@ class IIIFManifest extends StylePluginBase {
       '#title' => $this->t('Structured OCR data file field'),
       '#type' => 'checkboxes',
       '#default_value' => $this->options['iiif_ocr_file_field'],
-      '#description' => $this->t('The source of structured OCR text for each entity.'),
+      '#description' => $this->t('The source of structured OCR text for each entity. If the term setting below is left blank, it will be the same entity as the source image'),
       '#options' => $field_options,
       '#required' => FALSE,
     ];
+    $form['structured_text_term'] = [
+      '#type' => 'entity_autocomplete',
+      '#target_type' => 'taxonomy_term',
+      '#title' => $this->t('Structured OCR text term'),
+      '#default_value' => $this->utils->getTermForUri($this->options['structured_text_term_uri']),
+      '#required' => FALSE,
+      '#description' => $this->t('Term indicating the media that holds structured text, such as hOCR, for the given object. Use this if the text is on a separate media from the tile source.'),
+    ];
+
   }
 
   /**
@@ -481,6 +515,26 @@ class IIIFManifest extends StylePluginBase {
    */
   public function getFormats() {
     return ['json' => 'json'];
+  }
+
+  /**
+   * Submit handler for options form.
+   * Used to store the structured text media term by URL instead of Ttid.
+   *
+   * @param array $form
+   * The form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   * The form state object.
+   *
+   * @return void
+   */
+  public function submitOptionsForm(&$form, FormStateInterface $form_state) {
+    $style_options = $form_state->getValue('style_options');
+    $tid = $style_options['structured_text_term'];
+    $term = $this->entityTypeManager->getStorage('taxonomy_term')->load($tid);
+    $style_options['structured_text_term_uri'] = $this->utils->getUriForTerm($term);
+    $form_state->setValue('style_options', $style_options);
+    parent::submitOptionsForm($form, $form_state);
   }
 
 }

--- a/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
+++ b/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
@@ -109,6 +109,13 @@ class IIIFManifest extends StylePluginBase {
    */
   protected $moduleHandler;
 
+  /*
+   * The media use term for structured OCR text.
+   *
+   * @var \Drupal\taxonomy\TermInterface|null
+   */
+  protected $structured_text_term;
+
   /**
    * {@inheritdoc}
    */
@@ -124,6 +131,7 @@ class IIIFManifest extends StylePluginBase {
     $this->messenger = $messenger;
     $this->moduleHandler = $moduleHandler;
     $this->utils = $utils;
+    $this->structured_text_term = $this->utils->getTermForUri($this->options['structured_text_term_uri']);
   }
 
   /**
@@ -173,11 +181,6 @@ class IIIFManifest extends StylePluginBase {
       $content_path = implode('/', $url_components);
       $iiif_base_id = $request_host . '/' . $content_path;
 
-      /**
-       * @var \Drupal\taxonomy\TermInterface|null
-       */
-      $structured_text_term = $this->utils->getTermForUri($this->options['structured_text_term_uri']);
-
       // @see https://iiif.io/api/presentation/2.1/#manifest
       $json += [
         '@type' => 'sc:Manifest',
@@ -197,7 +200,7 @@ class IIIFManifest extends StylePluginBase {
       // For each row in the View result.
       foreach ($this->view->result as $row) {
         // Add the IIIF URL to the image to print out as JSON.
-        $canvases = $this->getTileSourceFromRow($row, $iiif_address, $iiif_base_id, $structured_text_term);
+        $canvases = $this->getTileSourceFromRow($row, $iiif_address, $iiif_base_id);
         foreach ($canvases as $tile_source) {
           $json['sequences'][0]['canvases'][] = $tile_source;
         }
@@ -223,13 +226,11 @@ class IIIFManifest extends StylePluginBase {
    * @param string $iiif_base_id
    *   The URL for the request, minus the last part of the URL,
    *   which is likely "manifest".
-   * @param \Drupal\taxonomy\TermInterface|null $structured_text_term
-   *   The term that structured text media references, if any.
    *
    * @return array
    *   List of IIIF URLs to display in the Openseadragon viewer.
    */
-  protected function getTileSourceFromRow(ResultRow $row, $iiif_address, $iiif_base_id, $structured_text_term) {
+  protected function getTileSourceFromRow(ResultRow $row, $iiif_address, $iiif_base_id) {
     $canvases = [];
     foreach (array_filter(array_values($this->options['iiif_tile_field'])) as $iiif_tile_field) {
       $viewsField = $this->view->field[$iiif_tile_field];
@@ -286,7 +287,7 @@ class IIIFManifest extends StylePluginBase {
             ],
           ];
 
-          if ($ocr_url = $this->getOcrUrl($entity, $structured_text_term)) {
+          if ($ocr_url = $this->getOcrUrl($entity, $this->structured_text_term)) {
             $tmp_canvas['seeAlso'] = [
               '@id' => $ocr_url,
               'format' => 'text/vnd.hocr+html',
@@ -360,14 +361,12 @@ class IIIFManifest extends StylePluginBase {
    *
    * @param \Drupal\Core\Entity\EntityInterface $entity
    *   The entity at the current row.
-   * @param \Drupal\taxonomy\TermInterface|null $structured_text_term
-   *   The term that structured text media references, if any.
    *
    * @return string|false
    *   The absolute URL of the current row's structured text,
    *   or FALSE if none.
    */
-  protected function getOcrUrl(EntityInterface $entity, $structured_text_term) {
+  protected function getOcrUrl(EntityInterface $entity) {
     $ocr_url = FALSE;
     $iiif_ocr_file_field = !empty($this->options['iiif_ocr_file_field']) ? array_filter(array_values($this->options['iiif_ocr_file_field'])) : [];
     $ocrField = count($iiif_ocr_file_field) > 0 ? $this->view->field[$iiif_ocr_file_field[0]] : NULL;
@@ -380,9 +379,9 @@ class IIIFManifest extends StylePluginBase {
         $ocr_url = $ocr->entity->createFileUrl(FALSE);
       }
     }
-    elseif ($structured_text_term) {
+    elseif ($this->structured_text_term) {
       $parent_node = $this->utils->getParentNode($entity);
-      $ocr_entity_array = $this->utils->getMediaReferencingNodeAndTerm($parent_node, $structured_text_term);
+      $ocr_entity_array = $this->utils->getMediaReferencingNodeAndTerm($parent_node, $this->structured_text_term);
       $ocr_entity_id = is_array($ocr_entity_array) ? array_shift($ocr_entity_array) : NULL;
       $ocr_entity = $ocr_entity_id ? $this->entityTypeManager->getStorage('media')->load($ocr_entity_id) : NULL;
       if ($ocr_entity) {

--- a/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
+++ b/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
@@ -168,6 +168,7 @@ class IIIFManifest extends StylePluginBase {
    * {@inheritdoc}
    */
   public function render() {
+    $this->structured_text_term = $this->utils->getTermForUri($this->options['structured_text_term_uri']);
     $json = [];
     $iiif_address = $this->iiifConfig->get('iiif_server');
     if (!is_null($iiif_address) && !empty($iiif_address)) {

--- a/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
+++ b/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
@@ -362,8 +362,8 @@ class IIIFManifest extends StylePluginBase {
    *   The entity at the current row.
    * @param \Drupal\taxonomy\TermInterface|null $structured_text_term
    *   The term that structured text media references, if any.
-  *
-   * return String|FALSE
+   *
+   * @return String|FALSE
    *   The absolute URL of the current row's structured text,
    *   or FALSE if none.
    */
@@ -519,16 +519,17 @@ class IIIFManifest extends StylePluginBase {
 
   /**
    * Submit handler for options form.
+   *
    * Used to store the structured text media term by URL instead of Ttid.
    *
    * @param array $form
-   * The form.
+  *.   The form.
    * @param \Drupal\Core\Form\FormStateInterface $form_state
-   * The form state object.
-   *
-   * @return void
+   *.  The form state object.
    */
+  // @codingStandardsIgnoreStart
   public function submitOptionsForm(&$form, FormStateInterface $form_state) {
+    // @codingStandardsIgnoreEnd
     $style_options = $form_state->getValue('style_options');
     $tid = $style_options['structured_text_term'];
     $term = $this->entityTypeManager->getStorage('taxonomy_term')->load($tid);

--- a/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
+++ b/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
@@ -288,7 +288,7 @@ class IIIFManifest extends StylePluginBase {
             ],
           ];
 
-          if ($ocr_url = $this->getOcrUrl($entity, $this->structuredTextTerm)) {
+          if ($ocr_url = $this->`getOcrUrl`($entity)) {
             $tmp_canvas['seeAlso'] = [
               '@id' => $ocr_url,
               'format' => 'text/vnd.hocr+html',

--- a/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
+++ b/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
@@ -131,7 +131,9 @@ class IIIFManifest extends StylePluginBase {
     $this->messenger = $messenger;
     $this->moduleHandler = $moduleHandler;
     $this->utils = $utils;
-    $this->structured_text_term = $this->utils->getTermForUri($this->options['structured_text_term_uri']);
+    $this->structured_text_term = isset($this->options['structured_text_term_uri'])
+    ? $this->utils->getTermForUri($this->options['structured_text_term_uri'])
+    : FALSE;
   }
 
   /**

--- a/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
+++ b/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
@@ -114,7 +114,7 @@ class IIIFManifest extends StylePluginBase {
    *
    * @var \Drupal\taxonomy\TermInterface|null
    */
-  protected $structured_text_term;
+  protected $structuredTextTerm;
 
   /**
    * {@inheritdoc}
@@ -168,7 +168,7 @@ class IIIFManifest extends StylePluginBase {
    * {@inheritdoc}
    */
   public function render() {
-    $this->structured_text_term = $this->utils->getTermForUri($this->options['structured_text_term_uri']);
+    $this->structuredTextTerm = $this->utils->getTermForUri($this->options['structured_text_term_uri']);
     $json = [];
     $iiif_address = $this->iiifConfig->get('iiif_server');
     if (!is_null($iiif_address) && !empty($iiif_address)) {
@@ -288,7 +288,7 @@ class IIIFManifest extends StylePluginBase {
             ],
           ];
 
-          if ($ocr_url = $this->getOcrUrl($entity, $this->structured_text_term)) {
+          if ($ocr_url = $this->getOcrUrl($entity, $this->structuredTextTerm)) {
             $tmp_canvas['seeAlso'] = [
               '@id' => $ocr_url,
               'format' => 'text/vnd.hocr+html',
@@ -380,9 +380,9 @@ class IIIFManifest extends StylePluginBase {
         $ocr_url = $ocr->entity->createFileUrl(FALSE);
       }
     }
-    elseif ($this->structured_text_term) {
+    elseif ($this->structuredTextTerm) {
       $parent_node = $this->utils->getParentNode($entity);
-      $ocr_entity_array = $this->utils->getMediaReferencingNodeAndTerm($parent_node, $this->structured_text_term);
+      $ocr_entity_array = $this->utils->getMediaReferencingNodeAndTerm($parent_node, $this->structuredTextTerm);
       $ocr_entity_id = is_array($ocr_entity_array) ? array_shift($ocr_entity_array) : NULL;
       $ocr_entity = $ocr_entity_id ? $this->entityTypeManager->getStorage('media')->load($ocr_entity_id) : NULL;
       if ($ocr_entity) {

--- a/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
+++ b/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
@@ -288,7 +288,7 @@ class IIIFManifest extends StylePluginBase {
             ],
           ];
 
-          if ($ocr_url = $this->`getOcrUrl`($entity)) {
+          if ($ocr_url = $this->getOcrUrl($entity)) {
             $tmp_canvas['seeAlso'] = [
               '@id' => $ocr_url,
               'format' => 'text/vnd.hocr+html',


### PR DESCRIPTION
**GitHub Issue**: (link)

# What does this Pull Request do?

Brings back the config item on IIIF Manifest Views style plugin so that a site builder can choose the term to retrieve hOCR text from on a sibling Media entity.

# What's new?

We outsmarted ourselves trying to retrieve a related media item using Views relationships. It turns out that this does not work if a row's object has an image media but no hOCR media.*

* This is with the current view that uses Media as its base table. 

This rolls back the commit where I removed the options form to explicitly select the term, and adds more descriptive help text.


* Does this change add any new dependencies?  No
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)?  No
* Could this change impact execution of existing code? No

# How should this be tested?

From a new instance of the starter site, e.g. 'make starter_dev' in ISLE-DC:

Back up your existing site config if you want to return to it with 'make config:export', then copy the files in codebase/config/sync to a temporary folder.
Run composer require islandora/islandora_mirador "islandora/islandora:dev-946-hocr-media as 2.7.x-dev". If composer gives you trouble you may need to chmod -R u+w web/sites/default and / or generate a GitHub API token. Alternatively you can just check out this issue branch manually.
I've attached a zip file with configs for setting up what you need to test this change. Import the attached configs:
[config-import.zip](https://github.com/Islandora/islandora/files/11791092/config-import.zip)
3.1. Unzip the file into your codebase folder so it is accessible inside ISLE-DC, e.g., to codebase/config. The files will be in a folder called 'config-import'./
3.2. Inside Docker's Drupal image, run the command: drush config:import --partial --source=/var/www/drupal/config/config-import
create a new term in the Media Use taxonomy with URL set to https://discoverygarden.ca/use#hocr (likely to be the future one we use.)
We should now be able to test hOCR generateion:

Add a Repository Item with Model 'Paged Content'
Upload one or more TIFFs with text on them as children, using Model 'Page', media type 'File' and media use 'Original File'.
You can monitor hOCR derivative generation with the logger, docker compose logs -f hypercube
After derivatives are generated you should see 'hOCR Extracted Text' media as part of the items on the Media tab.
Next test the IIIF Manifest:

Go to Admin > Structure > Views and edit the IIIF Manifest view.
Click 'Settings' next to IIF Manifest in the Format section on the left.
You should see a new config form element, allowing you to choose the Media Use term for hOCR Extracted Text:
![image](https://github.com/Islandora/islandora/assets/82412/7ca1d8e2-08d0-419c-be35-d3ef3deb8da5)


Append '/manifest' to the URL of the Paged Content node you created earlier. This should print a manifest including "SeeAlso" entries where the hOCR URLs are included.
The node page itself should include a Mirador viewer with the Text Overlay plugin enabled. Text should be slectable. You can turn this off via Mirador's UI in the top-right. If the text selection buttons don't appear, try clearing Drupal's cache.
image
Next go to one of the children objects, and click on the Media tab. Delete the hOCR Extracted Text media, then go back to the original book page. You should still see the image in Mirador, but it won't have a text overlay.


The part of this PR that is new is the Views Plugin setting. The rest is already in Islandora


# Documentation Status

* Does this change existing behaviour that's currently documented? No
* Does this change require new pages or sections of documentation? No
* Who does this need to be documented for?


# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
 @rosiel 