### PR TITLE
Islandora/islandora#2338: Handle unset structured_text_term_uri option

### DIFF
--- a/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
+++ b/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
@@ -709,9 +709,10 @@ class IIIFManifest extends StylePluginBase {
    *   The term if it could be found; otherwise, NULL.
    */
   protected function getStructuredTextTerm() : ?TermInterface {
-    if (!$this->structuredTextTermMemoized) {
-      $this->structuredTextTermMemoized = TRUE;
-      $this->structuredTextTerm = $this->utils->getTermForUri($this->options['structured_text_term_uri']);
+    if (!$this->structuredTextTermMemoized && !empty($this->options['structured_text_term_uri'])) {
+      if ($this->structuredTextTerm = $this->utils->getTermForUri($this->options['structured_text_term_uri'])) {
+        $this->structuredTextTermMemoized = TRUE;
+      }
     }
 
     return $this->structuredTextTerm;


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/2338

# What does this Pull Request do?

Prevents Islandora emitting a warning when the `structured_text_term_uri` option is not configured in `iiif_manifest` view REST export.

# What's new?

After viewing content via Mirador, mapped to node/%/book-manifest, when structured_text_term_uri and search_endpoint fields are null (default state), a warning is displayed or logged:

> Warning: Undefined array key "structured_text_term_uri" in Drupal\islandora_iiif\Plugin\views\style\IIIFManifest->getStructuredTextTerm() (line 714 of /app/web/modules/contrib/islandora/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php)

# How should this be tested?

Steps to reproduce behaviour:

1. At `/admin/config/development/logging` set " Error messages to display " to "All messages, with backtrace information"
2. At `/admin/structure/views/view/iiif_manifest/edit/rest_export_3`, do not have structured_text_term_uri field set (default state).
3. View an image in Mirador viewer
4. Reload the page, or click to another page
5. Error should be displayed

Steps to test:

1. Apply patch
2. Do steps to reproduce, do not see error at 5

# Documentation Status

No docs required

# Additional Notes:

n/a

# Interested parties

@adam-vessey, @kayakr