### PR TITLE
Update islandora_audio.libraries.yml

### DIFF
--- a/modules/islandora_audio/islandora_audio.libraries.yml
+++ b/modules/islandora_audio/islandora_audio.libraries.yml
@@ -1,5 +1,4 @@
 audio:
-  version: 1.x
   js:
     js/audio.js: {preprocess: false}
   dependencies:


### PR DESCRIPTION
# What does this Pull Request do?

Removes the version line of the `islandora_audio.libraries.yml`. Drupal caches the old broken javascript using this version key. To get the new code to show up when updating the module one would have to remember to increment this tag each time OR simply remove it so we don't have to deal with it anymore.

Why might we keep it? It can be useful if sites write their own JS dependent on our libraries; but that would also mean copying the old template file if they update the module too. Either way, they are going to have to update their site.

# How should this be tested?

* Have a site with islandora < 12.13.3
* See that audio captions don't work.
* Update to islandora 12.13.3
* See that audio captions _still_ don't work because it is using a versioned copy of the JavaScript (e.g. `<site>/modules/contrib/islandora/modules/islandora_audio/js/audio.js?v=1.x`).
* Drop the version line from the `libaries.yml` as shown in the code changes
* Clear cache
* See it work now.

# Additional Comments

If anyone else's Drupal-fu has a better solution, I'm all 👂.

# Interested parties
@Islandora/committers
