### PR TITLE
Node and media delete action

### DIFF
--- a/config/install/system.action.delete_node_and_media.yml
+++ b/config/install/system.action.delete_node_and_media.yml
@@ -1,0 +1,12 @@
+status: true
+dependencies:
+  enforced:
+    module:
+      - islandora
+  module:
+    - islandora
+id: delete_node_and_media
+label: 'Delete node(s) and associated media'
+type: node
+plugin: delete_node_and_media
+configuration: {  }

--- a/config/schema/islandora.schema.yml
+++ b/config/schema/islandora.schema.yml
@@ -81,6 +81,10 @@ action.configuration.delete_media_and_file:
   type: action_configuration_default
   label: 'Delete media and file'
 
+action.configuration.delete_node_and_media:
+  type: action_configuration_default
+  label: 'Delete node and media'
+
 condition.plugin.node_has_term:
   type: condition.plugin
   mapping:
@@ -173,10 +177,6 @@ condition.plugin.node_had_namespace:
 field.formatter.settings.islandora_image:
   type: field.formatter.settings.image
   label: 'Islandora image field display format settings'
-  mapping:
-    image_alt_text:
-      type: string
-      label: "Alt text source"
 
 condition.plugin.islandora_entity_bundle:
   type: condition.plugin

--- a/config/schema/islandora.schema.yml
+++ b/config/schema/islandora.schema.yml
@@ -177,6 +177,10 @@ condition.plugin.node_had_namespace:
 field.formatter.settings.islandora_image:
   type: field.formatter.settings.image
   label: 'Islandora image field display format settings'
+  mapping:
+    image_alt_text:
+      type: string
+      label: "Alt text source"
 
 condition.plugin.islandora_entity_bundle:
   type: condition.plugin

--- a/islandora.install
+++ b/islandora.install
@@ -8,6 +8,7 @@
 use Drupal\Core\Extension\ExtensionNameLengthException;
 use Drupal\Core\Extension\MissingDependencyException;
 use Drupal\Core\Utility\UpdateException;
+use Symfony\Component\Yaml\Yaml;
 
 /**
  * Adds common namespaces to jsonld.settings.
@@ -221,8 +222,8 @@ function islandora_update_8008() {
   if ($config) {
     $config->set('redirect_after_media_save', FALSE);
     $config->save(TRUE);
-    return t('A new configuration option, "Redirect after media save" is now available. 
-    It has been turned off to preserve existing behaviour. To enable this setting visit 
+    return t('A new configuration option, "Redirect after media save" is now available.
+    It has been turned off to preserve existing behaviour. To enable this setting visit
     Configuration > Islandora > Core Settings.');
   }
 }
@@ -232,7 +233,7 @@ function islandora_update_8008() {
  */
 function islandora_update_9001(&$sandbox) {
   $config_id = 'system.action.delete_node_and_media';
-  $config_path = \Drupal::service('extension.list.module')->getPath('islandora') . '/config/install/' . $config_id .'.yml';
-  $data = \Symfony\Component\Yaml\Yaml::parseFile($config_path);
+  $config_path = \Drupal::service('extension.list.module')->getPath('islandora') . '/config/install/' . $config_id . '.yml';
+  $data = Yaml::parseFile($config_path);
   \Drupal::configFactory()->getEditable($config_id)->setData($data)->save(TRUE);
 }

--- a/islandora.install
+++ b/islandora.install
@@ -226,3 +226,13 @@ function islandora_update_8008() {
     Configuration > Islandora > Core Settings.');
   }
 }
+
+/**
+ * Add "Delete node and media" action.
+ */
+function islandora_update_9001(&$sandbox) {
+  $config_id = 'system.action.delete_node_and_media';
+  $config_path = \Drupal::service('extension.list.module')->getPath('islandora') . '/config/install/' . $config_id .'.yml';
+  $data = \Symfony\Component\Yaml\Yaml::parseFile($config_path);
+  \Drupal::configFactory()->getEditable($config_id)->setData($data)->save(TRUE);
+}

--- a/islandora.routing.yml
+++ b/islandora.routing.yml
@@ -109,3 +109,10 @@ islandora.confirm_delete_media_and_file:
     _form: 'Drupal\islandora\Form\ConfirmDeleteMediaAndFile'
   requirements:
     _permission: 'administer media+delete any media'
+
+islandora.confirm_delete_node_and_media:
+  path: '/node/delete_with_media'
+  defaults:
+    _form: 'Drupal\islandora\Form\ConfirmDeleteNodeAndMedia'
+  requirements:
+    _permission: 'administer media+delete any media'

--- a/src/Form/ConfirmDeleteNodeAndMedia.php
+++ b/src/Form/ConfirmDeleteNodeAndMedia.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace Drupal\islandora\Form;
+
+use Drupal\Core\Entity\EntityFieldManagerInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\Form\DeleteMultipleForm;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\TempStore\PrivateTempStoreFactory;
+use Drupal\Core\Url;
+use Drupal\islandora\IslandoraUtils;
+use Drupal\islandora\MediaSource\MediaSourceService;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Confirmation form for the 'Delete node(s) and media' action.
+ */
+class ConfirmDeleteNodeAndMedia extends DeleteMultipleForm {
+
+  /**
+   * Media source service.
+   *
+   * @var \Drupal\islandora\MediaSource\MediaSourceService
+   */
+  protected $mediaSourceService;
+
+  /**
+   * Logger.
+   *
+   * @var Psr\Log\LoggerInterface
+   */
+  protected $logger;
+
+  /**
+   * Deleted media count.
+   *
+   * @var string
+   */
+  protected $deletedMediaCount = [];
+
+  /**
+   * Deleted file count.
+   *
+   * @var string
+   */
+  protected $deletedFileCount = [];
+
+  /**
+   * List of nodes targeted.
+   *
+   * @var array
+   */
+  protected $selection = [];
+
+  /**
+   * Entity field manager.
+   *
+   * @var \Drupal\Core\Entity\EntityFieldManagerInterface
+   */
+  protected $entityFieldManager;
+
+  /**
+   * The Islandora Utils service.
+   *
+   * @var \Drupal\islandora\IslandoraUtils
+   */
+  protected IslandoraUtils $utils;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(AccountInterface $current_user, EntityTypeManagerInterface $entity_type_manager, EntityFieldManagerInterface $entity_field_manager, PrivateTempStoreFactory $temp_store_factory, MessengerInterface $messenger, IslandoraUtils $utils, MediaSourceService $media_source_service, LoggerInterface $logger) {
+    $this->currentUser = $current_user;
+    $this->entityTypeManager = $entity_type_manager;
+    $this->entityFieldManager = $entity_field_manager;
+    $this->tempStore = $temp_store_factory->get('node_and_media_delete_confirm');
+    $this->messenger = $messenger;
+    $this->utils = $utils;
+    $this->mediaSourceService = $media_source_service;
+    $this->logger = $logger;
+    $this->deletedMediaCount = 0;
+    $this->deletedFileCount = 0;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('current_user'),
+      $container->get('entity_type.manager'),
+      $container->get('entity_field.manager'),
+      $container->get('tempstore.private'),
+      $container->get('messenger'),
+      $container->get('islandora.utils'),
+      $container->get('islandora.media_source_service'),
+      $container->get('logger.channel.islandora'));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'node_and_media_delete_confirm_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getQuestion() {
+    return $this->formatPlural(count($this->selection),
+      'Are you sure you want to delete this node and its associated media and files?',
+      'Are you sure you want to delete these nodes and their associated media and files?');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCancelUrl() {
+    return new Url('entity.media.collection');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state, $entity_type_id = NULL) {
+    return parent::buildForm($form, $form_state, 'node');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $deleted_media = 0;
+    $node_storage = $this->entityTypeManager->getStorage('node');
+    $nodes = $node_storage->loadMultiple(array_keys($this->selection));
+    $deleteable_nodes = [];
+    foreach ($nodes as $node) {
+      if ($node->access('delete', $this->currentUser)) {
+        $deleteable_nodes[] = $node;
+      }
+      else {
+        $nondeleteable_nodes = $node;
+      }
+    }
+    foreach ($deleteable_nodes as $candidate) {
+      $media = $this->utils->getMedia($candidate);
+      $this->utils->deleteMediaAndFiles($media);
+      $candidate->delete();
+    }
+    $this->messenger->addStatus($this->getDeletedMessage(count($deleteable_nodes)));
+    if ($nondeleteable_nodes) {
+      $failures = count($nondeleteable_nodes);
+      $this->messenger->addStatus($this->formatPlural($failures, 'Unable to delete 1 node', 'Unable to delete @count nodes'));
+    }
+    $this->tempStore->delete($this->currentUser->id());
+    $form_state->setRedirectUrl($this->getCancelUrl());
+  }
+
+}

--- a/src/Plugin/Action/DeleteNodeAndMedia.php
+++ b/src/Plugin/Action/DeleteNodeAndMedia.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Drupal\islandora\Plugin\Action;
+
+use Drupal\Core\Action\Plugin\Action\DeleteAction;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\TempStore\PrivateTempStoreFactory;
+
+/**
+ * Deletes a node, its media and its source file.
+ *
+ * @Action(
+ *   id = "delete_node_and_media",
+ *   label = @Translation("Delete node(s) and associated media"),
+ *   type = "node",
+ *   confirm_form_route_name = "islandora.confirm_delete_node_and_media"
+ * )
+ */
+class DeleteNodeAndMedia extends DeleteAction {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, PrivateTempStoreFactory $temp_store_factory, AccountInterface $current_user) {
+    $this->currentUser = $current_user;
+    $this->tempStore = $temp_store_factory->get('node_and_media_delete_confirm');
+    $this->entityTypeManager = $entity_type_manager;
+    $this->configuration = $configuration;
+    $this->pluginId = $plugin_id;
+    $this->pluginDefinition = $plugin_definition;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function executeMultiple(array $entities): void {
+    $selection = [];
+    foreach ($entities as $entity) {
+      $langcode = $entity->language()->getId();
+      $selection[$entity->id()][$langcode] = $langcode;
+    }
+    $this->tempStore->set("{$this->currentUser->id()}:node", $selection);
+  }
+
+}


### PR DESCRIPTION

# What does this Pull Request do?

Provides an additional Action to delete a node along with all associated media and the files attached to those media.

# What's new?
Provides the Action in code, and an instantiation of that action in config

This is new functionality and should not have any effect on existing code.

# How should this be tested?
Once installed you should see a new action defined anywhere the Node Action Bulk Form is used (like the default content view)
<img width="269" alt="image" src="https://github.com/user-attachments/assets/d06605c9-a616-47da-a17f-7ff83cafef67">


# Documentation Status

No existing behaviour is affected, and AFAIK we allow all actions to be self-documenting.  It might be worth mentioning the 'no spaces in usernames if you want to delete Fedora files' somewhere

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
