### PR TITLE
Issue #964: Allow relative paths in IIIF manifests.

### DIFF
--- a/modules/islandora_iiif/config/schema/islandora_iiif.schema.yml
+++ b/modules/islandora_iiif/config/schema/islandora_iiif.schema.yml
@@ -5,6 +5,9 @@ islandora_iiif.settings:
     iiif_server:
       type: string
       label: 'IIIF Server Url'
+    use_relative_paths:
+    type: boolean
+    label: 'Use relative paths in manifest.'
 
 views.style.iiif_manifest:
   type: views_style

--- a/modules/islandora_iiif/src/Form/IslandoraIIIFConfigForm.php
+++ b/modules/islandora_iiif/src/Form/IslandoraIIIFConfigForm.php
@@ -73,6 +73,14 @@ class IslandoraIIIFConfigForm extends ConfigFormBase {
       '#description' => $this->t('Please enter the image server location without trailing slash. e.g. http://www.example.org/iiif/2.'),
       '#default_value' => $config->get('iiif_server'),
     ];
+
+    $form['use_relative_paths'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t("Use relative file paths in manifest."),
+      '#description' => $this->t("Check this if your IIIF Server is configured to access files locally. If unchecked, the absolute URL will be given and the IIIF server will make requests to this site to retrieve images."),
+      '#default_value' => $config->get('use_relative_paths'),
+    ];
+
     return parent::buildForm($form, $form_state);
   }
 
@@ -99,6 +107,7 @@ class IslandoraIIIFConfigForm extends ConfigFormBase {
 
     $this->config('islandora_iiif.settings')
       ->set('iiif_server', $form_state->getValue('iiif_server'))
+      ->set('use_relative_paths', $form_state->getValue('use_relative_paths'))
       ->save();
   }
 

--- a/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
+++ b/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
@@ -5,6 +5,7 @@ namespace Drupal\islandora_iiif\Plugin\views\style;
 use Drupal\Core\Config\ImmutableConfig;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\Field\FieldItemInterface;
 use Drupal\Core\Form\FormStateInterface;

--- a/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
+++ b/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
@@ -229,7 +229,7 @@ class IIIFManifest extends StylePluginBase {
           // Create the IIIF URL for this file
           // Visiting $iiif_url will resolve to the info.json for the image.
           if ($this->iiifConfig->get('use_relative_paths')) {
-          $file_url = ltrim($image->entity->createFileUrl(TRUE), '/');
+            $file_url = ltrim($image->entity->createFileUrl(TRUE), '/');
           }
           else {
             $file_url = $image->entity->createFileUrl(FALSE);

--- a/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
+++ b/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
@@ -228,7 +228,13 @@ class IIIFManifest extends StylePluginBase {
 
           // Create the IIIF URL for this file
           // Visiting $iiif_url will resolve to the info.json for the image.
-          $file_url = $image->entity->createFileUrl(FALSE);
+          if ($this->iiifConfig->get('use_relative_paths')) {
+          $file_url = ltrim($image->entity->createFileUrl(TRUE), '/');
+          }
+          else {
+            $file_url = $image->entity->createFileUrl(FALSE);
+          }
+
           $mime_type = $image->entity->getMimeType();
           $iiif_url = rtrim($iiif_address, '/') . '/' . urlencode($file_url);
 


### PR DESCRIPTION
**GitHub Issue**: [(link)](https://github.com/Islandora/islandora/issues/964)

# What does this Pull Request do?

Adds a configuration option for IIIF manifests to use relative paths for image URLs.

# What's new?

Adds a config option to make IIIF manifests use local file paths.
* Does this change add any new dependencies? No
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? No
* Could this change impact execution of existing code? No

# How should this be tested?

On an Islandora site set up with Islandora IIIF and paged content, go to a piece of paged content, and's manifest URL, usually node/[node:nid]/book-manifest or .../manifest.

Note the image URLs under canvases > images > resources include URL encoded strings representing the full URL of the image, including the Drupal site host.

Go to the Admin settings page for Islandora IIIF, /admin/config/islandora/iiif

Check the 'Use relative paths' option and save the settings.

Reload the same manifest and inspect the @id elements under canvases > resources and note they don't include the full (encoded) url of the Drupal site but only the relative path.
# Documentation Status

* Does this change existing behaviour that's currently documented? No
* Does this change require new pages or sections of documentation? No
* Who does this need to be documented for?
* Associated documentation pull request(s): ___  or documentation issue ___ TK

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

If you want to test this fully including a Cantaloupe stack I can give an example site config and Cantaloupe properties file.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
