### PR TITLE
Allow filehash 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "drupal/ctools": "^3.8 || ^4",
     "drupal/eva" : "^3.0",
     "drupal/file_replace": "^1.1",
-    "drupal/filehash": "^2",
+    "drupal/filehash": "^2 || ^3",
     "drupal/flysystem" : "^2.0@alpha",
     "drupal/jwt": "^1.1 || ^2",
     "drupal/migrate_plus" : "^5.1 || ^6",


### PR DESCRIPTION
**GitHub Issue**: #1005 

I've tested this and Islandora's code still runs without errors. 

* Other Relevant Links

The [DGI Fixity module](https://github.com/discoverygarden/dgi_fixity) still requires 2.x so we're keeping it in here (also makes it compatible with Drupal < 10.2) 

# What does this Pull Request do?

Allows Filehash 3

# What's new?


* Allows Filehash 3
* Does this change add any new dependencies?  No
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)?  no
* Could this change impact execution of existing code? potentially! But my testing showed behaviour stays the same.

# How should this be tested?

Put a breakpoint around https://github.com/Islandora/islandora/blob/2.x/islandora.module#L186 and see that you can still access those "fields" on the file entity, and that they return the appropriate checksums.

Also I noted that as before, if you look at the Content > Files list (and edit the view to add Original SHA-1 and SHA-1), any media created by derivatives has a null Original SHA-1. 

# Documentation Status

* Does this change existing behaviour that's currently documented? no
* Does this change require new pages or sections of documentation? no
* Who does this need to be documented for? no
* Associated documentation pull request(s): ___  or documentation issue ___

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
