### PR TITLE
Force push 2x branch to Gitlab

### DIFF
--- a/.github/workflows/gitlab-mirror.yml
+++ b/.github/workflows/gitlab-mirror.yml
@@ -16,7 +16,7 @@ jobs:
         args: "https://git.drupalcode.org/project/islandora"
       env:
         FOLLOW_TAGS: "true"
-        FORCE_PUSH: "false"
+        FORCE_PUSH: "true"
         GITLAB_HOSTNAME: "git.drupal.org"
         GITLAB_USERNAME: "project_34868_bot"
         GITLAB_PASSWORD: ${{ secrets.GITLAB_PASSWORD }}


### PR DESCRIPTION
**GitHub Issue**: 
N/A. Tags are not being pushed to Drupal.org's Gitlab consistently. 

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.) 
 N/A

# What does this Pull Request do?
It forces a push of the 2.x branch to Gitlab. 

A brief description of what the intended result of the PR will be and/or what
 problem it solves.
Should fix theses errors I believe: https://github.com/Islandora/islandora/actions/runs/6300409377/job/17103202042#step:4:20

# What's new?
A in-depth description of the changes made by this PR. Technical details and
 possible side effects.
Changes line here from false to true: https://github.com/Islandora/islandora/blob/2.x/.github/workflows/gitlab-mirror.yml#L19

* Changes x feature to such that y
* Added x
* Removed y
* Does this change add any new dependencies? 
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? 
* Could this change impact execution of existing code?

# How should this be tested?
Probably needs to be merged to see the change.

A description of what steps someone could take to:
* Reproduce the problem you are fixing (if applicable)
* Test that the Pull Request does what is intended.
* Please be as detailed as possible.
* Good testing instructions help get your PR completed faster.

# Documentation Status

* Does this change existing behaviour that's currently documented?
* Does this change require new pages or sections of documentation?
* Who does this need to be documented for?
* Associated documentation pull request(s): ___  or documentation issue ___

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
