### PR TITLE
Add PHP 8.2 <strike>and Drupal 10.2</strike> to testing matrix

### DIFF
--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -23,10 +23,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ["8.1"]
+        php-versions: ["8.1", "8.2"]
         # test-suite functional-javascript will appear to pass but will skip tests; missing chromedriver.
         test-suite: ["kernel", "functional", "functional-javascript"]
-        drupal-version: ["9.5.x", "10.0.x", "10.1.x"]
+        drupal-version: ["10.0.x", "10.1.x", "10.2.x-dev"]
         mysql: ["8.0"]
         allowed_failure: [false]
 

--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -26,7 +26,7 @@ jobs:
         php-versions: ["8.1", "8.2"]
         # test-suite functional-javascript will appear to pass but will skip tests; missing chromedriver.
         test-suite: ["kernel", "functional", "functional-javascript"]
-        drupal-version: ["10.0.x", "10.1.x", "10.2.x-dev"]
+        drupal-version: ["10.0.x", "10.1.x"] # Fails on 10.2 until https://github.com/Islandora/islandora/issues/989 is resolved.
         mysql: ["8.0"]
         allowed_failure: [false]
 

--- a/config/install/islandora.settings.yml
+++ b/config/install/islandora.settings.yml
@@ -1,5 +1,4 @@
 broker_url: 'tcp://localhost:61613'
 jwt_expiry: '+2 hour'
-gemini_url: ''
 delete_media_and_files: TRUE
 gemini_pseudo_bundles: []

--- a/config/schema/islandora.schema.yml
+++ b/config/schema/islandora.schema.yml
@@ -26,9 +26,6 @@ islandora.settings:
     upload_form_allowed_mimetypes:
       type: string
       label: 'Upload Form Allowed Extensions'
-    gemini_url:
-      type: uri
-      label: 'Url to Gemini microservice'
     gemini_pseudo_bundles:
       type: sequence
       label: 'List of node, media and taxonomy terms that should include the linked Fedora URI'

--- a/modules/islandora_text_extraction/src/Plugin/Field/FieldFormatter/OcrTextFormatter.php
+++ b/modules/islandora_text_extraction/src/Plugin/Field/FieldFormatter/OcrTextFormatter.php
@@ -132,8 +132,9 @@ class OcrTextFormatter extends FormatterBase implements ContainerFactoryPluginIn
     $fileItem = $item->getValue();
     $file = $this->entityTypeManager->getStorage('file')->load($fileItem['target_id']);
     $contents = file_get_contents($file->getFileUri());
-    if (mb_detect_encoding($contents) != 'UTF-8') {
-      $contents = utf8_encode($contents);
+    $detected_encoding = mb_detect_encoding($contents);
+    if ($detected_encoding != 'UTF-8') {
+      $contents = mb_convert_encoding($contents, 'UTF-8', $detected_encoding);
     }
     $contents = nl2br($contents);
     return $contents;

--- a/tests/src/Kernel/EventGeneratorTest.php
+++ b/tests/src/Kernel/EventGeneratorTest.php
@@ -49,7 +49,7 @@ class EventGeneratorTest extends IslandoraKernelTestBase {
 
     $test_type = NodeType::create([
       'type' => 'test_type',
-      'label' => 'Test Type',
+      'name' => 'Test Type',
     ]);
     $test_type->save();
 


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/2262

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)
Discussed at Committers Call Oct 18, 2023

# What does this Pull Request do?

Adds PHP 8.2 and Drupal 10.2 to the testing matrix. Removes Drupal 9.5 (6 days till EOL).

# How should this be tested?

Check the tests! Likely they will fail, and/or reveal some deprecations and other things we need to take care of. This should probably be merged anyway and the tests dealt with separately.

# Documentation Status

* Does this change existing behaviour that's currently documented? no
* Does this change require new pages or sections of documentation? no
* Who does this need to be documented for? no
* Associated documentation pull request(s): ___  or documentation issue ___

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
