### PR TITLE
Only generate tokens for our Islandora-esque nodes.

### DIFF
--- a/islandora.tokens.inc
+++ b/islandora.tokens.inc
@@ -80,6 +80,9 @@ function islandora_tokens($type, $tokens, array $data, array $options, Bubbleabl
       return;
     }
     $islandoraUtils = \Drupal::service('islandora.utils');
+    if (!$islandoraUtils->isIslandoraType('node', $data['node']->bundle())) {
+      return;
+    }
     foreach ($tokens as $name => $original) {
       switch ($name) {
         case 'media-original-file:basename':


### PR DESCRIPTION
So, have found myself in something of a funky situation during site installation and with the use of metatag and Islandora’s token. In particular, during site installation, we create a number of non-repository pieces of content (nodes) before the taxonomies are populated, which causes an error in `islandora_url_to_service_file_media_by_mimetype()`. 

<details>

<summary>Error dump/stacktrace</summary>

```
> TypeError: Drupal\islandora\IslandoraUtils::getMediaWithTerm(): Argument #2 ($term) must be of type Drupal\taxonomy\TermInterface, null given, called in /var/www/html/web/modules/contrib/islandora/islandora.tokens.inc on line 159 in /var/www/html/web/modules/contrib/islandora/src/IslandoraUtils.php on line 176 #0 /var/www/html/web/modules/contrib/islandora/islandora.tokens.inc(159): Drupal\islandora\IslandoraUtils->getMediaWithTerm(Object(Drupal\node\Entity\Node), NULL)
> #1 /var/www/html/web/modules/contrib/islandora/islandora.tokens.inc(137): islandora_url_to_service_file_media_by_mimetype(Object(Drupal\node\Entity\Node), 'application/pdf')
> #2 [internal function]: islandora_tokens('islandoratokens', Array, Array, Array, Object(Drupal\Core\Render\BubbleableMetadata))
> #3 /var/www/html/web/core/lib/Drupal/Core/Extension/ModuleHandler.php(409): call_user_func_array(Object(Closure), Array)
> #4 /var/www/html/web/core/lib/Drupal/Core/Extension/ModuleHandler.php(388): Drupal\Core\Extension\ModuleHandler->Drupal\Core\Extension\{closure}(Object(Closure), 'islandora')
> #5 /var/www/html/web/core/lib/Drupal/Core/Extension/ModuleHandler.php(408): Drupal\Core\Extension\ModuleHandler->invokeAllWith('tokens', Object(Closure))
> #6 /var/www/html/web/core/lib/Drupal/Core/Utility/Token.php(364): Drupal\Core\Extension\ModuleHandler->invokeAll('tokens', Array)
> #7 /var/www/html/web/core/lib/Drupal/Core/Utility/Token.php(241): Drupal\Core\Utility\Token->generate('islandoratokens', Array, Array, Array, Object(Drupal\Core\Render\BubbleableMetadata))
> #8 /var/www/html/web/core/lib/Drupal/Core/Utility/Token.php(191): Drupal\Core\Utility\Token->doReplace(true, '[islandoratoken...', Array, Array, Object(Drupal\Core\Render\BubbleableMetadata))
> #9 /var/www/html/web/modules/contrib/metatag/src/MetatagToken.php(66): Drupal\Core\Utility\Token->replace('[islandoratoken...', Array, Array, NULL)
> #10 /var/www/html/web/modules/contrib/metatag/src/MetatagManager.php(789): Drupal\metatag\MetatagToken->replace('[islandoratoken...', Array, Array)
> #11 /var/www/html/web/modules/contrib/metatag/src/MetatagManager.php(628): Drupal\metatag\MetatagManager->processTagValue(Object(Drupal\metatag_google_scholar\Plugin\metatag\Tag\CitationPdfUrl), Array, Array, false, 'en')
> #12 /var/www/html/web/modules/contrib/metatag/src/Plugin/Field/MetatagEntityFieldItemList.php(61): Drupal\metatag\MetatagManager->generateRawElements(Array, Object(Drupal\node\Entity\Node))
> #13 /var/www/html/web/core/lib/Drupal/Core/Render/Renderer.php(592): Drupal\metatag\Plugin\Field\MetatagEntityFieldItemList::Drupal\metatag\Plugin\Field\{closure}()
> #14 /var/www/html/web/modules/contrib/metatag/src/Plugin/Field/MetatagEntityFieldItemList.php(48): Drupal\Core\Render\Renderer->executeInRenderContext(Object(Drupal\Core\Render\RenderContext), Object(Closure))
> #15 /var/www/html/web/modules/contrib/metatag/src/TypedData/ComputedItemListTrait.php(32): Drupal\metatag\Plugin\Field\MetatagEntityFieldItemList->computeValue()
> #16 /var/www/html/web/core/lib/Drupal/Core/TypedData/ComputedItemListTrait.php(132): Drupal\metatag\Plugin\Field\MetatagEntityFieldItemList->ensureComputedValue()
> #17 /var/www/html/web/core/lib/Drupal/Core/Entity/ContentEntityBase.php(1274): Drupal\metatag\Plugin\Field\MetatagEntityFieldItemList->getIterator()
> #18 /var/www/html/web/modules/contrib/islandora/src/Plugin/Condition/NodeHasTerm.php(185): Drupal\Core\Entity\ContentEntityBase->referencedEntities()
> #19 /var/www/html/web/modules/contrib/islandora/src/Plugin/Condition/NodeHasTerm.php(170): Drupal\islandora\Plugin\Condition\NodeHasTerm->evaluateEntity(Object(Drupal\node\Entity\Node))
> #20 /var/www/html/web/core/lib/Drupal/Core/Condition/ConditionManager.php(68): Drupal\islandora\Plugin\Condition\NodeHasTerm->evaluate()
> #21 /var/www/html/web/core/lib/Drupal/Core/Condition/ConditionPluginBase.php(84): Drupal\Core\Condition\ConditionManager->execute(Object(Drupal\islandora\Plugin\Condition\NodeHasTerm))
> #22 /var/www/html/web/core/lib/Drupal/Core/Condition/ConditionAccessResolverTrait.php(26): Drupal\Core\Condition\ConditionPluginBase->execute()
> #23 /var/www/html/web/modules/contrib/islandora/src/IslandoraContextManager.php(80): Drupal\context\ContextManager->resolveConditions(Object(Drupal\Core\Condition\ConditionPluginCollection), 'or')
> #24 /var/www/html/web/modules/contrib/islandora/src/IslandoraContextManager.php(40): Drupal\islandora\IslandoraContextManager->evaluateContextConditions(Object(Drupal\context\Entity\Context), Array)
> #25 /var/www/html/web/modules/contrib/islandora/src/IslandoraUtils.php(328): Drupal\islandora\IslandoraContextManager->evaluateContexts(Array)
> #26 /var/www/html/web/modules/contrib/islandora/islandora.module(56): Drupal\islandora\IslandoraUtils->executeNodeReactions('\\Drupal\\islando...', Object(Drupal\node\Entity\Node))
[...]
```

</details>

It might be possible to entirely side-step this issue.