### PR TITLE
Deprecate advanced_search.

### DIFF
--- a/modules/islandora_advanced_search/islandora_advanced_search.info.yml
+++ b/modules/islandora_advanced_search/islandora_advanced_search.info.yml
@@ -9,3 +9,5 @@ dependencies:
   - drupal:facets
   - drupal:facets_summary
   - drupal:search_api_solr
+lifecycle: deprecated
+lifecycle_link: https://groups.google.com/g/islandora/c/SEOAWJrfE_M


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/2001

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What does this Pull Request do?

Marks the Islandora submodule "Islandora Advanced Search" as deprecated, linking to the deprecation announcement.

# How should this be tested?

Islandora Advanced Search will be marked "Deprecated" under the "Extend" tab.

# Documentation Status

* Does this change existing behaviour that's currently documented? perhaps - another PR will follow.
* Does this change require new pages or sections of documentation? no
* Who does this need to be documented for? n/a
* Associated documentation pull request(s): ___  or documentation issue ___

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
