### PR TITLE
Issue 1000

### DIFF
--- a/modules/islandora_iiif/config/schema/islandora_iiif.schema.yml
+++ b/modules/islandora_iiif/config/schema/islandora_iiif.schema.yml
@@ -6,8 +6,11 @@ islandora_iiif.settings:
       type: string
       label: 'IIIF Server Url'
     use_relative_paths:
-    type: boolean
-    label: 'Use relative paths in manifest.'
+      type: boolean
+      label: 'Use relative paths in manifest.'
+    show_title:
+      type: string
+      label: 'Show title in view'
 
 views.style.iiif_manifest:
   type: views_style

--- a/modules/islandora_iiif/src/Form/IslandoraIIIFConfigForm.php
+++ b/modules/islandora_iiif/src/Form/IslandoraIIIFConfigForm.php
@@ -66,6 +66,11 @@ class IslandoraIIIFConfigForm extends ConfigFormBase {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
+    $options = [
+      'none' => $this->t('None'),
+      'view' => $this->t("From view title"),
+      'node' => $this->t("From node title"),
+    ];
     $config = $this->config('islandora_iiif.settings');
     $form['iiif_server'] = [
       '#type' => 'url',
@@ -82,6 +87,14 @@ class IslandoraIIIFConfigForm extends ConfigFormBase {
       '#title' => $this->t("Use relative file paths in manifest."),
       '#description' => $this->t("Check this if your IIIF Server is configured to access files locally. If unchecked, the absolute URL will be given and the IIIF server will make requests to this site to retrieve images."),
       '#default_value' => $config->get('use_relative_paths'),
+    ];
+
+    $form['show_title'] = [
+      '#type' => 'select',
+      '#options' => $options,
+      '#title' => $this->t("Show title in viewer."),
+      '#description' => $this->t("Show title on your viewer, if viewer allows"),
+      '#default_value' => $config->get('show_title'),
     ];
 
     return parent::buildForm($form, $form_state);
@@ -111,6 +124,7 @@ class IslandoraIIIFConfigForm extends ConfigFormBase {
     $this->config('islandora_iiif.settings')
       ->set('iiif_server', $form_state->getValue('iiif_server'))
       ->set('use_relative_paths', $form_state->getValue('use_relative_paths'))
+      ->set('show_title', $form_state->getValue('show_title'))
       ->save();
   }
 

--- a/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
+++ b/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
@@ -343,7 +343,7 @@ class IIIFManifest extends StylePluginBase {
 
         // If this is a TIFF AND we don't know the width/height
         // see if we can get the image size via PHP's core function.
-        if ($mime_type === 'image/tiff' && !($width || !$height)) {
+        if ($mime_type === 'image/tiff' && (!$width || !$height)) {
           $uri = $image->entity->getFileUri();
           $path = $this->fileSystem->realpath($uri);
           $image_size = getimagesize($path);

--- a/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
+++ b/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
@@ -343,7 +343,6 @@ class IIIFManifest extends StylePluginBase {
 
         // If this is a TIFF AND we don't know the width/height
         // see if we can get the image size via PHP's core function.
-
         if ($mime_type === 'image/tiff' && (!$width || !$height)) {
           $uri = $image->entity->getFileUri();
           $path = $this->fileSystem->realpath($uri);

--- a/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
+++ b/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
@@ -169,13 +169,31 @@ class IIIFManifest extends StylePluginBase {
       array_pop($url_components);
       $content_path = '/' . implode('/', $url_components);
       $iiif_base_id = "{$request_host}{$content_path}";
+      $display = $this->iiifConfig->get('show_title');
+      switch ($display) {
+        case 'none':
+          $label = '';
+          break;
+
+        case 'view':
+          $label = $this->view->getTitle();
+          break;
+
+        case 'node':
+          $label = $this->getEntityTitle($content_path);
+
+          break;
+
+        default:
+          $label = $this->t("IIIF Manifest");
+      }
 
       // @see https://iiif.io/api/presentation/2.1/#manifest
       $json += [
         '@type' => 'sc:Manifest',
         '@id' => $request_url,
         // If the View has a title, set the View title as the manifest label.
-        'label' => $this->view->getTitle() ?: $this->getEntityTitle($content_path),
+        'label' => $label,
         '@context' => 'http://iiif.io/api/presentation/2/context.json',
         // @see https://iiif.io/api/presentation/2.1/#sequence
         'sequences' => [

--- a/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
+++ b/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
@@ -167,8 +167,8 @@ class IIIFManifest extends StylePluginBase {
       // @todo assumming the view is a path like /node/1/manifest.json
       $url_components = explode('/', trim($request_url, '/'));
       array_pop($url_components);
-      $content_path = implode('/', $url_components);
-      $iiif_base_id = $request_host . '/' . $content_path;
+      $content_path = '/' . implode('/', $url_components);
+      $iiif_base_id = "{$request_host}{$content_path}";
 
       // @see https://iiif.io/api/presentation/2.1/#manifest
       $json += [


### PR DESCRIPTION
**GitHub Issue**: ([Issue 1000](https://github.com/Islandora/islandora/issues/1000))

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What does this Pull Request do?
The code's original intent was to set the @label of the manifest to the title of the requesting view, and if that title was not set, it was to use the title of the node or media. This never worked - a missing slash prevented the node title from being returned.  Further, once a node has been given a title, it can only be changed to another title, so it can never be reverted to a condition which allows the (now fixed) node title to display.

These changes add a configuration to allow the user to choose between the View title, the Node title, or nothing at all.

# What's new?
Choices!

# How should this be tested?
Open a page with Mirador viewer on an Islandora instance with the manifest supplied by the IIIF view.  On most Islandora instances this will be `admin/structure/views/view/iiif_manifest
Navigate to  `admin/config/islandora/iiif` and try each of the settings.

# Documentation Status
No changes are required.

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
