### PR TITLE
Add Context Conditions for term_is_published and media_is_published.

### DIFF
--- a/islandora.module
+++ b/islandora.module
@@ -505,6 +505,7 @@ function islandora_form_block_form_alter(&$form, FormStateInterface $form_state,
   unset($form['visibility']['media_has_mimetype']);
   unset($form['visibility']['media_has_term']);
   unset($form['visibility']['media_is_islandora_media']);
+  unset($form['visibility']['media_is_published']);
   unset($form['visibility']['media_uses_filesystem']);
   unset($form['visibility']['node_had_namespace']);
   unset($form['visibility']['node_has_ancestor']);
@@ -513,6 +514,7 @@ function islandora_form_block_form_alter(&$form, FormStateInterface $form_state,
   unset($form['visibility']['node_is_islandora_object']);
   unset($form['visibility']['node_referenced_by_node']);
   unset($form['visibility']['parent_node_has_term']);
+  unset($form['visibility']['term_is_published']);
 }
 
 /**

--- a/src/Plugin/Condition/MediaIsPublished.php
+++ b/src/Plugin/Condition/MediaIsPublished.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Drupal\islandora\Plugin\Condition;
+
+use Drupal\Core\Condition\ConditionPluginBase;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides an 'Is Published' condition for media.
+ *
+ * @Condition(
+ *   id = "media_is_published",
+ *   label = @Translation("Media is published"),
+ *   context_definitions = {
+ *     "media" = @ContextDefinition("entity:media", required = TRUE , label = @Translation("media"))
+ *   }
+ * )
+ */
+class MediaIsPublished extends ConditionPluginBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * Term storage.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Constructor.
+   *
+   * @param array $configuration
+   *   The plugin configuration, i.e. an array with configuration values keyed
+   *   by configuration option name. The special key 'context' may be used to
+   *   initialize the defined contexts by setting it to an array of context
+   *   values keyed by context names.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   Entity type manager.
+   */
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    EntityTypeManagerInterface $entity_type_manager
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function evaluate() {
+    $taxonomy_media = $this->getContextValue('taxonomy_media');
+    if (!$taxonomy_media  && !$this->isNegated()) {
+      return FALSE;
+    }
+    elseif (!$taxonomy_media) {
+      return FALSE;
+    }
+    else {
+      return $taxonomy_media->isPublished();
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function summary() {
+    if (!empty($this->configuration['negate'])) {
+      return $this->t('The taxonomy media is not published.');
+    }
+    else {
+      return $this->t('The taxonomy media is published.');
+    }
+  }
+
+}

--- a/src/Plugin/Condition/TermIsPublished.php
+++ b/src/Plugin/Condition/TermIsPublished.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Drupal\islandora\Plugin\Condition;
+
+use Drupal\Core\Condition\ConditionPluginBase;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides an 'Is Published' condition for taxonomy terms.
+ *
+ * @Condition(
+ *   id = "term_is_published",
+ *   label = @Translation("Term is published"),
+ *   context_definitions = {
+ *     "taxonomy_term" = @ContextDefinition("entity:taxonomy_term", required = TRUE , label = @Translation("taxonomy term"))
+ *   }
+ * )
+ */
+class TermIsPublished extends ConditionPluginBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * Term storage.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Constructor.
+   *
+   * @param array $configuration
+   *   The plugin configuration, i.e. an array with configuration values keyed
+   *   by configuration option name. The special key 'context' may be used to
+   *   initialize the defined contexts by setting it to an array of context
+   *   values keyed by context names.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   Entity type manager.
+   */
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    EntityTypeManagerInterface $entity_type_manager
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function evaluate() {
+    $taxonomy_term = $this->getContextValue('taxonomy_term');
+    if (!$taxonomy_term  && !$this->isNegated()) {
+      return FALSE;
+    }
+    elseif (!$taxonomy_term) {
+      return FALSE;
+    }
+    else {
+      return $taxonomy_term->isPublished();
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function summary() {
+    if (!empty($this->configuration['negate'])) {
+      return $this->t('The taxonomy term is not published.');
+    }
+    else {
+      return $this->t('The taxonomy term is published.');
+    }
+  }
+
+}


### PR DESCRIPTION
**GitHub Issue**: #1057 

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What does this Pull Request do?

Adds "Term is published" and "Media is published" conditions. It also removes them from the block placement interface because they can interfere.

# What's new?
2 new conditions.

* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? not at all.

# How should this be tested?

* make some published and unpublished terms or media. 
* Set up this context with, for example, a new custom block (create it under Manage > Content > Blocks)
* see the block only on the terms/media that are published / unpublished (depending how you set it up)

# Documentation Status

* Does this change existing behaviour that's currently documented? no
* Does this change require new pages or sections of documentation? no
* Who does this need to be documented for? We don't document our list of conditions.
* Associated documentation pull request(s): ___  or documentation issue ___

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
