### PR TITLE
#2355 Handle multiple audio tracks on a single audio element

### DIFF
--- a/modules/islandora_audio/js/audio.js
+++ b/modules/islandora_audio/js/audio.js
@@ -50,43 +50,61 @@
           return cues;
         }
 
-        const vtt_source = element.querySelector("track[kind='captions'], track[kind='subtitles']")?.getAttribute('src');
-        if (!vtt_source) { return; }
-        fetch(vtt_source).then(response => {
-          if (!response.ok) {
-            throw new Error(`HTTP error! status: ${response.status}`);
+        element.textTracks.addEventListener('change', function(e)  {
+          // Which track is showing?
+          for (let i = 0; i < this.length; i++) {
+            if (this[i].mode === 'showing') {
+              // Build cues for this track, now we know the index.
+              // @todo: Make this work with multiple audio elements.
+              var src = document.querySelectorAll("track[kind='captions'], track[kind='subtitles']")[i].getAttribute('src');
+              bindVttSource(src);
+            }
           }
-          return response.text();
-        }).then(text => {
-          const cues = parseWebVTT(text);
-
-          // Create a Custom Event attached to the timeupdate event to pass cues along.
-          element.addEventListener('timeupdate', (e) => {
-            const captionEvent = new CustomEvent('updateCaptions', { detail: cues })
-            e.target.dispatchEvent(captionEvent);
-          });
-          element.addEventListener('updateCaptions', (e) => {
-            if (!e.detail) {
-              return;
-            }
-
-            // Grab the caption for the current time.
-            const currentTime = e.target.currentTime;
-            let cue = e.detail.find(
-              (cue) =>
-                currentTime >= cue.start &&
-                currentTime <= cue.end
-            );
-
-            // Update the caption box.
-            let captionsBox = e.target.parentElement.querySelector('div.audioTrack')
-            if (cue?.text) {
-              captionsBox.innerHTML = cue.text.replace(/\n/g, "<br>");
-            } else {
-              captionsBox.innerHTML = '';
-            }
-          });
         });
+
+        // Invoke change event to get started.
+        const changeEvent = new Event('change');
+        element.textTracks.dispatchEvent(changeEvent);
+
+        function bindVttSource(vtt_source) {
+
+          fetch(vtt_source).then(response => {
+            if (!response.ok) {
+              throw new Error(`HTTP error! status: ${response.status}`);
+            }
+            return response.text();
+          }).then(text => {
+            const cues = parseWebVTT(text);
+
+            // Create a Custom Event attached to the timeupdate event to pass cues along.
+            element.addEventListener('timeupdate', (e) => {
+              const captionEvent = new CustomEvent('updateCaptions', { detail: cues })
+              e.target.dispatchEvent(captionEvent);
+            });
+            element.addEventListener('updateCaptions', (e) => {
+              if (!e.detail) {
+                return;
+              }
+
+              // Grab the caption for the current time.
+              const currentTime = e.target.currentTime;
+              let cue = e.detail.find(
+                  (cue) =>
+                      currentTime >= cue.start &&
+                      currentTime <= cue.end
+              );
+
+              // Update the caption box.
+              let captionsBox = e.target.parentElement.querySelector('div.audioTrack')
+              if (cue?.text) {
+                captionsBox.innerHTML = cue.text.replace(/\n/g, "<br>");
+              }
+              else {
+                captionsBox.innerHTML = '';
+              }
+            });
+          });
+        }
       })
     }
   }

--- a/modules/islandora_audio/js/audio.js
+++ b/modules/islandora_audio/js/audio.js
@@ -96,6 +96,7 @@
                 const currentTime = e.target.currentTime;
                 let cue = e.detail.find(
                   (cue) =>
+                    cue !== null &&
                     currentTime >= cue.start &&
                     currentTime <= cue.end
                 );

--- a/modules/islandora_audio/js/audio.js
+++ b/modules/islandora_audio/js/audio.js
@@ -52,12 +52,14 @@
 
         element.textTracks.addEventListener('change', function(e)  {
           // Which track is showing?
+          element.setAttribute('data-showing', false);
           for (let i = 0; i < this.length; i++) {
             if (this[i].mode === 'showing') {
               // Build cues for this track, now we know the index.
               // @todo: Make this work with multiple audio elements.
               var src = document.querySelectorAll("track[kind='captions'], track[kind='subtitles']")[i].getAttribute('src');
               bindVttSource(src);
+              element.setAttribute('data-showing', true);
             }
           }
         });
@@ -85,19 +87,24 @@
               if (!e.detail) {
                 return;
               }
-
-              // Grab the caption for the current time.
-              const currentTime = e.target.currentTime;
-              let cue = e.detail.find(
-                  (cue) =>
-                      currentTime >= cue.start &&
-                      currentTime <= cue.end
-              );
-
+              // Check if a track is showing.
+              var showing = e.target.getAttribute('data-showing');
               // Update the caption box.
-              let captionsBox = e.target.parentElement.querySelector('div.audioTrack')
-              if (cue?.text) {
-                captionsBox.innerHTML = cue.text.replace(/\n/g, "<br>");
+              let captionsBox = e.target.parentElement.querySelector('div.audioTrack');
+              if (showing === 'true') {
+                // Grab the caption for the current time.
+                const currentTime = e.target.currentTime;
+                let cue = e.detail.find(
+                  (cue) =>
+                    currentTime >= cue.start &&
+                    currentTime <= cue.end
+                );
+                if (cue?.text) {
+                  captionsBox.innerHTML = cue.text.replace(/\n/g, "<br>");
+                }
+                else {
+                  captionsBox.innerHTML = '';
+                }
               }
               else {
                 captionsBox.innerHTML = '';


### PR DESCRIPTION
**GitHub Issue**: (link)
#2355 Handle multiple audio tracks

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What does this Pull Request do?
Reworks islandora audio js to add a eventListener to detect a track change, to allow the user to switch between multiple webvtt tracks for an audio element (e.g. different webvtt files for different languages).

# What's new?
I don't expect this to work for multiple audio elements on the same page. The event listener assumes only one track has the mode='showing'.

It wraps the previous logic in a new function `bindVttSource()` so we can invoke it on different track files.

# How should this be tested?

1. Create an Audio repository item that includes a multiple WebVTT tracks on the Audio media. 
2. Play the audio and observe that if webvtt captions are available, it is not possible to switch between them.
3. Apply the PR
4. Clear caches
5. Play the audio again and observe the captions appear, and it is possible to switch between the captions while playing.

Browser should see markup like this:
```html
<audio controls="controls" data-once="islandora_audio_captions">
    <source src="/_flysystem/fedora/2025-02/myinterview.mp3" type="audio/mpeg">
    <track src="/_flysystem/fedora/2025-02/transcript-french.vtt" srclang="fr" label="(fr)Transcript" kind="captions" default="default">
    <track src="/_flysystem/fedora/2025-02/transcript-english.vtt" srclang="en" label="(en)Transcript" kind="captions">
    <track src="/_flysystem/fedora/2025-02/transcript-punjabi.vtt" srclang="pa" label="(pa)Transcript" kind="captions">
</audio>
```

# Documentation Status

* Does this change existing behaviour that's currently documented? Unsure
* Does this change require new pages or sections of documentation? Probably.
* Who does this need to be documented for? Users
* Associated documentation pull request(s): ___  or documentation issue ___


# Interested parties
@Islandora/committers @seth-shaw-asu 
