### PR TITLE
D10.3

### DIFF
--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -22,13 +22,9 @@ jobs:
       matrix:
         php-versions: ["8.1", "8.2", "8.3"]
         test-suite: ["kernel", "functional", "functional-javascript"]
-        drupal-version: ["10.1.x", "10.2.x", "10.3.x-dev"]
+        drupal-version: ["10.2.x", "10.3.x", "10.4.x-dev"]
         mysql: ["8.0"]
         allowed_failure: [false]
-        exclude:
-          - php-versions: "8.3"
-            drupal-version: "10.1.x"
-
 
     name: PHP ${{ matrix.php-versions }} | drupal ${{ matrix.drupal-version }} | mysql ${{ matrix.mysql }} | test-suite ${{ matrix.test-suite }}
 

--- a/islandora.info.yml
+++ b/islandora.info.yml
@@ -4,7 +4,7 @@ name: 'islandora'
 description: "Islandora Core"
 type: module
 package: Islandora
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10.2
 dependencies:
   - context:context_ui
   - ctools:ctools

--- a/tests/src/Functional/DeleteMediaTest.php
+++ b/tests/src/Functional/DeleteMediaTest.php
@@ -50,12 +50,7 @@ class DeleteMediaTest extends IslandoraFunctionalTestBase {
   public function setUp(): void {
     parent::setUp();
 
-    if (version_compare(\Drupal::VERSION, '10.1', '>=')) {
-      $permissions = ['create media', 'delete any media', 'delete any file'];
-    }
-    else {
-      $permissions = ['create media', 'delete any media'];
-    }
+    $permissions = ['create media', 'delete any media'];
 
     // Create a test user.
     $this->account = $this->createUser($permissions);

--- a/tests/src/Functional/DeleteMediaTest.php
+++ b/tests/src/Functional/DeleteMediaTest.php
@@ -50,7 +50,7 @@ class DeleteMediaTest extends IslandoraFunctionalTestBase {
   public function setUp(): void {
     parent::setUp();
 
-    $permissions = ['create media', 'delete any media'];
+    $permissions = ['create media', 'delete any media', 'delete any file'];
 
     // Create a test user.
     $this->account = $this->createUser($permissions);

--- a/tests/src/Functional/JsonldTypeAlterReactionTest.php
+++ b/tests/src/Functional/JsonldTypeAlterReactionTest.php
@@ -26,15 +26,7 @@ class JsonldTypeAlterReactionTest extends JsonldSelfReferenceReactionTest {
 
     // Add the typed predicate we will select in the reaction config.
     // Taken from FieldUiTestTrait->fieldUIAddNewField.
-    if (version_compare(\Drupal::VERSION, '10.2.x-dev', 'lt')) {
-      $this->submitForm([
-        'new_storage_type' => 'string',
-        'label' => 'Typed Predicate',
-        'field_name' => 'type_predicate',
-      ], 'Save and continue');
-      $this->submitForm([], 'Save field settings');
-    }
-    elseif (version_compare(\Drupal::VERSION, '10.3.x-dev', 'lt')) {
+    if (version_compare(\Drupal::VERSION, '10.3.x-dev', 'lt')) {
       $this->getSession()->getPage()->selectFieldOption('new_storage_type', 'plain_text');
       // For Drupal 10.2, we first need to submit the form with the elements
       // displayed on initial page load. The form is using AJAX to send a


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/2324

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.) - Discussed at Tech Call 2024-06-26

# What does this Pull Request do?

Shifts the compatibility window to drop Drupal 10.1 and start testing on 10.4.x-dev.

# What's new?


* Testing matrix change
* Compatibility shims regarding drupal 10.1/10.2 reconciled to new compatibility window
* Version of compatibility added to info.yml.

* Does this change add any new dependencies? Yes - you must be on drupal 10.2 now 
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)?  no
* Could this change impact execution of existing code? no

# How should this be tested?

* Tests should pass - implying that the changes to tests are valid on the new testing matrix, and that the new compatibility declaration in info.yml is working.

# Documentation Status

* Does this change existing behaviour that's currently documented? no
* Does this change require new pages or sections of documentation? no
* Who does this need to be documented for? no
* Associated documentation pull request(s): ___  or documentation issue ___

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
