### PR TITLE
Format the 'Fedora URI' label as a label.

### DIFF
--- a/islandora.module
+++ b/islandora.module
@@ -686,13 +686,17 @@ function islandora_entity_view(array &$build, EntityInterface $entity, EntityVie
           'id' => 'field-gemini-uri',
         ],
         'internal_label' => [
-          '#type' => 'item',
-          '#title' => t('Fedora URI'),
-          'internal_uri' => [
-            '#type' => 'link',
-            '#title' => t("@url", ['@url' => $fedora_uri]),
-            '#url' => Url::fromUri($fedora_uri),
+          '#type' => 'html_tag',
+          '#tag' => 'div',
+          '#attributes' => [
+            'class' => ['field__label'],
           ],
+          '#value' => t('Fedora URI:'),
+        ],
+        'internal_uri' => [
+          '#type' => 'link',
+          '#title' => t("@url", ['@url' => $fedora_uri]),
+          '#url' => Url::fromUri($fedora_uri),
         ],
       ];
     }
@@ -742,3 +746,4 @@ function islandora_preprocess_views_view_table(&$variables) {
     }
   }
 }
+

--- a/islandora.module
+++ b/islandora.module
@@ -746,4 +746,3 @@ function islandora_preprocess_views_view_table(&$variables) {
     }
   }
 }
-


### PR DESCRIPTION
**GitHub Issue**: https://github.com/LEAF-VRE/islandora-UX-useathon/issues/13

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What does this Pull Request do?

Bolds the Fedora URI label.

# What's new?

* Changes the HTML tag surrounding the "Fedora URI" pseudo-field label to match field labels. 
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)?  no
* Could this change impact execution of existing code?
    * This could mess up your custom CSS if you are fixing this issue a different way.

# How should this be tested?

Load up a repository item and see that the Fedora URI field should be bolded.

<img width="740" alt="Screenshot 2023-08-07 at 4 06 17 PM" src="https://github.com/Islandora/islandora/assets/1943338/dcdeb423-fb75-4983-99c1-c03dc7595361">


# Documentation Status

* Does this change existing behaviour that's currently documented? no
* Does this change require new pages or sections of documentation? no
* Who does this need to be documented for? n/a
* Associated documentation pull request(s): ___  or documentation issue ___

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
@steinburgb
@ilovan
 @Islandora/committers
