### PR TITLE
Update to use the new hook.

### DIFF
--- a/islandora.module
+++ b/islandora.module
@@ -545,14 +545,14 @@ function islandora_object_delete_form_submit($form, FormStateInterface $form_sta
 }
 
 /**
- * Implements hook_field_widget_WIDGET_TYPE_form_alter().
+ * Implements hook_field_widget_single_element_WIDGET_TYPE_form_alter().
  */
-function islandora_field_widget_image_image_form_alter(&$element, $form_state, $context) {
+function islandora_field_widget_single_element_image_image_form_alter(&$element, $form_state, $context) {
   $element['#process'][] = 'islandora_add_default_image_alt_text';
 }
 
 /**
- * Callback for hook_field_widget_WIDGET_TYPE_form_alter().
+ * Callback for hook_field_widget_single_element_WIDGET_TYPE_form_alter().
  */
 function islandora_add_default_image_alt_text($element, $form_state, $form) {
   if ($element['alt']['#access']) {


### PR DESCRIPTION
`hook_field_widget_WIDGET_TYPE_form_alter()` was deprecated in Drupal 9.2.0 and removed in Drupal 10; however, it was what this functionality was using.

It has been replaced with
`hook_field_widget_single_element_WIDGET_TYPE_form_alter()`.

See: https://www.drupal.org/node/3180429

**GitHub Issue**: (link)

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What does this Pull Request do?

Fixes the hook naming, so the alt-text should be populated as it used to be.

# What's new?

Nothing, just fixing.

# How should this be tested?

See https://github.com/Islandora/islandora/pull/783

# Documentation Status

* Does this change existing behaviour that's currently documented? No.
* Does this change require new pages or sections of documentation? No.
* Who does this need to be documented for? Nobody, is fixing pre-existing functionality.
* Associated documentation pull request(s): ___  or documentation issue ___ N/A

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
