### PR TITLE
Do not have a fatal error on a missing action

### DIFF
--- a/src/PresetReaction/PresetReaction.php
+++ b/src/PresetReaction/PresetReaction.php
@@ -7,6 +7,7 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -22,11 +23,19 @@ class PresetReaction extends ContextReactionPluginBase implements ContainerFacto
   protected $actionStorage;
 
   /**
+   * The logger.
+   *
+   * @var \Psr\Log\LoggerInterface
+   */
+  protected $logger;
+
+  /**
    * {@inheritdoc}
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityStorageInterface $action_storage) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityStorageInterface $action_storage, LoggerInterface $logger) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->actionStorage = $action_storage;
+    $this->logger = $logger;
   }
 
   /**
@@ -37,7 +46,8 @@ class PresetReaction extends ContextReactionPluginBase implements ContainerFacto
       $configuration,
       $plugin_id,
       $plugin_definition,
-      $container->get('entity_type.manager')->getStorage('action')
+      $container->get('entity_type.manager')->getStorage('action'),
+      $container->get('logger.factory')->get('islandora')
     );
   }
 
@@ -57,9 +67,19 @@ class PresetReaction extends ContextReactionPluginBase implements ContainerFacto
     foreach ($action_ids as $action_id) {
       $action = $this->actionStorage->load($action_id);
       if (empty($action)) {
+        $this->logger->warning('Action "@action" not found.', ['@action' => $action_id]);
         continue;
       }
-      $action->execute([$entity]);
+      try {
+        $action->execute([$entity]);
+      }
+      catch (\Exception $e) {
+        $this->logger->error('Error executing action "@action" on entity "@entity": @message', [
+          '@action' => $action->label(),
+          '@entity' => $entity->label(),
+          '@message' => $e->getMessage(),
+        ]);
+      }
     }
   }
 

--- a/src/PresetReaction/PresetReaction.php
+++ b/src/PresetReaction/PresetReaction.php
@@ -56,6 +56,9 @@ class PresetReaction extends ContextReactionPluginBase implements ContainerFacto
     $action_ids = $config['actions'];
     foreach ($action_ids as $action_id) {
       $action = $this->actionStorage->load($action_id);
+      if (empty($action)) {
+        continue;
+      }
       $action->execute([$entity]);
     }
   }


### PR DESCRIPTION
https://github.com/Islandora/islandora/issues/1015

# What does this Pull Request do?

Makes `PresetReaction` more robust by not relying on the assumption that all actions are always available.

A brief description of what the intended result of the PR will be and/or what
 problem it solves.

During using Islandora Drupal module inside https://github.com/Gizra/drupal-starter, we had a fatal error during the installation:
```
 [error]  Error: Call to a member function execute() on null in Drupal\islandora\PresetReaction\PresetReaction->execute() (line 59 of /var/www/html/web/modules/contrib/islandora/src/PresetReaction/PresetReaction.php) #0 /var/www/html/web/modules/contrib/islandora/src/IslandoraUtils.php(389): Drupal\islandora\PresetReaction\PresetReaction->execute(Object(Drupal\taxonomy\Entity\Term))

#1 /var/www/html/web/modules/contrib/islandora/islandora.module(226): Drupal\islandora\IslandoraUtils->executeTermReactions('\\Drupal\\islando...', Object(Drupal\taxonomy\Entity\Term))

#2 [internal function]: islandora_taxonomy_term_insert(Object(Drupal\taxonomy\Entity\Term))

#3 /var/www/html/web/core/lib/Drupal/Core/Extension/ModuleHandler.php(409): call_user_func_array(Object(Closure), Array)
```

# What's new?
No new functionalities were added.

# How should this be tested?
Intentionally creating a config that refers to a non-existing action would be sufficient.

# Documentation Status
N/A

# Interested parties
@Islandora/committers
