### PR TITLE
Add media save redirect.

### DIFF
--- a/config/schema/islandora.schema.yml
+++ b/config/schema/islandora.schema.yml
@@ -17,6 +17,9 @@ islandora.settings:
     delete_media_and_files:
       type: boolean
       label: 'Node Delete with Media and Files'
+    redirect_after_media_save:
+      type: boolean
+      label: 'Redirect to node after media save.'
     upload_form_location:
       type: string
       label: 'Upload Form Location'

--- a/islandora.install
+++ b/islandora.install
@@ -212,3 +212,17 @@ function islandora_update_8007() {
   // have the here, just in case?
   throw new UpdateException('Failed; hit the end of the update hook implementation, which is not expected.');
 }
+
+/**
+ * Set config to no redirect after media save.
+ */
+function islandora_update_8008() {
+  $config = \Drupal::configFactory()->getEditable('islandora.settings');
+  if ($config) {
+    $config->set('redirect_after_media_save', FALSE);
+    $config->save(TRUE);
+    return t('A new configuration option, "Redirect after media save" is now available. 
+    It has been turned off to preserve existing behaviour. To enable this setting visit 
+    Configuration > Islandora > Core Settings.');
+  }
+}

--- a/islandora.module
+++ b/islandora.module
@@ -392,14 +392,16 @@ function islandora_form_alter(&$form, FormStateInterface $form_state, $form_id) 
  * Redirect submit handler for media save.
  */
 function islandora_media_custom_form_submit(&$form, FormStateInterface $form_state) {
-  $params = \Drupal::request()->query->all();
-
-  if (!empty($params)) {
-    $target_id = $params['edit']['field_media_of']['widget'][0]['target_id'];
-    $url = Url::fromRoute('entity.node.canonical', ['node' => $target_id]);
-    $form_state->setRedirectUrl($url);
+  // Check configuration to see whether a redirect is desired.
+  $redirect = \Drupal::config('islandora.settings')->get('redirect_after_media_save');
+  if ($redirect) {
+    $params = \Drupal::request()->query->all();
+    if (!empty($params)) {
+      $target_id = $params['edit']['field_media_of']['widget'][0]['target_id'];
+      $url = Url::fromRoute('view.media_of.page_1', ['node' => $target_id]);
+      $form_state->setRedirectUrl($url);
+    }
   }
-
 }
 
 /**

--- a/islandora.module
+++ b/islandora.module
@@ -332,6 +332,7 @@ function islandora_form_alter(&$form, FormStateInterface $form_state, $form_id) 
       if ($node) {
         $form['name']['widget'][0]['value']['#default_value'] = $node->getTitle();
       }
+      $form['actions']['submit']['#submit'][] = 'islandora_media_custom_form_submit';
     }
   }
 
@@ -385,6 +386,20 @@ function islandora_form_alter(&$form, FormStateInterface $form_state, $form_id) 
   }
 
   return $form;
+}
+
+/**
+ * Redirect submit handler for media save.
+ */
+function islandora_media_custom_form_submit(&$form, FormStateInterface $form_state) {
+  $params = \Drupal::request()->query->all();
+
+  if (!empty($params)) {
+    $target_id = $params['edit']['field_media_of']['widget'][0]['target_id'];
+    $url = Url::fromRoute('entity.node.canonical', ['node' => $target_id]);
+    $form_state->setRedirectUrl($url);
+  }
+
 }
 
 /**

--- a/src/Form/IslandoraSettingsForm.php
+++ b/src/Form/IslandoraSettingsForm.php
@@ -214,7 +214,7 @@ class IslandoraSettingsForm extends ConfigFormBase {
     $form[self::REDIRECT_AFTER_MEDIA_SAVE] = [
       '#type' => 'checkbox',
       '#title' => $this->t('Redirect after media save.'),
-      '#description' => $this->t('Redirect to node page after creation of media.'),
+      '#description' => $this->t('Redirect to node-specific media list after creation of media.'),
       '#default_value' => (bool) $config->get(self::REDIRECT_AFTER_MEDIA_SAVE),
     ];
 

--- a/src/Form/IslandoraSettingsForm.php
+++ b/src/Form/IslandoraSettingsForm.php
@@ -43,6 +43,7 @@ class IslandoraSettingsForm extends ConfigFormBase {
   ];
   const GEMINI_PSEUDO_FIELD = 'field_gemini_uri';
   const NODE_DELETE_MEDIA_AND_FILES = 'delete_media_and_files';
+  const REDIRECT_AFTER_MEDIA_SAVE = 'redirect_after_media_save';
 
   /**
    * To list the available bundle types.
@@ -210,6 +211,13 @@ class IslandoraSettingsForm extends ConfigFormBase {
       '#default_value' => (bool) $config->get(self::NODE_DELETE_MEDIA_AND_FILES),
     ];
 
+    $form[self::REDIRECT_AFTER_MEDIA_SAVE] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Redirect after media save.'),
+      '#description' => $this->t('Redirect to node page after creation of media.'),
+      '#default_value' => (bool) $config->get(self::REDIRECT_AFTER_MEDIA_SAVE),
+    ];
+
     $form[self::FEDORA_URL] = [
       '#type' => 'textfield',
       '#title' => $this->t('Fedora URL'),
@@ -361,6 +369,7 @@ class IslandoraSettingsForm extends ConfigFormBase {
       ->set(self::UPLOAD_FORM_ALLOWED_MIMETYPES, $form_state->getValue(self::UPLOAD_FORM_ALLOWED_MIMETYPES))
       ->set(self::GEMINI_PSEUDO, $new_pseudo_types)
       ->set(self::NODE_DELETE_MEDIA_AND_FILES, $form_state->getValue(self::NODE_DELETE_MEDIA_AND_FILES))
+      ->set(self::REDIRECT_AFTER_MEDIA_SAVE, $form_state->getValue(self::REDIRECT_AFTER_MEDIA_SAVE))
       ->save();
 
     parent::submitForm($form, $form_state);


### PR DESCRIPTION
**GitHub Issue**: https://github.com/LEAF-VRE/islandora-UX-useathon/issues/3

# What does this Pull Request do?

Redirects you to the node page after creating a media from "Add Media".

# What's new?

* Adds a redirect
* Does this change add any new dependencies?  no
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# How should this be tested?

Create a node and create an attached media. Without this PR, you land at the global media view.
With this PR, you land on a node.
It should also not break when you create a media that is not a member of a node.
This applies only to the creation of new media 

# Documentation Status

* Does this change existing behaviour that's currently documented? yes - https://islandora.github.io/documentation/tutorials/create-a-resource-node/ 
* Does this change require new pages or sections of documentation? no
* Who does this need to be documented for? admins
* Associated documentation pull request(s): ___  or documentation issue ___

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
