### PR TITLE
Remove required from condition plugin forms

### DIFF
--- a/src/Plugin/Condition/MediaHasMimetype.php
+++ b/src/Plugin/Condition/MediaHasMimetype.php
@@ -103,7 +103,6 @@ class MediaHasMimetype extends ConditionPluginBase implements ContainerFactoryPl
       '#type' => 'textfield',
       '#title' => $this->t('Mime types'),
       '#default_value' => $this->configuration['mimetypes'],
-      '#required' => TRUE,
       '#maxlength' => 256,
       '#description' => $this->t('Comma-delimited list of Mime types (e.g. image/jpeg, video/mp4, etc...) that trigger the condition.'),
     ];

--- a/src/Plugin/Condition/NodeHasParent.php
+++ b/src/Plugin/Condition/NodeHasParent.php
@@ -84,7 +84,6 @@ class NodeHasParent extends ConditionPluginBase implements ContainerFactoryPlugi
       '#type' => 'entity_autocomplete',
       '#title' => $this->t('Parent node'),
       '#default_value' => $this->entityTypeManager->getStorage('node')->load($this->configuration['parent_nid']),
-      '#required' => TRUE,
       '#description' => $this->t("Can be a collection node or a compound object."),
       '#target_type' => 'node',
     ];

--- a/src/Plugin/Condition/NodeHasTerm.php
+++ b/src/Plugin/Condition/NodeHasTerm.php
@@ -111,7 +111,6 @@ class NodeHasTerm extends ConditionPluginBase implements ContainerFactoryPluginI
       '#tags' => TRUE,
       '#default_value' => $default,
       '#target_type' => 'taxonomy_term',
-      '#required' => TRUE,
       '#selection_handler' => 'islandora:external_uri',
     ];
 


### PR DESCRIPTION
Condition Plugins are optional and only enabled when required. Config forms for these plugins should not have required fields.

**GitHub Issue**: (link)
https://github.com/Islandora/islandora/issues/1065

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What does this Pull Request do?
Makes config for condition plugins optional.

* Could this change impact execution of existing code?
No

# How should this be tested?
Install either [google_tag](https://www.drupal.org/project/google_tag) or [asset_injector](https://www.drupal.org/project/asset_injector).
Try saving the google tag form or the asset injector form.
These forms can't be saved without this PR

# Interested parties
@Islandora/committers
