### PR TITLE
Use FileUrlGeneratorInterface

### DIFF
--- a/src/Plugin/Field/FieldFormatter/IslandoraImageFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/IslandoraImageFormatter.php
@@ -57,7 +57,7 @@ class IslandoraImageFormatter extends ImageFormatter {
    *   The image style storage.
    * @param \Drupal\islandora\IslandoraUtils $utils
    *   Islandora utils.
-   * @param \Drupal\Core\File\FileUrlGenerator $file_url_generator
+   * @param \Drupal\Core\File\FileUrlGeneratorInterface $file_url_generator
    *   The File URL Generator.
    */
   public function __construct(

--- a/src/Plugin/Field/FieldFormatter/IslandoraImageFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/IslandoraImageFormatter.php
@@ -5,7 +5,7 @@ namespace Drupal\islandora\Plugin\Field\FieldFormatter;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Field\FieldItemListInterface;
-use Drupal\Core\File\FileUrlGenerator;
+use Drupal\Core\File\FileUrlGeneratorInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\image\Plugin\Field\FieldFormatter\ImageFormatter;
 use Drupal\islandora\IslandoraUtils;
@@ -71,7 +71,7 @@ class IslandoraImageFormatter extends ImageFormatter {
     AccountInterface $current_user,
     EntityStorageInterface $image_style_storage,
     IslandoraUtils $utils,
-    FileUrlGenerator $file_url_generator
+    FileUrlGeneratorInterface $file_url_generator
   ) {
     parent::__construct(
       $plugin_id,


### PR DESCRIPTION
**GitHub Issue**: N/A

Ran into an issue where I couldn't update an entity_view_display:
```
TypeError: Drupal\islandora\Plugin\Field\FieldFormatter\IslandoraImageFormatter::__construct(): Argument #11 ($file_url_generator) must be of type Drupal\Core\File\FileUrlGenerator, Drupal\cdn\File\FileUrlGenerator given, called in /var/www/html/drupal/web/modules/contrib/islandora/src/Plugin/Field/FieldFormatter/IslandoraImageFormatter.php on line 106 in /var/www/html/drupal/web/modules/contrib/islandora/src/Plugin/Field/FieldFormatter/IslandoraImageFormatter.php on line 63
#0 /var/www/html/drupal/web/modules/contrib/islandora/src/Plugin/Field/FieldFormatter/IslandoraImageFormatter.php(106): Drupal\islandora\Plugin\Field\FieldFormatter\IslandoraImageFormatter->__construct()
#1 /var/www/html/drupal/web/core/lib/Drupal/Core/Field/FormatterPluginManager.php(64): Drupal\islandora\Plugin\Field\FieldFormatter\IslandoraImageFormatter::create()
...
```

# What does this Pull Request do?

Replaces FileUrlGenerator class with FileUrlGeneratorInterface which preserves compatibility with CDN replacements.

# How should this be tested?

Not sure how to test this quickly. Mine was probably triggered by either our S3 integration or Cloudflare. Not sure which.

But, really, just smoke-test it and make sure tests pass.

# Interested parties
@Islandora/committers
