### PR TITLE
Fix Audio Captions

### DIFF
--- a/modules/islandora_audio/js/audio.js
+++ b/modules/islandora_audio/js/audio.js
@@ -44,6 +44,9 @@
               currentCue.text += (currentCue.text ? '\n' : '') + trimmedLine;
             }
           }
+          if (typeof currentCue !== 'undefined') {
+            cues.push(currentCue);
+          }
           return cues;
         }
 

--- a/modules/islandora_audio/js/audio.js
+++ b/modules/islandora_audio/js/audio.js
@@ -5,10 +5,10 @@
  * Displays Audio viewer.
  */
 (function (Drupal, once) {
-  Drupal.behaviors.customBehavior = {
+  Drupal.behaviors.islandora_audio_captions = {
     attach: function (context, settings) {
 
-      once('customBehavior', 'audio', context).forEach(function (element) {
+      once('islandora_audio_captions', 'audio', context).forEach(function (element) {
         function parseTimestamp(timestamp) {
           const [hours, minutes, seconds] = timestamp.split(':').map(Number);
           return hours * 3600 + minutes * 60 + seconds;

--- a/modules/islandora_audio/js/audio.js
+++ b/modules/islandora_audio/js/audio.js
@@ -47,7 +47,7 @@
           return cues;
         }
 
-        const vtt_source = element.querySelector("track[kind='captions']")?.getAttribute('src');
+        const vtt_source = element.querySelector("track[kind='captions'], track[kind='subtitles']")?.getAttribute('src');
         if (!vtt_source) { return; }
         fetch(vtt_source).then(response => {
           if (!response.ok) {

--- a/modules/islandora_audio/js/audio.js
+++ b/modules/islandora_audio/js/audio.js
@@ -4,44 +4,87 @@
  * @file
  * Displays Audio viewer.
  */
-(function ($, Drupal) {
-    'use strict';
+(function (Drupal, once) {
+  Drupal.behaviors.customBehavior = {
+    attach: function (context, settings) {
 
-    /**
-     * If initialized.
-     * @type {boolean}
-     */
-    var initialized;
-    /**
-     * Unique HTML id.
-     * @type {string}
-     */
-    var base;
+      once('customBehavior', 'audio', context).forEach(function (element) {
+        function parseTimestamp(timestamp) {
+          const [hours, minutes, seconds] = timestamp.split(':').map(Number);
+          return hours * 3600 + minutes * 60 + seconds;
+        }
+        function parseWebVTT(content) {
+          timeMarkerRegex = new RegExp("^\\d{2}:\\d{2}:\\d{2}\\.\\d{3} --> \\d{2}:\\d{2}:\\d{2}\\.\\d{3}$");
+          const lines = content.split('\n');
+          const cues = [];
+          let currentCue = null;
 
-    function init(context,settings){
-        if (!initialized){
-            initialized = true;
-            if ($('audio')[0].textTracks.length > 0) {
-                $('audio')[0].textTracks[0].oncuechange = function() {
-                  if (this.activeCues.length > 0) {
-                    var currentCue = this.activeCues[0].text;
-                    $('#audioTrack').html(currentCue);
-                  }
-                }
+          for (const line of lines) {
+            const trimmedLine = line.trim();
+            if (trimmedLine === 'WEBVTT') {
+              continue;
             }
+            if (!trimmedLine) {
+              // Empty line indicates the end of a cue
+              if (currentCue) {
+                cues.push(currentCue);
+                currentCue = null;
+              }
+              continue;
+            }
+
+            if (timeMarkerRegex.test(trimmedLine)) {
+              // Timing line
+              currentCue = { start: '', end: '', text: '' };
+              const [start, end] = trimmedLine.split(' --> ');
+              currentCue.start = parseTimestamp(start);
+              currentCue.end = parseTimestamp(end);
+            } else if (currentCue) {
+              // Text line
+              currentCue.text += (currentCue.text ? '\n' : '') + trimmedLine;
+            }
+          }
+          return cues;
         }
+
+        const vtt_source = element.querySelector("track[kind='captions']")?.getAttribute('src');
+        if (!vtt_source) { return; }
+        fetch(vtt_source).then(response => {
+          if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`);
+          }
+          return response.text();
+        }).then(text => {
+          const cues = parseWebVTT(text);
+
+          // Create a Custom Event attached to the timeupdate event to pass cues along.
+          element.addEventListener('timeupdate', (e) => {
+            const captionEvent = new CustomEvent('updateCaptions', { detail: cues })
+            e.target.dispatchEvent(captionEvent);
+          });
+          element.addEventListener('updateCaptions', (e) => {
+            if (!e.detail) {
+              return;
+            }
+
+            // Grab the caption for the current time.
+            const currentTime = e.target.currentTime;
+            let cue = e.detail.find(
+              (cue) =>
+                currentTime >= cue.start &&
+                currentTime <= cue.end
+            );
+
+            // Update the caption box.
+            let captionsBox = e.target.parentElement.querySelector('div.audioTrack')
+            if (cue?.text) {
+              captionsBox.innerHTML = cue.text.replace(/\n/g, "<br>");
+            } else {
+              captionsBox.innerHTML = '';
+            }
+          });
+        });
+      })
     }
-    Drupal.Audio = Drupal.Audio || {};
-
-    /**
-     * Initialize the Audio Viewer.
-     */
-    Drupal.behaviors.Audio = {
-        attach: function (context, settings) {
-            init(context,settings);
-        },
-        detach: function () {
-        }
-    };
-
-})(jQuery, Drupal);
+  }
+})(Drupal, once);

--- a/modules/islandora_audio/templates/islandora-file-audio.html.twig
+++ b/modules/islandora_audio/templates/islandora-file-audio.html.twig
@@ -15,7 +15,7 @@
 * @ingroup themeable
 */
 #}
-<div id="audioTrack"></div>
+<div class="audioTrack"></div>
 <audio {{ attributes }}>
   {% for file in files %}
     <source {{ file.source_attributes }} />


### PR DESCRIPTION
**GitHub Issue**: N/A

# What does this Pull Request do?

This PR replaces the existing islandora_audio JavaScript for displaying captions.

Why? The existing one doesn't work. Again, why? Because: 1) it relied on jQuery but didn't declare the dependency, and 2) it relied on non-spec browser behavior that has since changed.

# What's new?

Removes the jQuery dependency and provides it's own WebVTT parsing and display to replace the existing one. Also changes the captions div "id" attribute into a "class" attribute to better support multiple audio on the same page.

# How should this be tested?

* Create an Audio repository item that includes a valid WebVTT track on the Audio media. You can download an [MP3](https://d1rbsgppyrdqq4.cloudfront.net/prism/s3fs-public/2025-01/67358-Service%20File.mp3) and [WebVTT](https://d1rbsgppyrdqq4.cloudfront.net/prism/s3fs-public/2025-01/captions-398377_0.vtt) from our site for testing.
* Play the audio and observe that no captions appear. (I tested on Chrome and Firefox.)
* Apply the PR
* Clear caches
* Play the audio again and observe the captions appear.

# Documentation Status

* Does this change existing behaviour that's currently documented? No.
* Does this change require new pages or sections of documentation? No.
* Who does this need to be documented for? N/a.

# Interested parties
@Islandora/committers
