### PR TITLE
Follow-up on caching Height and Width on the media: Add config schema for new Action, and adjust wording.

### DIFF
--- a/modules/islandora_iiif/README.md
+++ b/modules/islandora_iiif/README.md
@@ -41,38 +41,39 @@ This module implements a Views Style plugin. It provides the following settings:
 3. Structured Text Term: If your Islandora Object has a separate media with hOCR, point to it with this setting.
 4. File Width and Height fields: If you want to use TIFF or JP2 files directly, set the fields where the files' width and height can be found with these settings.
 
-### Media Attributes from IIIF Action
+### Action to add image dimensions from the IIIF server
 
 The module also provides an action that lets a site owner populate a TIFF or JP2 image's width and
-height attributes into fields so the IIIF server is not bogged down trying to generate a manifest if
+height attributes into fields on the media so the IIIF server is not bogged down trying to generate a manifest if
 it doesn't have them.
 
-It is a complex action that must be configured. Go to
+It is an advanced action that must be configured. Go to
 Admin -> Actions UI -> Actions, choose
 "Add image dimensions retrieved from the IIIF server" from the Create Action drop-down
-And on  the next screen, choose the width
+And on  the next screen, choose the Media Use term which this should be applied to (as
+it is a node action), as well as the width
 and height fields that the action should
 populate.
 
 To use it, either:
-- Add it as a derivative reaction to a node with an Original FIle as its child, or
-- Use it as a batch action, such as on a Paged Content object's list of child pages.
+- Add it as a derivative reaction (in Contexts) to a node, or
+- Use it as a batch action in a View, such as on a Paged Content object's list of child pages.
 
-### Setting up the action as a Context Reaction
+### Setting up the action as a Contexts Derivative Reaction
 
 These instructions assume a standard Islandora Starter Site, so if you have different field names or Contexts, adjust accordingly.
 
 1. Go to admin/config/system/actions
-2. Choose "Add image dimensions retrieved from the IIIF server" from the Create Complex Action drop-down and then click Create.
+2. Choose "Add image dimensions retrieved from the IIIF server" from the Create advanced Action drop-down and then click Create.
 3. Enter Original File for the Source Media Use term.
 4. Choose media -- file -- Width and Media -- File -- Height for the corresponding configuration values and click Save.
-5. Go to admin/structure/context, and click Duplicate oon the Page Derivatives row.
-6. Name the new context something like "Retrieve Page Dimensionss". and edit it.
+5. Go to admin/structure/context, and click Duplicate on the Page Derivatives row.
+6. Name the new context something like "Retrieve Page Dimensions" and edit it.
 7. This is the tricky bit, delete 'Original File' from the 'Media has term with URI' field and replace it with Service File. The explanation for this is that to retrieve a file from the IIIF server, it must be part of an Islandora Media that has been fully created and saved and given a URL. This hasn't happened yet when Original File derivatives are being created, so we need to hang our action onto a derivative that is created after the original one.
-8. Under Reactions, deselect the existing actions and select  "Add i mage dimensions from IIIF sserver" and click Save and continue.
+8. Under Reactions, deselect the existing actions and select  "Add image dimensions from IIIF server" and click Save and continue.
 9. Go back to your Paged Content object and add another child with a File media, to which you should upload another TIFF or JP2 file.
 10. Without going  to the Original File Book Manifestt, make sure that a service file has been generated, then click Edit on the Original File media.
-11. Ensure that the Width and Height fields are populated with thee correct values from the file.
+11. Ensure that the Width and Height fields are populated with the correct values based on the file.
 
 
 ## Documentation

--- a/modules/islandora_iiif/config/schema/islandora_iiif.schema.yml
+++ b/modules/islandora_iiif/config/schema/islandora_iiif.schema.yml
@@ -31,3 +31,13 @@ views.style.iiif_manifest:
     search_endpoint:
       type: string
       label: "Search endpoint path"
+
+action.configuration.media_attributes_from_iiif_action:
+  type: mapping
+  mapping:
+    source_term_uri:
+      type: string
+    width_field:
+      type: string
+    height_field:
+      type: string

--- a/modules/islandora_iiif/src/Plugin/Action/MediaAttributesFromIiif.php
+++ b/modules/islandora_iiif/src/Plugin/Action/MediaAttributesFromIiif.php
@@ -151,7 +151,7 @@ class MediaAttributesFromIiif extends ConfigurableActionBase implements Containe
   public function execute($entity = NULL) {
     $width = $height = FALSE;
 
-    // Get the original File media use term.
+    // Get the selected media use term.
     $source_term = $this->utils->getTermForUri($this->configuration['source_term_uri']);
 
     $source_mids = $this->utils->getMediaReferencingNodeAndTerm($entity, $source_term);
@@ -204,10 +204,10 @@ class MediaAttributesFromIiif extends ConfigurableActionBase implements Containe
     $form['source_term'] = [
       '#type' => 'entity_autocomplete',
       '#target_type' => 'taxonomy_term',
-      '#title' => $this->t('Source media use term'),
+      '#title' => $this->t('Media use term of media to process.'),
       '#default_value' => $this->utils->getTermForUri($this->configuration['source_term_uri']),
       '#required' => TRUE,
-      '#description' => $this->t('Term indicating the source media'),
+      '#description' => $this->t('Term that indicates the child media on which to perform this action.'),
     ];
 
     $form['width_field'] = [
@@ -235,7 +235,7 @@ class MediaAttributesFromIiif extends ConfigurableActionBase implements Containe
   public function defaultConfiguration() {
     $config = parent::defaultConfiguration();
 
-    $config['media_use_term'] = '';
+    $config['source_term_uri'] = '';
     $config['width_field'] = '';
     $config['height_field'] = '';
 


### PR DESCRIPTION
**GitHub Issue**:  n/a

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

#1029 

# What does this Pull Request do?

A little housekeeping, creating a config schema, and some rewording 

# What's new?

* Config schema. 
* Wording changes 
    * In the Actions config page, there's a blurb at the top talking about how there are "simple" and "advanced" actions. Since this is the terminology used by Drupal, I changed "complex" to "advanced".
    * When talking about the Media Use to do this action on, I removed the word "Source". It implies a "destination" and more confusingly, implies that the destination is not the source. What we're actually selecting is "the Media to do the thing to", being both Source and Destination.
    * Removed hard coded references to Original File (in comments/documentation) since you could do this to any media.  (Admittedly, in our standard config, Original File makes the most sense)
* It looks like there was a stray 'media_use_term' that was later renamed to 'source_term_uri'. 

* Does this change add any new dependencies? nope
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? nope
* Could this change impact execution of existing code? nope

# How should this be tested?

Due to the nature of the all-string config schema, as well as the useful dropdown list to choose from, you could do what I did and mess with the schema (change one value to Boolean) then inspect the saved config in Devel's Config Editor or however you like to inspect your configs. In my case, the value stored was "True". 

# Documentation Status

* Does this change existing behaviour that's currently documented? this changes documentation about existing behaviour.
* Does this change require new pages or sections of documentation? Yeah maybe there could be a page in the docs.
* Who does this need to be documented for? site managers getting frustrated with IIIF slowness.
* Associated documentation pull request(s): ___  or documentation issue ___

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
