### PR TITLE
Add COI integration to islandora settings form.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     "sebastian/phpcpd": "*"
   },
   "suggest": {
-    "drupal/transliterate_filenames": "Sanitizes filenames when they are uploaded so they don't break your repository."
+    "drupal/transliterate_filenames": "Sanitizes filenames when they are uploaded so they don't break your repository.",
     "drupal/coi": "Some configuration fields work with Config Override Inspector."
   },
   "license": "GPL-2.0-or-later",

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
   },
   "suggest": {
     "drupal/transliterate_filenames": "Sanitizes filenames when they are uploaded so they don't break your repository."
+    "drupal/coi": "Some configuration fields work with Config Override Inspector."
   },
   "license": "GPL-2.0-or-later",
   "authors": [

--- a/modules/islandora_iiif/src/Form/IslandoraIIIFConfigForm.php
+++ b/modules/islandora_iiif/src/Form/IslandoraIIIFConfigForm.php
@@ -72,6 +72,9 @@ class IslandoraIIIFConfigForm extends ConfigFormBase {
       '#title' => $this->t('IIIF Image server location'),
       '#description' => $this->t('Please enter the image server location without trailing slash. e.g. http://www.example.org/iiif/2.'),
       '#default_value' => $config->get('iiif_server'),
+      '#config' => [
+        'key' => 'islandora_iiif.settings:iiif_server',
+      ],
     ];
 
     $form['use_relative_paths'] = [

--- a/src/Form/IslandoraSettingsForm.php
+++ b/src/Form/IslandoraSettingsForm.php
@@ -167,6 +167,7 @@ class IslandoraSettingsForm extends ConfigFormBase {
       ],
       '#config' => [
         'key' => 'islandora.settings:' . self::BROKER_PASSWORD,
+        'secret' => TRUE,
       ],
     ];
     $form[self::JWT_EXPIRY] = [

--- a/src/Form/IslandoraSettingsForm.php
+++ b/src/Form/IslandoraSettingsForm.php
@@ -129,6 +129,9 @@ class IslandoraSettingsForm extends ConfigFormBase {
       '#type' => 'textfield',
       '#title' => $this->t('URL'),
       '#default_value' => $config->get(self::BROKER_URL),
+      '#config' => [
+        'key' => 'islandora.settings:' . self::BROKER_URL,
+      ],
     ];
     $broker_user = $config->get(self::BROKER_USER);
     $form['broker_info']['provide_user_creds'] = [
@@ -149,6 +152,9 @@ class IslandoraSettingsForm extends ConfigFormBase {
           $state_selector => ['checked' => TRUE],
         ],
       ],
+      '#config' => [
+        'key' => 'islandora.settings:' . self::BROKER_USER,
+      ],
     ];
     $form['broker_info'][self::BROKER_PASSWORD] = [
       '#type' => 'password',
@@ -158,6 +164,9 @@ class IslandoraSettingsForm extends ConfigFormBase {
         'visible' => [
           $state_selector => ['checked' => TRUE],
         ],
+      ],
+      '#config' => [
+        'key' => 'islandora.settings:' . self::BROKER_PASSWORD,
       ],
     ];
     $form[self::JWT_EXPIRY] = [
@@ -221,7 +230,11 @@ class IslandoraSettingsForm extends ConfigFormBase {
     $form[self::FEDORA_URL] = [
       '#type' => 'textfield',
       '#title' => $this->t('Fedora URL'),
-      '#attributes' => ['readonly' => 'readonly'],
+      '#description' => $this->t('Read-only. This value is set in settings.php as the URL for the Fedora flysystem.'),
+      '#attributes' => [
+        'readonly' => 'readonly',
+        'disabled' => 'disabled',
+      ],
       '#default_value' => $fedora_url,
     ];
 


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-Devops/islandora-starter-site/issues/112

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)
* https://github.com/Islandora-Devops/islandora-starter-site/issues/17

# What does this Pull Request do?

Adds a key to the islandora settings form that allows the Config Override Inspector (COI) module to note these fields as overridden. (It can disable the fields and display a custom message too)

# What's new?
Enables COI on select islandora settings fields.

* Does this change add any new dependencies? No - this does not do anything if COI is not enabled)
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)?  No
* Could this change impact execution of existing code? No

# How should this be tested?

* Install Islandora using a method that uses the settings.php file to override config - for example, the site template currently does this.
* Visit the form fields for overridden values. You will see the "saved config" value which is overridden so not actually active. You will also be able to change the "saved config" value.
* Install Config Override Inspector (coi). Before this PR, nothing happens. But with this PR, the Islandora settings values are marked as overridden.


<img width="1044" alt="Screenshot 2023-10-23 at 1 55 31 PM" src="https://github.com/Islandora/islandora/assets/1943338/231baba9-aba0-40ed-b1ea-690adf8de0b6">
("Provide User identification" section opened for clarity; the form has it closed by default).


# Documentation Status

* Does this change existing behaviour that's currently documented? no
* Does this change require new pages or sections of documentation? perhaps
* Who does this need to be documented for? site admins
* Associated documentation pull request(s): ___  or documentation issue ___

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
