### PR TITLE
Add push to Gitlab action.

### DIFF
--- a/.github/workflows/gitlab-mirror.yml
+++ b/.github/workflows/gitlab-mirror.yml
@@ -1,0 +1,21 @@
+name: Mirror and run GitLab CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Mirror + trigger CI
+      uses: SvanBoxel/gitlab-mirror-and-ci-action@master
+      with:
+        args: "https://git.drupalcode.org/project/islandora"
+      env:
+        FOLLOW_TAGS: "true"
+        FORCE_PUSH: "false"
+        GITLAB_HOSTNAME: "git.drupal.org"
+        GITLAB_USERNAME: "project_34868_bot"
+        GITLAB_PASSWORD: ${{ secrets.GITLAB_PASSWORD }}
+        GITLAB_PROJECT_ID: "34868"
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gitlab-mirror.yml
+++ b/.github/workflows/gitlab-mirror.yml
@@ -1,6 +1,8 @@
 name: Mirror and run GitLab CI
 
-on: [push]
+on:
+  push:
+    branches: [2.x]
 
 jobs:
   build:


### PR DESCRIPTION
**GitHub Issue**: IslandoraCon 2023 Use-a-thon

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What does this Pull Request do?

Pushes the repo and tags to the Drupal.org gitlab.

@Natkeeran 
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
