### PR TITLE
Cache terms returned by IslandoraUtils::getTermForUri() (Islandora#2272)

### DIFF
--- a/islandora.services.yml
+++ b/islandora.services.yml
@@ -54,7 +54,7 @@ services:
     arguments: ['@entity_type.manager', '@current_user', '@language_manager', '@file_system', '@islandora.utils']
   islandora.utils:
     class: Drupal\islandora\IslandoraUtils
-    arguments: ['@entity_type.manager', '@entity_field.manager', '@context.manager', '@flysystem_factory', '@language_manager', '@current_user']
+    arguments: ['@entity_type.manager', '@entity_field.manager', '@context.manager', '@flysystem_factory', '@language_manager', '@current_user', '@cache.data']
   islandora.entity_mapper:
     class: Islandora\EntityMapper\EntityMapper
   islandora.stomp.auth_header_listener:

--- a/src/IslandoraUtils.php
+++ b/src/IslandoraUtils.php
@@ -92,13 +92,6 @@ class IslandoraUtils {
   protected $cache;
 
   /**
-   * Current user.
-   *
-   * @var \Drupal\Core\Session\AccountProxyInterface
-   */
-  protected $currentUser;
-
-  /**
    * Constructor.
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
@@ -122,7 +115,7 @@ class IslandoraUtils {
     ContextManager $context_manager,
     FlysystemFactory $flysystem_factory,
     LanguageManagerInterface $language_manager,
-    AccountInterface $current_user
+    AccountInterface $current_user,
     CacheBackendInterface $cache,
   ) {
     $this->entityTypeManager = $entity_type_manager;

--- a/src/IslandoraUtils.php
+++ b/src/IslandoraUtils.php
@@ -4,6 +4,7 @@ namespace Drupal\islandora;
 
 use Drupal\context\ContextManager;
 use Drupal\Component\Utility\Html;
+use Drupal\Core\Cache\Cache;
 use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityFieldManagerInterface;
@@ -316,7 +317,7 @@ class IslandoraUtils {
       $cid,
       $term,
       CacheBackendInterface::CACHE_PERMANENT,
-      $term->getCacheTags()
+      Cache::mergeTags(array_merge($term->getCacheTags(), ['user:' . $this->currentUser->id()]))
     );
 
     return $term;

--- a/src/IslandoraUtils.php
+++ b/src/IslandoraUtils.php
@@ -311,14 +311,13 @@ class IslandoraUtils {
     if (!empty($results)) {
       $term = $this->entityTypeManager->getStorage('taxonomy_term')
         ->load(reset($results));
+      $this->cache->set(
+        $cid,
+        $term,
+        CacheBackendInterface::CACHE_PERMANENT,
+        Cache::mergeTags(array_merge($term->getCacheTags(), ['user:' . $this->currentUser->id()]))
+      );
     }
-
-    $this->cache->set(
-      $cid,
-      $term,
-      CacheBackendInterface::CACHE_PERMANENT,
-      Cache::mergeTags(array_merge($term->getCacheTags(), ['user:' . $this->currentUser->id()]))
-    );
 
     return $term;
   }

--- a/src/IslandoraUtils.php
+++ b/src/IslandoraUtils.php
@@ -90,7 +90,8 @@ class IslandoraUtils {
    */
   protected $cache;
 
-  /** Current user.
+  /**
+   * Current user.
    *
    * @var \Drupal\Core\Session\AccountProxyInterface
    */


### PR DESCRIPTION
**GitHub Issue**: [(link)](https://github.com/Islandora/documentation/issues/2272)

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What does this Pull Request do?

Caches the term found when calling IslandoraUtils::getTermForUri().

Cache ID is based on user id because the db query has an access check.

# What's new?

* Changes IslandoraUtils service by adding a CacheBackend and CurrentUser argument to its constructor
* Creates a Cache ID based on user id and external uri
* Tries to retrieve the term from the cache if it exists
* If the cached term doesn't exist, run the db query and store the result in cache

# How should this be tested?

A description of what steps someone could take to:
* Install webprofiler, compare number of slow db queries before/after, you should see the queries related to this function disappear once the results are loaded from the cache

# Documentation Status

* Does this change existing behaviour that's currently documented? I don't think so?

# Additional Notes:

I'm fairly new to using the Cache API so would appreciate any advice you have. In the meantime I'll try find example test cases so that this can be added to the test suite.

# Interested parties

@Islandora/committers
