### PR TITLE
Context condition for Parent node of node has term

### DIFF
--- a/src/Plugin/Condition/ParentNodeOfNodeHasTerm.php
+++ b/src/Plugin/Condition/ParentNodeOfNodeHasTerm.php
@@ -29,6 +29,16 @@ class ParentNodeOfNodeHasTerm extends NodeHasTerm {
   /**
    * {@inheritdoc}
    */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
+    $form = parent::buildConfigurationForm($form, $form_state);
+    // Make term not required.
+    $form['term']['#required'] = FALSE;
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function evaluate() {
     if (empty($this->configuration['uri']) && !$this->isNegated()) {
       return TRUE;

--- a/src/Plugin/Condition/ParentNodeOfNodeHasTerm.php
+++ b/src/Plugin/Condition/ParentNodeOfNodeHasTerm.php
@@ -2,12 +2,7 @@
 
 namespace Drupal\islandora\Plugin\Condition;
 
-use Drupal\Core\Condition\ConditionPluginBase;
-use Drupal\Core\Entity\EntityInterface;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Provides a 'term' condition for a node's parent.
@@ -59,10 +54,10 @@ class ParentNodeOfNodeHasTerm extends NodeHasTerm {
       $parent = $this->entityTypeManager->getStorage('node')->load($parentId);
       if ($parent) {
         $parentResult = $this->evaluateEntity($parent);
-        $result = $result + (int)$parentResult;
+        $result = $result + (int) $parentResult;
       }
     }
-    return (boolean)$result;
+    return (boolean) $result;
   }
 
   /**

--- a/src/Plugin/Condition/ParentNodeOfNodeHasTerm.php
+++ b/src/Plugin/Condition/ParentNodeOfNodeHasTerm.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Drupal\islandora\Plugin\Condition;
+
+use Drupal\Core\Condition\ConditionPluginBase;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides a 'term' condition for a node's parent.
+ *
+ * Like parent_node_has_term but applicable to a node instead of media.
+ * Like node_has_term but applicable to parent node.
+ * A typical use case is to test for a child node within a compound item.
+ *
+ * @Condition(
+ *   id = "parent_node_of_node_has_term",
+ *   label = @Translation("Parent node for node has term with URI"),
+ *   context_definitions = {
+ *     "node" = @ContextDefinition("entity:node", required = TRUE , label = @Translation("node"))
+ *   }
+ * )
+ */
+class ParentNodeOfNodeHasTerm extends NodeHasTerm {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function evaluate() {
+    if (empty($this->configuration['uri']) && !$this->isNegated()) {
+      return TRUE;
+    }
+
+    $node = $this->getContextValue('node');
+    if (!$node) {
+      return FALSE;
+    }
+
+    $fields = [$this->utils::MEMBER_OF_FIELD];
+    $parentIds = $this->utils->findAncestors($node, $fields, 1);
+    if (!$parentIds) {
+      return FALSE;
+    }
+    $result = 0;
+    foreach ($parentIds as $parentId) {
+      $parent = $this->entityTypeManager->getStorage('node')->load($parentId);
+      if ($parent) {
+        $parentResult = $this->evaluateEntity($parent);
+        $result = $result + (int)$parentResult;
+      }
+    }
+    return (boolean)$result;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function summary() {
+    if (!empty($this->configuration['negate'])) {
+      return $this->t('The parent node is not associated with taxonomy term with uri @uri.', ['@uri' => $this->configuration['uri']]);
+    }
+    else {
+      return $this->t('The parent node is associated with taxonomy term with uri @uri.', ['@uri' => $this->configuration['uri']]);
+    }
+  }
+
+}


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/2348

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What does this Pull Request do?

Defines a context condition useful for displaying a navigation block for compound objects, by testing to see if the current node's parent has Model=Compound object.

# How should this be tested?
On a repository with a compound object with several children, create a context (say, "Compound object navigation") that has condition "Parent node for node has term with URL", set Term=Compound object, Logic=And, Negate=false. As a reaction for test purposes, show block "Context inspector" on the page.

Alternatively, you can choose to create a view block that takes current node id as contextual filter (default content ID from URL), and uses two relationships based on `field_member_of` to first reference the parent item, then to list items that have the same parent. Display this view block as the reaction in the context above.

If you visit the compound object, you should see no block reaction, but if you browse to the compound object's child node(s)  you should see the block reaction.

# Documentation Status

* Does this change existing behaviour that's currently documented?
* Does this change require new pages or sections of documentation?
* Who does this need to be documented for?
* Associated documentation pull request(s): ___  or documentation issue ___

# Additional Notes:
Only lightly tested so far, e.g. it should fire if any of the parents of a node with multiple parents has a matching term.

# Interested parties
@Islandora/committers
