### PR TITLE
959 Use image dimension properties in IIIF Manifest if they exist…

### DIFF
--- a/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
+++ b/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
@@ -313,6 +313,12 @@ class IIIFManifest extends StylePluginBase {
    *   The width and height of the image.
    */
   protected function getCanvasDimensions(string $iiif_url, FieldItemInterface $image, string $mime_type) {
+
+    if (isset($image->width)
+    && isset($image->height)) {
+      return [$image->width, $image->height];
+    }
+
     try {
       $info_json = $this->httpClient->get($iiif_url)->getBody();
       $resource = json_decode($info_json, TRUE);

--- a/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
+++ b/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
@@ -314,9 +314,9 @@ class IIIFManifest extends StylePluginBase {
    */
   protected function getCanvasDimensions(string $iiif_url, FieldItemInterface $image, string $mime_type) {
 
-    if (isset($image->width)
-    && isset($image->height)) {
-      return [$image->width, $image->height];
+    if (isset($image->width) && is_numeric($image->width)
+    && isset($image->height) && is_numeric($image->height)) {
+      return [intval($image->width), intval($image->height)];
     }
 
     try {


### PR DESCRIPTION

**GitHub Issue**: (link)

#959

# What does this Pull Request do?


When generating IIIF manifests, get with and height from the image field properties if they exist.

# What's new?

If the site builder has chosen to use Service Files or otherwise picks a field that is an image type for the source of the image tiles, we have direct access to the image's dimensions and don't need to get them from Cantaloupe or by examining the file.
 This greatly speeds up IIIF generation and takes a lot of load off of the Cantaloupe IIIF server.

* Does this change add any new dependencies? 
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)?  No
* Could this change impact execution of existing code? No

# How should this be tested?

If using the Starter Site:

1. Go to Admin -> Structure -> Views and edit IIIF Manifest 
2. For the default view, with path /node/%node/book-manifest, edit the settings for the IIIF Manifest in the Format section.
3. Uncheck 'File, leaving 'Image' checked.
    ![image](https://github.com/Islandora/islandora/assets/82412/e1feb82e-d770-46fb-80f0-66a666066ca3)
4. Clear Drupal's cache
5. Add a repository item with model Paged Content.
6. Add at least one child page Reposity Item with model Page.
7. Add a media to the page object(s). It can be a TIFF or JPEG, we are going be using the Service File regardless.
8. Tail the cantaloupe log, if running in Docker, it's likely: docker compose logs -f cantaloupe
9. Clear Drupal's cache.
10. Go to /node/[nid]/book-manifest where nid is the node id of the Paged Content item.
11. You should not see any activity in the Cantaloupe logs for the manifest request.


# Documentation Status

* Does this change existing behaviour that's currently documented? No
* Does this change require new pages or sections of documentation? No
* Who does this need to be documented for? N/A


# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
