### PR TITLE
Move away from `orConditionGroup` to `UNION`-ized queries

### DIFF
--- a/islandora.services.yml
+++ b/islandora.services.yml
@@ -54,7 +54,7 @@ services:
     arguments: ['@entity_type.manager', '@current_user', '@language_manager', '@file_system', '@islandora.utils']
   islandora.utils:
     class: Drupal\islandora\IslandoraUtils
-    arguments: ['@entity_type.manager', '@entity_field.manager', '@context.manager', '@flysystem_factory', '@language_manager', '@current_user', '@database']
+    arguments: ['@entity_type.manager', '@entity_field.manager', '@context.manager', '@flysystem_factory', '@language_manager', '@current_user', '@database', '@logger.channel.islandora']
   islandora.entity_mapper:
     class: Islandora\EntityMapper\EntityMapper
   islandora.stomp.auth_header_listener:

--- a/islandora.services.yml
+++ b/islandora.services.yml
@@ -54,7 +54,7 @@ services:
     arguments: ['@entity_type.manager', '@current_user', '@language_manager', '@file_system', '@islandora.utils']
   islandora.utils:
     class: Drupal\islandora\IslandoraUtils
-    arguments: ['@entity_type.manager', '@entity_field.manager', '@context.manager', '@flysystem_factory', '@language_manager', '@current_user']
+    arguments: ['@entity_type.manager', '@entity_field.manager', '@context.manager', '@flysystem_factory', '@language_manager', '@current_user', '@database']
   islandora.entity_mapper:
     class: Islandora\EntityMapper\EntityMapper
   islandora.stomp.auth_header_listener:

--- a/src/IslandoraUtils.php
+++ b/src/IslandoraUtils.php
@@ -287,21 +287,15 @@ class IslandoraUtils {
       },
     );
 
-    $results = $query->execute()->fetchCol();
-
     $term_storage = $this->entityTypeManager->getStorage('taxonomy_term');
-    foreach ($results as $term_id) {
-      /** @var ?\Drupal\taxonomy\TermInterface $term */
-      if (!($term = $term_storage->load($term_id))) {
-        // Term failed to load/is null; skip it.
-        continue;
-      }
-      if ($term->access('view')) {
-        return $term;
-      }
-    }
+    $results = $term_storage->getQuery()
+      ->accessCheck(TRUE)
+      ->condition('tid', $query, 'IN')
+      ->execute();
 
-    return NULL;
+    return $results ?
+      $term_storage->load(reset($results)) :
+      NULL;
   }
 
   /**

--- a/src/IslandoraUtils.php
+++ b/src/IslandoraUtils.php
@@ -3,6 +3,9 @@
 namespace Drupal\islandora;
 
 use Drupal\context\ContextManager;
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Database\Query\SelectInterface;
+use Drupal\Core\DependencyInjection\DependencySerializationTrait;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\Core\Entity\EntityInterface;
@@ -28,6 +31,7 @@ use Drupal\taxonomy\TermInterface;
  * Utility functions for figuring out when to fire derivative reactions.
  */
 class IslandoraUtils {
+  use DependencySerializationTrait;
   use StringTranslationTrait;
   const EXTERNAL_URI_FIELD = 'field_external_uri';
 
@@ -96,6 +100,8 @@ class IslandoraUtils {
    *   Language manager.
    * @param \Drupal\Core\Session\AccountInterface $current_user
    *   The current user.
+   * @param \Drupal\Core\Database\Connection $database
+   *   Drupal's database service.
    */
   public function __construct(
     EntityTypeManagerInterface $entity_type_manager,
@@ -103,7 +109,8 @@ class IslandoraUtils {
     ContextManager $context_manager,
     FlysystemFactory $flysystem_factory,
     LanguageManagerInterface $language_manager,
-    AccountInterface $current_user
+    AccountInterface $current_user,
+    protected Connection $database,
   ) {
     $this->entityTypeManager = $entity_type_manager;
     $this->entityFieldManager = $entity_field_manager;
@@ -261,24 +268,40 @@ class IslandoraUtils {
     // Add field_external_uri.
     $fields[] = self::EXTERNAL_URI_FIELD;
 
-    $query = $this->entityTypeManager->getStorage('taxonomy_term')->getQuery();
-
-    $orGroup = $query->orConditionGroup();
-    foreach ($fields as $field) {
-      $orGroup->condition("$field.uri", $uri);
+    $queries = [];
+    foreach ($fields as $field_name) {
+      $queries[] = $this->database->select("taxonomy_term__{$field_name}", 'f')
+        ->fields('f', ['entity_id'])
+        ->condition("f.{$field_name}_uri", $uri);
     }
 
-    $results = $query
-      ->accessCheck(TRUE)
-      ->condition($orGroup)
-      ->execute();
+    /** @var \Drupal\Core\Database\Query\SelectInterface $query */
+    $query = array_reduce(
+      $queries,
+      static function (?SelectInterface $carry, SelectInterface $item) {
+        if ($carry === NULL) {
+          return $item;
+        }
 
-    if (empty($results)) {
-      return NULL;
+        return $carry->union($item);
+      },
+    );
+
+    $results = $query->execute()->fetchCol();
+
+    $term_storage = $this->entityTypeManager->getStorage('taxonomy_term');
+    foreach ($results as $term_id) {
+      /** @var ?\Drupal\taxonomy\TermInterface $term */
+      if (!($term = $term_storage->load($term_id))) {
+        // Term failed to load/is null; skip it.
+        continue;
+      }
+      if ($term->access('view')) {
+        return $term;
+      }
     }
 
-    return $this->entityTypeManager->getStorage('taxonomy_term')
-      ->load(reset($results));
+    return NULL;
   }
 
   /**

--- a/src/IslandoraUtils.php
+++ b/src/IslandoraUtils.php
@@ -199,9 +199,8 @@ class IslandoraUtils {
    *   Calling getStorage() throws if the storage handler couldn't be loaded.
    */
   public function getMediaWithTerm(NodeInterface $node, TermInterface $term) {
-    $mids = $this->getMediaReferencingNodeAndTermQuery($node, $term)
-      ->range(0, 1)
-      ->execute();
+    $query = $this->getMediaReferencingNodeAndTermQuery($node, $term);
+    $mids = $query?->range(0, 1)->execute() ?? [];
     if (empty($mids)) {
       return NULL;
     }
@@ -514,16 +513,32 @@ class IslandoraUtils {
     return array_merge($schemes, $this->flysystemFactory->getSchemes());
   }
 
-  private function getMediaReferencingNodeAndTermQuery(NodeInterface $node, TermInterface $term) : QueryInterface {
+  /**
+   * Build out query for selecting media related to a given node and term.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The node in question.
+   * @param \Drupal\taxonomy\TermInterface $term
+   *   The term in question.
+   *
+   * @return \Drupal\Core\Entity\Query\QueryInterface|null
+   *   An entity query over media, constrained to those relating to the given
+   *   node and term. NULL if a field does not exist to relate media to either
+   *   nodes or terms.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  private function getMediaReferencingNodeAndTermQuery(NodeInterface $node, TermInterface $term) : ?QueryInterface {
     $term_fields = $this->getReferencingFields('media', 'taxonomy_term');
     if (empty($term_fields)) {
       $this->logger->debug("No media fields found referencing a taxonomy term.");
-      return [];
+      return NULL;
     }
     $node_fields = $this->getReferencingFields('media', 'node');
     if (empty($node_fields)) {
       $this->logger->debug("No media fields found referencing a node.");
-      return [];
+      return NULL;
     }
 
     $remove_entity = static function (&$o) {
@@ -567,8 +582,7 @@ class IslandoraUtils {
    *   Array of media IDs.
    */
   public function getMediaReferencingNodeAndTerm(NodeInterface $node, TermInterface $term) {
-    return $this->getMediaReferencingNodeAndTermQuery($node, $term)
-      ->execute();
+    return $this->getMediaReferencingNodeAndTermQuery($node, $term)?->execute() ?? [];
   }
 
   /**

--- a/src/IslandoraUtils.php
+++ b/src/IslandoraUtils.php
@@ -199,7 +199,9 @@ class IslandoraUtils {
    *   Calling getStorage() throws if the storage handler couldn't be loaded.
    */
   public function getMediaWithTerm(NodeInterface $node, TermInterface $term) {
-    $mids = $this->getMediaReferencingNodeAndTerm($node, $term);
+    $mids = $this->getMediaReferencingNodeAndTermQuery($node, $term)
+      ->range(0, 1)
+      ->execute();
     if (empty($mids)) {
       return NULL;
     }
@@ -289,6 +291,7 @@ class IslandoraUtils {
     $results = $term_storage->getQuery()
       ->accessCheck(TRUE)
       ->condition('tid', $query, 'IN')
+      ->range(0, 1)
       ->execute();
 
     return $results ?
@@ -511,18 +514,7 @@ class IslandoraUtils {
     return array_merge($schemes, $this->flysystemFactory->getSchemes());
   }
 
-  /**
-   * Get array of media ids that have fields that reference $node and $term.
-   *
-   * @param \Drupal\node\NodeInterface $node
-   *   The node to reference.
-   * @param \Drupal\taxonomy\TermInterface $term
-   *   The term to reference.
-   *
-   * @return array
-   *   Array of media IDs.
-   */
-  public function getMediaReferencingNodeAndTerm(NodeInterface $node, TermInterface $term) {
+  private function getMediaReferencingNodeAndTermQuery(NodeInterface $node, TermInterface $term) : QueryInterface {
     $term_fields = $this->getReferencingFields('media', 'taxonomy_term');
     if (empty($term_fields)) {
       $this->logger->debug("No media fields found referencing a taxonomy term.");
@@ -560,8 +552,42 @@ class IslandoraUtils {
     return $this->entityTypeManager->getStorage('media')->getQuery()
       ->accessCheck(TRUE)
       ->condition('mid', $term_query, 'IN')
-      ->condition('mid', $node_query, 'IN')
+      ->condition('mid', $node_query, 'IN');
+  }
+
+  /**
+   * Get array of media ids that have fields that reference $node and $term.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The node to reference.
+   * @param \Drupal\taxonomy\TermInterface $term
+   *   The term to reference.
+   *
+   * @return array
+   *   Array of media IDs.
+   */
+  public function getMediaReferencingNodeAndTerm(NodeInterface $node, TermInterface $term) {
+    return $this->getMediaReferencingNodeAndTermQuery($node, $term)
       ->execute();
+  }
+
+  /**
+   * Determine if there is a media referencing the given node and term.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The node in question.
+   * @param \Drupal\taxonomy\TermInterface $term
+   *   The term in question.
+   *
+   * @return bool
+   *   TRUE if there exists at least one media related to the node and term;
+   *   otherwise, FALSE.
+   */
+  public function hasMediaReferencingNodeAndTerm(NodeInterface $node, TermInterface $term) : bool {
+    $results = $this->getMediaReferencingNodeAndTermQuery($node, $term)
+      ->range(0, 1)
+      ->execute();
+    return !empty($results);
   }
 
   /**

--- a/src/IslandoraUtils.php
+++ b/src/IslandoraUtils.php
@@ -572,25 +572,6 @@ class IslandoraUtils {
   }
 
   /**
-   * Determine if there is a media referencing the given node and term.
-   *
-   * @param \Drupal\node\NodeInterface $node
-   *   The node in question.
-   * @param \Drupal\taxonomy\TermInterface $term
-   *   The term in question.
-   *
-   * @return bool
-   *   TRUE if there exists at least one media related to the node and term;
-   *   otherwise, FALSE.
-   */
-  public function hasMediaReferencingNodeAndTerm(NodeInterface $node, TermInterface $term) : bool {
-    $results = $this->getMediaReferencingNodeAndTermQuery($node, $term)
-      ->range(0, 1)
-      ->execute();
-    return !empty($results);
-  }
-
-  /**
    * Get the fields on an entity of $entity_type that reference a $target_type.
    *
    * @param string $entity_type

--- a/src/IslandoraUtils.php
+++ b/src/IslandoraUtils.php
@@ -519,8 +519,8 @@ class IslandoraUtils {
    * @param \Drupal\taxonomy\TermInterface $term
    *   The term to reference.
    *
-   * @return int[]
-   *   Array of media IDs or NULL.
+   * @return array
+   *   Array of media IDs.
    */
   public function getMediaReferencingNodeAndTerm(NodeInterface $node, TermInterface $term) {
     $term_fields = $this->getReferencingFields('media', 'taxonomy_term');

--- a/src/IslandoraUtils.php
+++ b/src/IslandoraUtils.php
@@ -225,6 +225,7 @@ class IslandoraUtils {
     $fields = $this->getReferencingFields('media', 'file');
 
     if (empty($fields)) {
+      $this->logger->debug('No media fields found referencing a file.');
       return [];
     }
 

--- a/src/IslandoraUtils.php
+++ b/src/IslandoraUtils.php
@@ -10,7 +10,6 @@ use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\Entity\Query\QueryException;
 use Drupal\Core\Entity\Query\QueryInterface;
 use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Session\AccountInterface;
@@ -26,6 +25,7 @@ use Drupal\islandora\ContextProvider\TermContextProvider;
 use Drupal\media\MediaInterface;
 use Drupal\node\NodeInterface;
 use Drupal\taxonomy\TermInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * Utility functions for figuring out when to fire derivative reactions.
@@ -102,6 +102,8 @@ class IslandoraUtils {
    *   The current user.
    * @param \Drupal\Core\Database\Connection $database
    *   Drupal's database service.
+   * @param \Psr\Log\LoggerInterface $logger
+   *   Islandora's logger service.
    */
   public function __construct(
     EntityTypeManagerInterface $entity_type_manager,
@@ -111,6 +113,7 @@ class IslandoraUtils {
     LanguageManagerInterface $language_manager,
     AccountInterface $current_user,
     protected Connection $database,
+    protected LoggerInterface $logger,
   ) {
     $this->entityTypeManager = $entity_type_manager;
     $this->entityFieldManager = $entity_field_manager;
@@ -221,25 +224,28 @@ class IslandoraUtils {
     // Get media fields that reference files.
     $fields = $this->getReferencingFields('media', 'file');
 
-    // Process field names, stripping off 'media.' and appending 'target_id'.
-    $conditions = array_map(
-      function ($field) {
-        return ltrim($field, 'media.') . '.target_id';
-      },
-      $fields
-    );
+    if (empty($fields)) {
+      return [];
+    }
+
+    $queries = [];
+    foreach ($fields as $full_field) {
+      // Process field names, stripping off 'media.' and appending 'target_id'.
+      assert(str_starts_with($full_field, 'media.'), 'Has expected prefix.');
+      $trimmed_field = substr($full_field, strlen('media.'));
+      $queries[] = $this->database->select("media__{$trimmed_field}", 'f')
+        ->fields('f', ['entity_id'])
+        ->condition("f.{$trimmed_field}_target_id", $fid);
+    }
+
+    $media_storage = $this->entityTypeManager->getStorage('media');
 
     // Query for media that reference this file.
-    $query = $this->entityTypeManager->getStorage('media')->getQuery();
-    $query->accessCheck(TRUE);
-    $group = $query->orConditionGroup();
-    foreach ($conditions as $condition) {
-      $group->condition($condition, $fid);
-    }
-    $query->condition($group);
+    $query = $media_storage->getQuery()
+      ->accessCheck(TRUE)
+      ->condition('mid', array_reduce($queries, static::unionReduction(...)), 'IN');
 
-    return $this->entityTypeManager->getStorage('media')
-      ->loadMultiple($query->execute());
+    return $media_storage->loadMultiple($query->execute());
   }
 
   /**
@@ -276,16 +282,7 @@ class IslandoraUtils {
     }
 
     /** @var \Drupal\Core\Database\Query\SelectInterface $query */
-    $query = array_reduce(
-      $queries,
-      static function (?SelectInterface $carry, SelectInterface $item) {
-        if ($carry === NULL) {
-          return $item;
-        }
-
-        return $carry->union($item);
-      },
-    );
+    $query = array_reduce($queries, static::unionReduction(...));
 
     $term_storage = $this->entityTypeManager->getStorage('taxonomy_term');
     $results = $term_storage->getQuery()
@@ -296,6 +293,17 @@ class IslandoraUtils {
     return $results ?
       $term_storage->load(reset($results)) :
       NULL;
+  }
+
+  /**
+   * Callback for array_reduce(); "join" queries with "UNION".
+   */
+  private static function unionReduction(?SelectInterface $carry, SelectInterface $item) : SelectInterface {
+    if ($carry === NULL) {
+      return $item;
+    }
+
+    return $carry->union($item);
   }
 
   /**
@@ -510,41 +518,49 @@ class IslandoraUtils {
    * @param \Drupal\taxonomy\TermInterface $term
    *   The term to reference.
    *
-   * @return array|int|null
+   * @return int[]
    *   Array of media IDs or NULL.
    */
   public function getMediaReferencingNodeAndTerm(NodeInterface $node, TermInterface $term) {
     $term_fields = $this->getReferencingFields('media', 'taxonomy_term');
-    if (count($term_fields) <= 0) {
-      \Drupal::logger("No media fields reference a taxonomy term");
-      return NULL;
+    if (empty($term_fields)) {
+      $this->logger->debug("No media fields found referencing a taxonomy term.");
+      return [];
     }
     $node_fields = $this->getReferencingFields('media', 'node');
-    if (count($node_fields) <= 0) {
-      \Drupal::logger("No media fields reference a node.");
-      return NULL;
+    if (empty($node_fields)) {
+      $this->logger->debug("No media fields found referencing a node.");
+      return [];
     }
 
-    $remove_entity = function (&$o) {
+    $remove_entity = static function (&$o) {
       $o = substr($o, strpos($o, '.') + 1);
     };
     array_walk($term_fields, $remove_entity);
     array_walk($node_fields, $remove_entity);
 
-    $query = $this->entityTypeManager->getStorage('media')->getQuery();
-    $query->accessCheck(TRUE);
-    $taxon_condition = $this->getEntityQueryOrCondition($query, $term_fields, $term->id());
-    $query->condition($taxon_condition);
-    $node_condition = $this->getEntityQueryOrCondition($query, $node_fields, $node->id());
-    $query->condition($node_condition);
-    // Does the tags field exist?
-    try {
-      $mids = $query->execute();
-    }
-    catch (QueryException $e) {
-      $mids = [];
-    }
-    return $mids;
+    $map_reference_field = function (int $value) : callable {
+      return function (string $field) use ($value) : SelectInterface {
+        return $this->database->select("media__{$field}", 'f')
+          ->fields('f', ['entity_id'])
+          ->condition("f.{$field}_target_id", $value);
+      };
+    };
+
+    $term_query = array_reduce(
+      array_map($map_reference_field($term->id()), $term_fields),
+      static::unionReduction(...),
+    );
+    $node_query = array_reduce(
+      array_map($map_reference_field($node->id()), $node_fields),
+      static::unionReduction(...),
+    );
+
+    return $this->entityTypeManager->getStorage('media')->getQuery()
+      ->accessCheck(TRUE)
+      ->condition('mid', $term_query, 'IN')
+      ->condition('mid', $node_query, 'IN')
+      ->execute();
   }
 
   /**
@@ -568,27 +584,6 @@ class IslandoraUtils {
       $fields = [$fields];
     }
     return $fields;
-  }
-
-  /**
-   * Make an OR condition for an array of fields and a value.
-   *
-   * @param \Drupal\Core\Entity\Query\QueryInterface $query
-   *   The QueryInterface for the query.
-   * @param array $fields
-   *   The array of field names.
-   * @param string $value
-   *   The value to search the fields for.
-   *
-   * @return \Drupal\Core\Entity\Query\ConditionInterface
-   *   The OR condition to add to your query.
-   */
-  private function getEntityQueryOrCondition(QueryInterface $query, array $fields, $value) {
-    $condition = $query->orConditionGroup();
-    foreach ($fields as $field) {
-      $condition->condition($field, $value);
-    }
-    return $condition;
   }
 
   /**
@@ -778,11 +773,12 @@ class IslandoraUtils {
       if ($entity->hasField($field)) {
         $reference_field = $entity->get($field);
         if (!$reference_field->isEmpty()) {
-          $parents = array_merge($parents, $reference_field->referencedEntities());
+          $parents[] = $reference_field->referencedEntities();
         }
       }
     }
-    return $parents;
+
+    return array_merge(...$parents);
   }
 
   /**


### PR DESCRIPTION
**GitHub Issue**: (link)

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

- https://github.com/Islandora/islandora/pull/1067
- https://github.com/Islandora/documentation/issues/2272
- https://github.com/Islandora/islandora/issues/1055

# What does this Pull Request do?

Issues reporting slowness in queries that was being patched by effectively avoiding the `orConditionGroup`, so, it seems we want to avoid them. At the same time, submitting the queries separately can be avoided by constructing the set of results by `UNION`-ing all the queries together so, let's make it so.

# What's new?
A in-depth description of the changes made by this PR. Technical details and
 possible side effects.

* Changes x feature to such that y
* Added x
* Removed y
* Does this change add any new dependencies? 
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? 
* Could this change impact execution of existing code?

# How should this be tested?

A description of what steps someone could take to:
* Reproduce the problem you are fixing (if applicable)
* Test that the Pull Request does what is intended.
* Please be as detailed as possible.
* Good testing instructions help get your PR completed faster.

# Documentation Status

* Does this change existing behaviour that's currently documented?
* Does this change require new pages or sections of documentation?
* Who does this need to be documented for?
* Associated documentation pull request(s): ___  or documentation issue ___

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
