### PR TITLE
Use checkout v4

### DIFF
--- a/.github/workflows/gitlab-mirror.yml
+++ b/.github/workflows/gitlab-mirror.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Mirror + trigger CI


### PR DESCRIPTION
v3 is deprecated, as seen in the Actions tab. This bumps it to v4 in the gitlab mirror action. 

No forseen consequences.