### PR TITLE
8.2 deprecations from tests

### DIFF
--- a/tests/src/Functional/AddChildTest.php
+++ b/tests/src/Functional/AddChildTest.php
@@ -10,12 +10,18 @@ namespace Drupal\Tests\islandora\Functional;
 class AddChildTest extends IslandoraFunctionalTestBase {
 
   /**
+   * The taxonomy term representing "Collection" items.
+   *
+   * @var \Drupal\taxonomy\TermInterface
+   */
+  protected $collectionTerm;
+
+  /**
    * {@inheritdoc}
    */
   public function setUp(): void {
     parent::setUp();
 
-    $this->parent =
     $this->collectionTerm = $this->container->get('entity_type.manager')->getStorage('taxonomy_term')->create([
       'name' => 'Collection',
       'vid' => $this->testVocabulary->id(),

--- a/tests/src/Functional/JsonldSelfReferenceReactionTest.php
+++ b/tests/src/Functional/JsonldSelfReferenceReactionTest.php
@@ -12,6 +12,13 @@ use function GuzzleHttp\json_decode;
  */
 class JsonldSelfReferenceReactionTest extends IslandoraFunctionalTestBase {
 
+	/**
+	 * An RDF Mapping object.
+	 *
+	 * @var \Drupal\rdf\Entity\RdfMapping
+	 */
+	protected $rdfMapping;
+
   /**
    * {@inheritdoc}
    */

--- a/tests/src/Functional/JsonldSelfReferenceReactionTest.php
+++ b/tests/src/Functional/JsonldSelfReferenceReactionTest.php
@@ -12,12 +12,12 @@ use function GuzzleHttp\json_decode;
  */
 class JsonldSelfReferenceReactionTest extends IslandoraFunctionalTestBase {
 
-	/**
-	 * An RDF Mapping object.
-	 *
-	 * @var \Drupal\rdf\Entity\RdfMapping
-	 */
-	protected $rdfMapping;
+  /**
+   * An RDF Mapping object.
+   *
+   * @var \Drupal\rdf\Entity\RdfMapping
+   */
+  protected $rdfMapping;
 
   /**
    * {@inheritdoc}

--- a/tests/src/Kernel/FedoraAdapterTest.php
+++ b/tests/src/Kernel/FedoraAdapterTest.php
@@ -354,7 +354,7 @@ class FedoraAdapterTest extends IslandoraKernelTestBase {
 
     $metadata = $adapter->read('');
     $this->assertFileMetadata($metadata);
-    $this->assertTrue($metadata['contents'] == "DERP", "Expecting 'content' of 'DERP', received '${metadata['contents']}'");
+    $this->assertTrue($metadata['contents'] == "DERP", "Expecting 'content' of 'DERP', received '{$metadata['contents']}'");
   }
 
   /**


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-Devops/isle-dc/issues/356

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.) the logs from the latest php 8.2 test runs have a lot of deprecations.

# What does this Pull Request do?

This should remove some/all of the deprecation problems in the logs when our CI Action runs.

(note: a lot of fuss is created by [Drupal Facets which is a separate issue](https://www.drupal.org/project/features/issues/3375425), at the moment of writing this it's RTBC. 

# What's new?

* Declare two variables
* Removed one unused variable (perhaps false start?)
* Reworked how a variable was included in a string.

* Does this change add any new dependencies?  no
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? shouldn't.

# How should this be tested?

Wait till tests run. Then, under PHPUnit Tests for all the 8.2 runs, are there any _non-Features-related_ deprecations listed?

# Documentation Status

* Does this change existing behaviour that's currently documented? n/a
* Does this change require new pages or sections of documentation? n/a
* Who does this need to be documented for? n/a
* Associated documentation pull request(s): ___  or documentation issue ___

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
