### PR TITLE
Stripping out json metadata in the queue messages except for the ones…

### DIFF
--- a/src/EventGenerator/EventGenerator.php
+++ b/src/EventGenerator/EventGenerator.php
@@ -147,8 +147,11 @@ class EventGenerator implements EventGeneratorInterface {
       }
     }
 
-    unset($data["event"]);
-    unset($data["queue"]);
+    $allowed_keys = ["file_upload_uri", "fedora_uri", "source_uri", "destination_uri", "args", "mimetype", "source_field"];
+    $keys_to_unset = array_diff(array_keys($data), $allowed_keys);
+    foreach ($keys_to_unset as $key) {
+      unset($data[$key]);
+    }
 
     if (!empty($data)) {
       $event["attachment"] = [

--- a/src/EventGenerator/EventGenerator.php
+++ b/src/EventGenerator/EventGenerator.php
@@ -147,7 +147,15 @@ class EventGenerator implements EventGeneratorInterface {
       }
     }
 
-    $allowed_keys = ["file_upload_uri", "fedora_uri", "source_uri", "destination_uri", "args", "mimetype", "source_field"];
+    $allowed_keys = [
+      "file_upload_uri",
+      "fedora_uri",
+      "source_uri",
+      "destination_uri",
+      "args",
+      "mimetype",
+      "source_field",
+    ];
     $keys_to_unset = array_diff(array_keys($data), $allowed_keys);
     foreach ($keys_to_unset as $key) {
       unset($data[$key]);


### PR DESCRIPTION
… java is expecting

**GitHub Issue**: https://github.com/Islandora/islandora/issues/972

# What does this Pull Request do?

Filters out everything that goes into the json blob on queue messages other than what Camel is expecting on the other side.

# How should this be tested?

- Install VBO
- Add the VBO widget to a view
- Try to use the VBO widget to perform a derivative action, like "Generate an image derivative"
![image](https://github.com/Islandora/islandora/assets/20773151/db6860be-f8eb-4d3e-b6f2-8bf8777d97f5)
- Fill out the little form it makes you fill out.  This makes it regen the service file as a jpeg
![image](https://github.com/Islandora/islandora/assets/20773151/0f5085c4-0ac0-4e02-92dc-d56201db1276)

## Before fix
- Alpaca logs will contain

```
alpaca_1 | 2023-08-24T00:41:11.804751513Z 2023-08-24 00:41:11,804 | ERROR | nnector-houdini] | DefaultErrorHandler | 56 - org.apache.camel.camel-core - 2.20.4 | Failed delivery for (MessageId: ID:484a3574eabd-35331-1690401177428-3:137507👎1:19 on ExchangeId: ID-5c8908e3ad99-1690401207016-3-731092). Exhausted after delivery attempt: 11 caught: com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "add_confirmation" (class ca.islandora.alpaca.support.event.AS2AttachmentContent), not marked as ignorable (7 known properties: "file_upload_uri", "fedora_uri", "source_uri", "destination_uri", "args", "mimetype", "source_field"])
```
- You will not have new derivatives

## After fix
- Alpaca logs will not have the error message above
- You will have new derivatives

# Documentation Status

* Does this change require new pages or sections of documentation?
  * Might wanna mention you're VBO compatible somewhere
  
# Interested parties
@Islandora/committers
