### PR TITLE
Typo prevented submodule functional tests from running.

### DIFF
--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -28,7 +28,7 @@ jobs:
         # test-suite functional-javascript will appear to pass but will skip tests; missing chromedriver.
         test-suite: ["kernel", "functional", "functional-javascript"]
         # Not yet Drupal 10 ready - see https://github.com/Islandora/islandora/issues/888
-        drupal-version: ["9.3.x", "9.4.x", "9.5.x-dev"]
+        drupal-version: ["9.4.x", "9.5.x-dev"]
         mysql: ["8.0"]
         allowed_failure: [false]
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -58,7 +58,7 @@
     </testsuite>
     <testsuite name="functional">
       <directory>../modules/contrib/islandora/tests/src/Functional</directory>
-      <directory>../modules/contrib/isladnora/modules/*/tests/src/Functional</directory>
+      <directory>../modules/contrib/islandora/modules/*/tests/src/Functional</directory>
     </testsuite>
     <testsuite name="functional-javascript">
       <directory>../modules/contrib/islandora/tests/src/FunctionalJavascript</directory>


### PR DESCRIPTION
**GitHub Issue**:  

This came up when phpUnit found some failing tests in islandora - namely, in its submodules, namely, the tests that check if specific derivatives work. 

This PR (as of now) only addresses the fact that they weren't being run by CI.

# What does this Pull Request do?

It should cause Github CI to run the submodules' functional tests. I expect them to fail.


# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
