### PR TITLE
Do not render the pdf_url metatag if there is no value

### DIFF
--- a/islandora.tokens.inc
+++ b/islandora.tokens.inc
@@ -188,4 +188,5 @@ function islandora_url_to_service_file_media_by_mimetype($node, $mime_type) {
       }
     }
   }
+  return '';
 }

--- a/islandora.tokens.inc
+++ b/islandora.tokens.inc
@@ -134,7 +134,7 @@ function islandora_tokens($type, $tokens, array $data, array $options, Bubbleabl
           break;
 
         case 'pdf_url':
-          $replacements[$original] = ' ' . islandora_url_to_service_file_media_by_mimetype($data['node'], 'application/pdf');
+          $replacements[$original] = islandora_url_to_service_file_media_by_mimetype($data['node'], 'application/pdf');
           break;
       }
     }


### PR DESCRIPTION
# What does this Pull Request do?

With the space added to the `[islandoratokens:pdf_url]` token, if that token is used in metatags, the `<meta>` element always renders even if there is no PDF associated with the given node.

Also updates the function that token uses to always return a string.

# What's new?

Remove the space from the token.

# How should this be tested?

* Enable the metatags module
* Add `[islandoratokens:pdf_url]` to one of the metatag elements (for testing purposes, it can be any element)
* Visit a node/XYZ page on your site that does not have a PDF
* View the HTML source and see `<meta name="citation_pdf_url" content=" " />`
* Apply this PR
* See that that element no longer shows

# Documentation Status

* Does this change existing behaviour that's currently documented? no
* Does this change require new pages or sections of documentation? no
* Who does this need to be documented for? no

# Interested parties
@Islandora/committers
@wgilling 