### PR TITLE
Use vocabulary's current name, Media Use

### DIFF
--- a/src/Controller/MediaSourceController.php
+++ b/src/Controller/MediaSourceController.php
@@ -164,7 +164,7 @@ class MediaSourceController extends ControllerBase {
     $transaction = $this->database->startTransaction();
 
     try {
-    $media = $this->service->putToNode(
+      $media = $this->service->putToNode(
         $node,
         $media_type,
         $taxonomy_term,

--- a/src/Controller/MediaSourceController.php
+++ b/src/Controller/MediaSourceController.php
@@ -136,7 +136,7 @@ class MediaSourceController extends ControllerBase {
    * @param \Drupal\media\MediaTypeInterface $media_type
    *   Media type for new media.
    * @param \Drupal\taxonomy\TermInterface $taxonomy_term
-   *   Term from the 'Behavior' vocabulary to give to new media.
+   *   Term from the 'Media Use' vocabulary to give to new media.
    * @param \Symfony\Component\HttpFoundation\Request $request
    *   The request object.
    *
@@ -164,7 +164,7 @@ class MediaSourceController extends ControllerBase {
     $transaction = $this->database->startTransaction();
 
     try {
-      $media = $this->service->putToNode(
+    $media = $this->service->putToNode(
         $node,
         $media_type,
         $taxonomy_term,


### PR DESCRIPTION
Must have been an old name of the vocabulary, used in a comment (non-actionable).