### PR TITLE
DDST-312: Addressing a warning when `search_endpoint` option isn't set

### DIFF
--- a/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
+++ b/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
@@ -494,17 +494,20 @@ class IIIFManifest extends StylePluginBase {
    */
   protected function addSearchEndpoint(array &$json, array $url_components) {
     $url_base = $this->getRequest()->getSchemeAndHttpHost();
-    $hocr_search_path = $this->options['search_endpoint'];
-    $hocr_search_url = $url_base . '/' . ltrim($hocr_search_path, '/');
+    $hocr_search_path = $this->options['search_endpoint'] ?? null;
 
-    $hocr_search_url = str_replace('%node', $url_components[1], $hocr_search_url);
+    if ($hocr_search_path) {
+      $hocr_search_url = $url_base . '/' . ltrim($hocr_search_path, '/');
 
-    $json['service'][] = [
-      "@context" => "http://iiif.io/api/search/0/context.json",
-      "@id" => $hocr_search_url,
-      "profile" => "http://iiif.io/api/search/0/search",
-      "label" => t("Search inside this work"),
-    ];
+      $hocr_search_url = str_replace('%node', $url_components[1], $hocr_search_url);
+
+      $json['service'][] = [
+        "@context" => "http://iiif.io/api/search/0/context.json",
+        "@id" => $hocr_search_url,
+        "profile" => "http://iiif.io/api/search/0/search",
+        "label" => t("Search inside this work"),
+      ];
+    }
   }
 
   /**


### PR DESCRIPTION
**GitHub Issue**: N/A

# What does this Pull Request do?
Adds a null coalescing operator when attempting to read the `search_endpoint` option and a null-check in the event that it hasn't been set, and handle the following warning:
```
Warning: Undefined array key "search_endpoint" in Drupal\islandora_iiif\Plugin\views\style\IIIFManifest->addSearchEndpoint() (line 497 of path/to/files/islandora/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php).
```

# What's new?
Adds a null coalescing operator when attempting to read the `search_endpoint` variable. Then performs a null-check before executing operations with that value that may not exist.

* Does this change add any new dependencies? No.
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? No.
* Could this change impact execution of existing code? Yes.

# How should this be tested?
Load a page where the `addSearchEndpoint` function is called, but the `search_endpoint` option is not set.

# Interested parties
@Islandora/committers
