### PR TITLE
Specify fetch-depth during mirroring to gitlab.

### DIFF
--- a/.github/workflows/gitlab-mirror.yml
+++ b/.github/workflows/gitlab-mirror.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     - name: Mirror + trigger CI
       uses: SvanBoxel/gitlab-mirror-and-ci-action@master
       with:


### PR DESCRIPTION
**GitHub Issue**: actions failed, e.g. https://github.com/Islandora/islandora/actions/runs/6300409377/job/17103202042#step:4:20

Similar ticket, taking the --force option: 
* https://github.com/Islandora/islandora/pull/981

* Issue with the mirroring script/source for this fix: https://github.com/SvanBoxel/gitlab-mirror-and-ci-action/issues/17

# What does this Pull Request do?

We were having problems because the during the action, the checked out repository didn't match the target gitlab - 
```
hint: Updates were rejected because the remote contains work that you do
hint: not have locally. This is usually caused by another repository pushing
hint: to the same ref. You may want to first integrate the remote changes
hint: (e.g., 'git pull ...') before pushing again. 
```

There dont' seem to be commits in gitlab that aren't in github. 

So, this is probably due to the new checkout actions including `v3` defaulting to only check out information about the latest commit. We apparently can use `fetch-depth: 0` to revert to getting all commits.

@aOelschlager , @Islandora/committers
