### PR TITLE
islandora#1059: HTTP error 500 on /media/:mid?_format=jsonld if Media lacks File

### DIFF
--- a/src/Plugin/ContextReaction/JsonldSelfReferenceReaction.php
+++ b/src/Plugin/ContextReaction/JsonldSelfReferenceReaction.php
@@ -88,10 +88,11 @@ class JsonldSelfReferenceReaction extends NormalizerAlterReaction {
       if (isset($normalized['@graph']) && is_array($normalized['@graph'])) {
         foreach ($normalized['@graph'] as &$graph) {
           if (isset($graph['@id']) && $graph['@id'] == $url) {
-            // Swap media and file urls.
+            // If a file URL is available, swap it in as the ID.
             if ($entity instanceof MediaInterface) {
-              $file = $this->mediaSource->getSourceFile($entity);
-              $graph['@id'] = $this->utils->getDownloadUrl($file);
+              if ($file = $this->mediaSource->getSourceFile($entity)) {
+                $graph['@id'] = $this->utils->getDownloadUrl($file);
+              }
             }
             if (isset($graph[$self_ref_predicate])) {
               if (!is_array($graph[$self_ref_predicate])) {


### PR DESCRIPTION
**GitHub Issue**: #1059

# What does this Pull Request do?

Prevent a (not user facing) error when a Media lacks an associated File and `/media/123456?_format=jsonld` is requested for the Media item.

Instead of trying to return an `@id` with the File URI, we return the existing `@id` which has come from the Media entity.

# What's new?

- When no file is attached and `$file` is FALSE, do not overwrite the JSON `@id` value with the file URL
- Media will then use the Media's URL

# How should this be tested?

Before patch:

1. Create a Media entity which has no File attached
2. Request /media/123456?_format=jsonld for that file
3. See error in Drupal logs

After patch:

2. Request /media/123456?_format=jsonld for that file
3. See no error in Drupal logs


# Documentation Status

* Does this change existing behaviour that's currently documented? NO
* Does this change require new pages or sections of documentation? NO
* Who does this need to be documented for? nobody?
* Associated documentation pull request(s): ___  or documentation issue ___

# Additional Notes:


# Interested parties
CC @seth-shaw-asu @Islandora/committers
