### PR TITLE
Drupal 10 Compatibility from Upgrade Status

### DIFF
--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -23,12 +23,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # PHP 8.1 fails - see https://github.com/Islandora/islandora/issues/887
-        php-versions: ["7.4", "8.0", "8.1"]
+        php-versions: ["8.1"]
         # test-suite functional-javascript will appear to pass but will skip tests; missing chromedriver.
         test-suite: ["kernel", "functional", "functional-javascript"]
-        # Not yet Drupal 10 ready - see https://github.com/Islandora/islandora/issues/888
-        drupal-version: ["9.4.x", "9.5.x"]
+        drupal-version: ["9.5.x", "10.0.x", "10.1.x"]
         mysql: ["8.0"]
         allowed_failure: [false]
 

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "drupal/token" : "^1.3",
     "islandora/chullo": "^2.0",
     "islandora/fedora-entity-mapper": "^1.0",
-    "islandora/jsonld": "^2",
+    "islandora/jsonld": "^2 || ^3",
     "stomp-php/stomp-php": "4.* || ^5"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "drupal/context": "^4 || ^5@RC",
     "drupal/ctools": "^3.8 || ^4",
     "drupal/eva" : "^3.0",
-    "drupal/features" : "^3.7",
+    "drupal/features" : "^3.13",
     "drupal/file_replace": "^1.1",
     "drupal/filehash": "^2",
     "drupal/flysystem" : "^2.0@alpha",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     }
   ],
   "require": {
-    "drupal/context": "^4",
+    "drupal/context": "^4 || ^5@RC",
     "drupal/ctools": "^3.8 || ^4",
     "drupal/eva" : "^3.0",
     "drupal/features" : "^3.7",

--- a/islandora.info.yml
+++ b/islandora.info.yml
@@ -4,32 +4,31 @@ name: 'islandora'
 description: "Islandora Core"
 type: module
 package: Islandora
-core: 8.x
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^9 || ^10
 dependencies:
-  - drupal:block
-  - drupal:node
-  - drupal:path
-  - drupal:text
-  - drupal:options
-  - drupal:link
-  - jsonld:jsonld
-  - search_api:search_api
-  - jwt:jwt
-  - drupal:rest
-  - filehash:filehash
-  - drupal:basic_auth
   - context:context_ui
-  - drupal:action
-  - eva:eva
-  - drupal:taxonomy
-  - drupal:views_ui
-  - drupal:media
-  - prepopulate:prepopulate
-  - features:features_ui
-  - migrate_source_csv:migrate_source_csv
-  - drupal:content_translation
-  - flysystem:flysystem
-  - token:token
-  - file_replace:file_replace
   - ctools:ctools
+  - drupal:action
+  - drupal:basic_auth
+  - drupal:block
+  - drupal:content_translation
+  - drupal:link
+  - drupal:media
+  - drupal:node
+  - drupal:options
+  - drupal:path
+  - drupal:rest
+  - drupal:taxonomy
+  - drupal:text
+  - drupal:views_ui
+  - eva:eva
+  - features:features_ui
+  - file_replace:file_replace
+  - filehash:filehash
+  - flysystem:flysystem
+  - jsonld:jsonld
+  - jwt:jwt
+  - migrate_source_csv:migrate_source_csv
+  - prepopulate:prepopulate
+  - search_api:search_api
+  - token:token

--- a/modules/islandora_advanced_search/islandora_advanced_search.info.yml
+++ b/modules/islandora_advanced_search/islandora_advanced_search.info.yml
@@ -4,7 +4,7 @@ name: 'Islandora Advanced Search'
 description: "Creates an Advanced Search block and other enhancements to search."
 type: module
 package: Islandora
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - drupal:facets
   - drupal:facets_summary

--- a/modules/islandora_advanced_search/src/Form/AdvancedSearchForm.php
+++ b/modules/islandora_advanced_search/src/Form/AdvancedSearchForm.php
@@ -71,7 +71,7 @@ class AdvancedSearchForm extends FormBase {
    */
   public static function create(ContainerInterface $container) {
     return new static(
-      $container->get('request_stack')->getMasterRequest(),
+      $container->get('request_stack')->getMainRequest(),
       $container->get('current_route_match')
     );
   }

--- a/modules/islandora_advanced_search/src/Plugin/Block/AdvancedSearchBlock.php
+++ b/modules/islandora_advanced_search/src/Plugin/Block/AdvancedSearchBlock.php
@@ -108,7 +108,7 @@ class AdvancedSearchBlock extends BlockBase implements ContainerFactoryPluginInt
       $plugin_definition,
       $container->get('plugin.manager.search_api.display'),
       $container->get('form_builder'),
-      $container->get('request_stack')->getMasterRequest()
+      $container->get('request_stack')->getMainRequest()
     );
   }
 

--- a/modules/islandora_advanced_search/src/Plugin/Block/SearchResultsPagerBlock.php
+++ b/modules/islandora_advanced_search/src/Plugin/Block/SearchResultsPagerBlock.php
@@ -58,7 +58,7 @@ class SearchResultsPagerBlock extends BlockBase implements ContainerFactoryPlugi
       $configuration,
       $plugin_id,
       $plugin_definition,
-      $container->get('request_stack')->getMasterRequest()
+      $container->get('request_stack')->getMainRequest()
     );
   }
 

--- a/modules/islandora_audio/islandora_audio.info.yml
+++ b/modules/islandora_audio/islandora_audio.info.yml
@@ -2,7 +2,6 @@ name: 'Islandora Audio'
 description: 'Islandora audio derivative actions'
 type: module
 package: Islandora
-core: 8.x
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - drupal:islandora

--- a/modules/islandora_breadcrumbs/islandora_breadcrumbs.info.yml
+++ b/modules/islandora_breadcrumbs/islandora_breadcrumbs.info.yml
@@ -1,8 +1,7 @@
 name: 'Islandora Breadcrumbs'
 type: module
 description: 'Builds breadcrumbs based on field_member_of relationships.'
-core: 8.x
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^9 || ^10
 package: Islandora
 dependencies:
   - islandora:islandora

--- a/modules/islandora_core_feature/islandora_core_feature.info.yml
+++ b/modules/islandora_core_feature/islandora_core_feature.info.yml
@@ -1,8 +1,7 @@
 name: 'Islandora Core Feature'
 description: 'Minimum configuration required for Islandora.'
 type: module
-core: 8.x
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - drupal:basic_auth
   - drupal:content_translation

--- a/modules/islandora_iiif/islandora_iiif.info.yml
+++ b/modules/islandora_iiif/islandora_iiif.info.yml
@@ -1,8 +1,7 @@
 name: 'Islandora IIIF'
 type: module
 description: 'IIIF support for Islandora'
-core: 8.x
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^9 || ^10
 package: Islandora
 dependencies:
   - drupal:islandora

--- a/modules/islandora_image/islandora_image.info.yml
+++ b/modules/islandora_image/islandora_image.info.yml
@@ -1,8 +1,7 @@
 name: 'Islandora Image'
 type: module
 description: 'Islandora Image derivative actions'
-core: 8.x
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^9 || ^10
 package: Islandora
 dependencies:
   - drupal:islandora

--- a/modules/islandora_text_extraction/islandora_text_extraction.info.yml
+++ b/modules/islandora_text_extraction/islandora_text_extraction.info.yml
@@ -1,8 +1,7 @@
 name: 'Islandora Text Extraction'
 type: module
 description: 'Islandora 8 module to connect to Hypercube microservice, and to get text from PDF ingest'
-core: 8.x
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^9 || ^10
 package: 'Islandora'
 dependencies:
   - drupal:islandora

--- a/modules/islandora_text_extraction_defaults/islandora_text_extraction_defaults.info.yml
+++ b/modules/islandora_text_extraction_defaults/islandora_text_extraction_defaults.info.yml
@@ -1,8 +1,7 @@
 name: 'Islandora Text Extraction Defaults'
 type: module
 description: 'Default config for the Islandora Text Extraction module.'
-core: 8.x
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^9 || ^10
 package: Islandora
 dependencies:
   - drupal:field

--- a/modules/islandora_video/islandora_video.info.yml
+++ b/modules/islandora_video/islandora_video.info.yml
@@ -2,7 +2,6 @@ name: 'Islandora Video'
 description: 'Islandora video derivative actions'
 type: module
 package: Islandora
-core: 8.x
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - drupal:islandora

--- a/src/EventGenerator/EventGenerator.php
+++ b/src/EventGenerator/EventGenerator.php
@@ -192,6 +192,7 @@ class EventGenerator implements EventGeneratorInterface {
   protected function getRevisionIds(Media $media, EntityStorageInterface $media_storage) {
     $result = $media_storage->getQuery()
       ->allRevisions()
+      ->accessCheck(TRUE)
       ->condition($media->getEntityType()->getKey('id'), $media->id())
       ->sort($media->getEntityType()->getKey('revision'), 'DESC')
       ->execute();

--- a/src/Flysystem/Adapter/FedoraAdapter.php
+++ b/src/Flysystem/Adapter/FedoraAdapter.php
@@ -160,14 +160,8 @@ class FedoraAdapter implements AdapterInterface {
     // NonRDFSource's are considered files.  Everything else is a
     // directory.
     $type = 'dir';
-    // phpcs:disable
-    if (class_exists(Header::class)) {
-      $links = Header::parse($response->getHeader('Link'));
-    }
-    else {
-      $links = parse_header($response->getHeader('Link'));
-    }
-    // phpcs:enable
+    $links = Header::parse($response->getHeader('Link'));
+
     foreach ($links as $link) {
       if ($link['rel'] == 'type' && $link[0] == '<http://www.w3.org/ns/ldp#NonRDFSource>') {
         $type = 'file';
@@ -403,14 +397,7 @@ class FedoraAdapter implements AdapterInterface {
     $return = NULL;
     if ($response->getStatusCode() == 410) {
       $return = FALSE;
-      // phpcs:disable
-      if (class_exists(Header::class)) {
-        $link_headers = Header::parse($response->getHeader('Link'));
-      }
-      else {
-        $link_headers = parse_header($response->getHeader('Link'));
-      }
-      // phpcs:enable
+      $link_headers = Header::parse($response->getHeader('Link'));
       if ($link_headers) {
         $tombstones = array_filter($link_headers, function ($o) {
           return (isset($o['rel']) && $o['rel'] == 'hasTombstone');

--- a/src/Flysystem/Adapter/FedoraAdapter.php
+++ b/src/Flysystem/Adapter/FedoraAdapter.php
@@ -3,7 +3,6 @@
 namespace Drupal\islandora\Flysystem\Adapter;
 
 use GuzzleHttp\Psr7\Header;
-use function GuzzleHttp\Psr7\parse_header;
 use Drupal\Core\Logger\LoggerChannelInterface;
 use Islandora\Chullo\IFedoraApi;
 use League\Flysystem\AdapterInterface;

--- a/src/Form/ConfirmDeleteMediaAndFile.php
+++ b/src/Form/ConfirmDeleteMediaAndFile.php
@@ -128,6 +128,9 @@ class ConfirmDeleteMediaAndFile extends DeleteMultipleForm {
       // Check for files.
       $fields = $this->entityFieldManager->getFieldDefinitions('media', $entity->bundle());
       foreach ($fields as $field) {
+        if ($field->getName() == 'thumbnail') {
+          continue;
+        }
         $type = $field->getType();
         if ($type == 'file' || $type == 'image') {
           $target_id = $entity->get($field->getName())->target_id;

--- a/src/Form/ConfirmDeleteMediaAndFile.php
+++ b/src/Form/ConfirmDeleteMediaAndFile.php
@@ -137,8 +137,11 @@ class ConfirmDeleteMediaAndFile extends DeleteMultipleForm {
               $inaccessible_entities[] = $file;
               continue;
             }
-            $delete_files[$file->id()] = $file;
-            $total_count++;
+            if (!array_key_exists($file->id(), $delete_files)) {
+              $delete_files[$file->id()] = $file;
+              $total_count++;
+            }
+
           }
         }
       }

--- a/src/Plugin/Condition/NodeReferencedByNode.php
+++ b/src/Plugin/Condition/NodeReferencedByNode.php
@@ -128,6 +128,7 @@ class NodeReferencedByNode extends ConditionPluginBase implements ContainerFacto
     $config = FieldStorageConfig::loadByName('node', $reference_field);
     if ($config) {
       $id_count = \Drupal::entityQuery('node')
+        ->accessCheck(TRUE)
         ->condition($reference_field, $entity->id())
         ->count()
         ->execute();

--- a/tests/modules/integer_weight_test_views/integer_weight_test_views.info.yml
+++ b/tests/modules/integer_weight_test_views/integer_weight_test_views.info.yml
@@ -2,7 +2,7 @@ name: 'Integer weight test views'
 type: module
 description: 'Provides default views for integer weight views tests.'
 package: Testing
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^8 || ^9 || ^10
 dependencies:
   - drupal:node
   - drupal:views

--- a/tests/modules/integer_weight_test_views/integer_weight_test_views.info.yml
+++ b/tests/modules/integer_weight_test_views/integer_weight_test_views.info.yml
@@ -2,7 +2,7 @@ name: 'Integer weight test views'
 type: module
 description: 'Provides default views for integer weight views tests.'
 package: Testing
-core_version_requirement: ^8 || ^9 || ^10
+core_version_requirement: ^9 || ^10
 dependencies:
   - drupal:node
   - drupal:views

--- a/tests/modules/integer_weight_test_views/integer_weight_test_views.info.yml
+++ b/tests/modules/integer_weight_test_views/integer_weight_test_views.info.yml
@@ -2,7 +2,7 @@ name: 'Integer weight test views'
 type: module
 description: 'Provides default views for integer weight views tests.'
 package: Testing
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^8 || ^9 || ^10
 dependencies:
   - drupal:node
   - drupal:views

--- a/tests/src/Functional/DeleteMediaTest.php
+++ b/tests/src/Functional/DeleteMediaTest.php
@@ -50,8 +50,14 @@ class DeleteMediaTest extends IslandoraFunctionalTestBase {
   public function setUp(): void {
     parent::setUp();
 
+    if (floatval(\Drupal::VERSION) >= 10.1) {
+      $permissions = ['create media', 'delete any media', 'delete any files'];
+    } else {
+      $permissions = ['create media', 'delete any media'];
+    }
+
     // Create a test user.
-    $this->account = $this->createUser(['create media', 'delete any media']);
+    $this->account = $this->createUser($permissions);
 
     list($this->file, $this->media) = $this->makeMediaAndFile($this->account);
   }

--- a/tests/src/Functional/DeleteMediaTest.php
+++ b/tests/src/Functional/DeleteMediaTest.php
@@ -51,7 +51,7 @@ class DeleteMediaTest extends IslandoraFunctionalTestBase {
     parent::setUp();
 
     if (version_compare(\Drupal::VERSION, '10.1', '>=')){
-      $permissions = ['create media', 'delete any media', 'delete any files'];
+      $permissions = ['create media', 'delete any media', 'delete any file'];
     } else {
       $permissions = ['create media', 'delete any media'];
     }

--- a/tests/src/Functional/DeleteMediaTest.php
+++ b/tests/src/Functional/DeleteMediaTest.php
@@ -50,7 +50,7 @@ class DeleteMediaTest extends IslandoraFunctionalTestBase {
   public function setUp(): void {
     parent::setUp();
 
-    if (floatval(\Drupal::VERSION) >= 10.1) {
+    if (version_compare(\Drupal::VERSION, '10.1', '>=')){
       $permissions = ['create media', 'delete any media', 'delete any files'];
     } else {
       $permissions = ['create media', 'delete any media'];

--- a/tests/src/Functional/DeleteMediaTest.php
+++ b/tests/src/Functional/DeleteMediaTest.php
@@ -50,9 +50,10 @@ class DeleteMediaTest extends IslandoraFunctionalTestBase {
   public function setUp(): void {
     parent::setUp();
 
-    if (version_compare(\Drupal::VERSION, '10.1', '>=')){
+    if (version_compare(\Drupal::VERSION, '10.1', '>=')) {
       $permissions = ['create media', 'delete any media', 'delete any file'];
-    } else {
+    }
+    else {
       $permissions = ['create media', 'delete any media'];
     }
 

--- a/tests/src/Kernel/FedoraAdapterTest.php
+++ b/tests/src/Kernel/FedoraAdapterTest.php
@@ -61,13 +61,8 @@ class FedoraAdapterTest extends IslandoraKernelTestBase {
       ]);
     $prophecy->getHeader('Content-Type')->willReturn(['text/plain']);
     $prophecy->getHeader('Content-Length')->willReturn([strlen("DERP")]);
-    // phpcs:disable
-    if (class_exists(Utils::class)) {
-      $prophecy->getBody()->willReturn(Utils::streamFor("DERP"));
-    } else {
-      $prophecy->getBody()->willReturn(stream_for("DERP"));
-    }
-    // phpcs:enable
+    $prophecy->getBody()->willReturn(Utils::streamFor("DERP"));
+
     return $prophecy;
   }
 

--- a/tests/src/Kernel/FedoraAdapterTest.php
+++ b/tests/src/Kernel/FedoraAdapterTest.php
@@ -235,7 +235,7 @@ class FedoraAdapterTest extends IslandoraKernelTestBase {
     $head_prophecy = $this->prophesize(Response::class);
     $head_prophecy->getStatusCode()->willReturn(410);
     $head_prophecy->getHeader('Link')
-      ->willReturn('<some-path-to-a-tombstone>; rel="hasTombstone"');
+      ->willReturn(['<some-path-to-a-tombstone>; rel="hasTombstone"']);
 
     $tombstone_prophecy = $this->prophesize(Response::class);
     $tombstone_prophecy->getStatusCode()->willReturn(204);
@@ -263,7 +263,7 @@ class FedoraAdapterTest extends IslandoraKernelTestBase {
     $head_prophecy = $this->prophesize(Response::class);
     $head_prophecy->getStatusCode()->willReturn(410);
     $head_prophecy->getHeader('Link')
-      ->willReturn('<some-path-to-a-tombstone>; rel="hasTombstone"');
+      ->willReturn(['<some-path-to-a-tombstone>; rel="hasTombstone"']);
 
     $tombstone_prophecy = $this->prophesize(Response::class);
     $tombstone_prophecy->getStatusCode()->willReturn(500);

--- a/tests/src/Kernel/FedoraAdapterTest.php
+++ b/tests/src/Kernel/FedoraAdapterTest.php
@@ -4,7 +4,6 @@ namespace Drupal\Tests\islandora\Kernel;
 
 use Prophecy\PhpUnit\ProphecyTrait;
 use GuzzleHttp\Psr7\Utils;
-use function GuzzleHttp\Psr7\stream_for;
 use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\islandora\Flysystem\Adapter\FedoraAdapter;
 use GuzzleHttp\Psr7\Response;

--- a/tests/src/Kernel/FedoraPluginTest.php
+++ b/tests/src/Kernel/FedoraPluginTest.php
@@ -6,6 +6,7 @@ use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\islandora\Flysystem\Fedora;
 use Islandora\Chullo\IFedoraApi;
 use League\Flysystem\AdapterInterface;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Mime\MimeTypeGuesserInterface;
 
@@ -16,6 +17,8 @@ use Symfony\Component\Mime\MimeTypeGuesserInterface;
  * @coversDefaultClass \Drupal\islandora\Flysystem\Fedora
  */
 class FedoraPluginTest extends IslandoraKernelTestBase {
+
+  use ProphecyTrait;
 
   /**
    * Mocks up a plugin.


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/2235

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

* follows #957  and #943 in getting Islandora 10-comptaible.

# What does this Pull Request do?

Removes deprecated code and updates compatiblity declarations.

# What's new?

* it's `->getMainResponse()` now.
* alphabetize the dependency list
* Remove D8 and add D10 to compatibility
* Remove shims that allowed deprecated code to be called (pre-D8 compatibility?) 
* add access checks to entity queries..

* Does this change add any new dependencies? No
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? No
* Could this change impact execution of existing code? No

# How should this be tested?

* Do the tests run on D10?
* Can you install islandora on D10 and run it with no problems?

# Documentation Status

* Does this change existing behaviour that's currently documented? eventually we will update the docs with this minor change, but probably once we update the islandora starter site.
* Does this change require new pages or sections of documentation?
* Who does this need to be documented for?
* Associated documentation pull request(s): ___  or documentation issue ___

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
