### PR TITLE
Support IIIF canvas labels and metadata from node

### DIFF
--- a/modules/islandora_iiif/config/schema/islandora_iiif.schema.yml
+++ b/modules/islandora_iiif/config/schema/islandora_iiif.schema.yml
@@ -31,6 +31,12 @@ views.style.iiif_manifest:
     search_endpoint:
       type: string
       label: "Search endpoint path"
+    metadata_fields:
+      type: sequence
+      label: "Metadata field(s)"
+    canvas_label:
+      type: string
+      label: "Canvas label field"
 
 action.configuration.media_attributes_from_iiif_action:
   type: mapping

--- a/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
+++ b/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
@@ -9,6 +9,7 @@ use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Field\FieldItemInterface;
 use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Url;
 use Drupal\islandora\IslandoraUtils;
@@ -138,9 +139,16 @@ class IIIFManifest extends StylePluginBase {
   protected bool $structuredTextTermMemoized = FALSE;
 
   /**
+   * Cached language code so we don't have to keep calling the lang service.
+   *
+   * @var string
+   */
+  protected $langCode = 'none';
+
+  /**
    * {@inheritdoc}
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, SerializerInterface $serializer, Request $request, ImmutableConfig $iiif_config, EntityTypeManagerInterface $entity_type_manager, FileSystemInterface $file_system, Client $http_client, MessengerInterface $messenger, ModuleHandlerInterface $moduleHandler, IslandoraUtils $utils, IiifInfo $iiif_info) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, SerializerInterface $serializer, Request $request, ImmutableConfig $iiif_config, EntityTypeManagerInterface $entity_type_manager, FileSystemInterface $file_system, Client $http_client, MessengerInterface $messenger, ModuleHandlerInterface $moduleHandler, IslandoraUtils $utils, IiifInfo $iiif_info, LanguageManagerInterface $languageManager) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
 
     $this->serializer = $serializer;
@@ -154,6 +162,7 @@ class IIIFManifest extends StylePluginBase {
     $this->moduleHandler = $moduleHandler;
     $this->utils = $utils;
     $this->iiifInfo = $iiif_info;
+    $this->langCode = \Drupal::languageManager()->getCurrentLanguage()->getId();
   }
 
   /**
@@ -173,7 +182,8 @@ class IIIFManifest extends StylePluginBase {
       $container->get('messenger'),
       $container->get('module_handler'),
       $container->get('islandora.utils'),
-      $container->get('islandora_iiif')
+      $container->get('islandora_iiif'),
+      $container->get('language_manager'),
     );
   }
 
@@ -261,6 +271,28 @@ class IIIFManifest extends StylePluginBase {
   }
 
   /**
+   * Helper function to get labels without relationship information.
+   *
+   * Ideally, we would use the display handler's `getFieldLabels`, but that
+   * adds relationship information to the label we don't want.
+   *
+   * @return array
+   *   List of field labels keyed on field name.
+   */
+  protected function getFieldLabels() {
+    $options = [];
+    foreach ($this->displayHandler->getHandlers('field') as $id => $handler) {
+      if ($label = $handler->label()) {
+        $options[$id] = $label;
+      }
+      else {
+        $options[$id] = $handler->adminLabel();
+      }
+    }
+    return $options;
+  }
+
+  /**
    * Render array from views result row.
    *
    * @param \Drupal\views\ResultRow $row
@@ -283,7 +315,7 @@ class IIIFManifest extends StylePluginBase {
       if (isset($entity->{$viewsField->definition['field_name']})) {
         /** @var \Drupal\Core\Field\FieldItemListInterface $images */
         $images = $entity->{$viewsField->definition['field_name']};
-        foreach ($images as $i => $image) {
+        foreach ($images as $image) {
           if (!$image->entity->access('view')) {
             // If the user does not have permission to view the file, skip it.
             continue;
@@ -340,6 +372,25 @@ class IIIFManifest extends StylePluginBase {
               ],
             ],
           ];
+
+          // Canvas label field to override the default media label.
+          if (array_key_exists($this->options['canvas_label'], $this->view->field) && $label = $this->getFieldValue($row->index, $this->options['canvas_label'])) {
+            $tmp_canvas['label'] = $label;
+          }
+
+          // Add metadata to canvas.
+          $metadata = [];
+          $labels = $this->getFieldLabels();
+          foreach ($this->options['metadata_fields'] as $field_name) {
+            if (array_key_exists($field_name, $labels) && array_key_exists($field_name, $this->view->field) && $value = $this->getField($row->index, $field_name)) {
+              $metadata[] = [
+                'label' => [$this->langCode => [$labels[$field_name]]],
+                'value' => [$this->langCode => [$value]],
+              ];
+            }
+          }
+
+          $tmp_canvas['metadata'] = $metadata;
 
           if ($ocr_url = $this->getOcrUrl($entity)) {
             $tmp_canvas['seeAlso'] = [
@@ -525,6 +576,8 @@ class IIIFManifest extends StylePluginBase {
 
     $options['iiif_tile_field'] = ['default' => ''];
     $options['iiif_ocr_file_field'] = ['default' => ''];
+    $options['metadata_fields'] = ['default' => []];
+    $options['canvas_label'] = ['default' => ''];
 
     return $options;
   }
@@ -550,7 +603,7 @@ class IIIFManifest extends StylePluginBase {
         "@context" => "http://iiif.io/api/search/0/context.json",
         "@id" => $hocr_search_url,
         "profile" => "http://iiif.io/api/search/0/search",
-        "label" => t("Search inside this work"),
+        "label" => $this->t("Search inside this work"),
       ];
     }
   }
@@ -613,6 +666,21 @@ class IIIFManifest extends StylePluginBase {
       // we have more than one option to choose from
       // otherwise could lock up the form when setting up a View.
       '#required' => count($field_options) > 0,
+    ];
+
+    $form['canvas_label'] = [
+      '#title' => $this->t('Canvas label source field'),
+      '#type' => 'select',
+      '#default_value' => $this->options['canvas_label'],
+      '#options' => array_merge(['' => 'None'], $this->displayHandler->getFieldLabels()),
+    ];
+
+    $form['metadata_fields'] = [
+      '#title' => $this->t('Fields to include in canvas metadata'),
+      '#type' => 'select',
+      '#multiple' => TRUE,
+      '#options' => $this->displayHandler->getFieldLabels(),
+      '#default_value' => $this->options['metadata_fields'],
     ];
 
     $form['advanced'] = [
@@ -692,13 +760,14 @@ class IIIFManifest extends StylePluginBase {
   public function submitOptionsForm(&$form, FormStateInterface $form_state) {
     // @codingStandardsIgnoreEnd
     $style_options = $form_state->getValue('style_options');
-    $tid = $style_options['structured_text_term'];
-    unset($style_options['structured_text_term']);
-    $term = $this->entityTypeManager->getStorage('taxonomy_term')->load($tid);
-    if ($term) {
-      $style_options['structured_text_term_uri'] = $this->utils->getUriForTerm($term);
+    if ($tid = $style_options['structured_text_term']) {
+      unset($style_options['structured_text_term']);
+      $term = $this->entityTypeManager->getStorage('taxonomy_term')->load($tid);
+      if ($term) {
+        $style_options['structured_text_term_uri'] = $this->utils->getUriForTerm($term);
+      }
+      $form_state->setValue('style_options', $style_options);
     }
-    $form_state->setValue('style_options', $style_options);
     parent::submitOptionsForm($form, $form_state);
   }
 

--- a/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
+++ b/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
@@ -143,7 +143,7 @@ class IIIFManifest extends StylePluginBase {
    *
    * @var string
    */
-  protected $langCode = 'none';
+  protected $langCode;
 
   /**
    * {@inheritdoc}


### PR DESCRIPTION
# What does this Pull Request do?

This PR allows us to use content fields to populate canvas labels and metadata for the IIIF Manifest views style plugin.

E.g. currently when we use Mirador the media's name is used for the canvas label in viewer. However, our child nodes have title metadata, even if it is simply as "Cover", "Page 1", etc. or "Recto" and "Verso" which this PR allows us to configure. Also, Mirador can display metadata with each canvas (see [IIIF Presentation API section on metadata](https://iiif.io/api/presentation/3.0/#metadata) and "[Metadata on any Resource" ](https://iiif.io/api/cookbook/recipe/0029-metadata-anywhere/)from the cookbook), which we didn't support. This PR allows us to add fields to the view and include them in metadata display.

# What's new?

* Two new configuration settings on the IIIF Manifest settings which use the currently configured field views as options:
  * "Canvas label" source field select box.
  * "Fields to include in canvas metadata" multi-select.
* Updated IIIF Manifest render to add the canvas label and metadata fields as configured for that view.
* A coding style update.
* A sanity check for a feature throwing warnings when not configured.

# How should this be tested?

* Create a paged content item with pages that include nice titles and a few fields populated (e.g. description or date created).
* Either view the book-manifest and see the canvas labels using the media name OR load the Mirador viewer and see the same. 😢
* Apply the PR
* Either use the included views configuration (see the additional notes section) which updates the existing starter-site configuration OR update the iiif_manifest view's book-manifest display:
  * Add fields from the Content section. E.g. "Title" which will display as "(field_media_of: Content) Title"
  * Update the IIIF Manifest style settings to use "Title" as the canvas label.
  * Select title, or any of the other content fields, to be included in the canvas metadata.
  * Save the configuration
* Either view the book-manifest and see the canvas labels using node titles and the other metadata being included OR load the Mirador viewer and see the same. 🎉 

# Documentation Status

* Does this change existing behavior that's currently documented? Adds new behavior.
* Does this change require new pages or sections of documentation? Not necessarily; but could possibly be documented @ https://islandora.github.io/documentation/user-documentation/iiif/#using-iiif-in-islandora

# Additional Notes:

<details>
<summary>`views.view.iiif_manifest.yml` for testing canvas metadata</summary>

```yml
langcode: en
status: true
dependencies:
  config:
    - field.storage.media.field_media_file
    - field.storage.media.field_media_image
    - field.storage.node.field_description
    - field.storage.node.field_edtf_date
    - field.storage.node.field_edtf_date_created
    - field.storage.node.field_identifier
    - field.storage.node.field_linked_agent
  module:
    - controlled_access_terms
    - file
    - image
    - islandora_iiif
    - media
    - node
    - rest
    - serialization
    - taxonomy
    - user
id: iiif_manifest
label: 'IIIF Manifest'
module: views
description: 'Generates IIIF manifests for paged content'
tag: ''
base_table: media_field_data
base_field: mid
display:
  default:
    id: default
    display_title: Main
    display_plugin: default
    position: 0
    display_options:
      title: ''
      fields:
        field_media_file:
          id: field_media_file
          table: media__field_media_file
          field: field_media_file
          relationship: none
          group_type: group
          admin_label: ''
          plugin_id: field
          label: ''
          exclude: false
          alter:
            alter_text: false
            text: ''
            make_link: false
            path: ''
            absolute: false
            external: false
            replace_spaces: false
            path_case: none
            trim_whitespace: false
            alt: ''
            rel: ''
            link_class: ''
            prefix: ''
            suffix: ''
            target: ''
            nl2br: false
            max_length: 0
            word_boundary: true
            ellipsis: true
            more_link: false
            more_link_text: ''
            more_link_path: ''
            strip_tags: false
            trim: false
            preserve_tags: ''
            html: false
          element_type: ''
          element_class: ''
          element_label_type: ''
          element_label_class: ''
          element_label_colon: false
          element_wrapper_type: ''
          element_wrapper_class: ''
          element_default_classes: true
          empty: ''
          hide_empty: false
          empty_zero: false
          hide_alter_empty: true
          click_sort_column: target_id
          type: file_default
          settings:
            use_description_as_link_text: true
          group_column: ''
          group_columns: {  }
          group_rows: true
          delta_limit: 0
          delta_offset: 0
          delta_reversed: false
          delta_first_last: false
          multi_type: separator
          separator: ', '
          field_api_classes: false
        field_media_image:
          id: field_media_image
          table: media__field_media_image
          field: field_media_image
          relationship: none
          group_type: group
          admin_label: ''
          plugin_id: field
          label: ''
          exclude: false
          alter:
            alter_text: false
            text: ''
            make_link: false
            path: ''
            absolute: false
            external: false
            replace_spaces: false
            path_case: none
            trim_whitespace: false
            alt: ''
            rel: ''
            link_class: ''
            prefix: ''
            suffix: ''
            target: ''
            nl2br: false
            max_length: 0
            word_boundary: true
            ellipsis: true
            more_link: false
            more_link_text: ''
            more_link_path: ''
            strip_tags: false
            trim: false
            preserve_tags: ''
            html: false
          element_type: ''
          element_class: ''
          element_label_type: ''
          element_label_class: ''
          element_label_colon: false
          element_wrapper_type: ''
          element_wrapper_class: ''
          element_default_classes: true
          empty: ''
          hide_empty: false
          empty_zero: false
          hide_alter_empty: true
          click_sort_column: target_id
          type: image
          settings:
            image_link: ''
            image_style: ''
            image_loading:
              attribute: lazy
          group_column: ''
          group_columns: {  }
          group_rows: true
          delta_limit: 0
          delta_offset: 0
          delta_reversed: false
          delta_first_last: false
          multi_type: separator
          separator: ', '
          field_api_classes: false
        title:
          id: title
          table: node_field_data
          field: title
          relationship: field_media_of
          group_type: group
          admin_label: Title
          entity_type: node
          entity_field: title
          plugin_id: field
          label: Title
          exclude: false
          alter:
            alter_text: false
            text: ''
            make_link: false
            path: ''
            absolute: false
            external: false
            replace_spaces: false
            path_case: none
            trim_whitespace: false
            alt: ''
            rel: ''
            link_class: ''
            prefix: ''
            suffix: ''
            target: ''
            nl2br: false
            max_length: 0
            word_boundary: true
            ellipsis: true
            more_link: false
            more_link_text: ''
            more_link_path: ''
            strip_tags: false
            trim: false
            preserve_tags: ''
            html: false
          element_type: ''
          element_class: ''
          element_label_type: ''
          element_label_class: ''
          element_label_colon: false
          element_wrapper_type: ''
          element_wrapper_class: ''
          element_default_classes: true
          empty: ''
          hide_empty: false
          empty_zero: false
          hide_alter_empty: true
          click_sort_column: value
          type: string
          settings:
            link_to_entity: false
          group_column: value
          group_columns: {  }
          group_rows: true
          delta_limit: 0
          delta_offset: 0
          delta_reversed: false
          delta_first_last: false
          multi_type: separator
          separator: ', '
          field_api_classes: false
        field_linked_agent:
          id: field_linked_agent
          table: node__field_linked_agent
          field: field_linked_agent
          relationship: field_media_of
          group_type: group
          admin_label: Contributors
          plugin_id: field
          label: ''
          exclude: false
          alter:
            alter_text: false
            text: ''
            make_link: false
            path: ''
            absolute: false
            external: false
            replace_spaces: false
            path_case: none
            trim_whitespace: false
            alt: ''
            rel: ''
            link_class: ''
            prefix: ''
            suffix: ''
            target: ''
            nl2br: false
            max_length: 0
            word_boundary: true
            ellipsis: true
            more_link: false
            more_link_text: ''
            more_link_path: ''
            strip_tags: false
            trim: false
            preserve_tags: ''
            html: false
          element_type: ''
          element_class: ''
          element_label_type: ''
          element_label_class: ''
          element_label_colon: false
          element_wrapper_type: ''
          element_wrapper_class: ''
          element_default_classes: true
          empty: ''
          hide_empty: false
          empty_zero: false
          hide_alter_empty: true
          click_sort_column: target_id
          type: typed_relation_default
          settings:
            link: false
          group_column: ''
          group_columns: {  }
          group_rows: true
          delta_limit: 0
          delta_offset: 0
          delta_reversed: false
          delta_first_last: false
          multi_type: separator
          separator: ', '
          field_api_classes: false
        field_edtf_date:
          id: field_edtf_date
          table: node__field_edtf_date
          field: field_edtf_date
          relationship: field_media_of
          group_type: group
          admin_label: ''
          plugin_id: field
          label: Date
          exclude: false
          alter:
            alter_text: false
            text: ''
            make_link: false
            path: ''
            absolute: false
            external: false
            replace_spaces: false
            path_case: none
            trim_whitespace: false
            alt: ''
            rel: ''
            link_class: ''
            prefix: ''
            suffix: ''
            target: ''
            nl2br: false
            max_length: 0
            word_boundary: true
            ellipsis: true
            more_link: false
            more_link_text: ''
            more_link_path: ''
            strip_tags: false
            trim: false
            preserve_tags: ''
            html: false
          element_type: ''
          element_class: ''
          element_label_type: ''
          element_label_class: ''
          element_label_colon: false
          element_wrapper_type: ''
          element_wrapper_class: ''
          element_default_classes: true
          empty: ''
          hide_empty: false
          empty_zero: false
          hide_alter_empty: true
          click_sort_column: value
          type: edtf_default
          settings:
            date_separator: dash
            date_order: big_endian
            month_format: mm
            day_format: dd
            year_format: 'y'
            relationship: field_media_of
            fieldsets:
              - more
              - admin_label
            custom_label: 0
            label: ''
            element_label_colon: 0
            exclude: 0
            element_type_enable: 0
            element_type: ''
            element_class_enable: 0
            element_class: ''
            element_label_type_enable: 0
            element_label_type: ''
            element_label_class_enable: 0
            element_label_class: ''
            element_wrapper_type_enable: 0
            element_wrapper_type: ''
            element_wrapper_class_enable: 0
            element_wrapper_class: ''
            element_default_classes: 1
            alter:
              alter_text: 0
              text: ''
              make_link: 0
              path: ''
              absolute: 0
              replace_spaces: 0
              external: 0
              path_case: none
              link_class: ''
              alt: ''
              rel: ''
              prefix: ''
              suffix: ''
              target: ''
              trim: 0
              max_length: '0'
              word_boundary: 1
              ellipsis: 1
              more_link: 0
              more_link_text: ''
              more_link_path: ''
              html: 0
              strip_tags: 0
              preserve_tags: ''
              trim_whitespace: 0
              nl2br: 0
            empty: ''
            empty_zero: 0
            hide_empty: 0
            hide_alter_empty: 1
            group_rows: 1
            multi_type: separator
            separator: ', '
            delta_limit: '0'
            delta_offset: '0'
            delta_reversed: 0
            delta_first_last: 0
            click_sort_column: value
            type: edtf_default
            field_api_classes: 0
          group_column: value
          group_columns: {  }
          group_rows: true
          delta_limit: 0
          delta_offset: 0
          delta_reversed: false
          delta_first_last: false
          multi_type: separator
          separator: ', '
          field_api_classes: false
        field_edtf_date_created:
          id: field_edtf_date_created
          table: node__field_edtf_date_created
          field: field_edtf_date_created
          relationship: field_media_of
          group_type: group
          admin_label: 'Date Created'
          plugin_id: field
          label: ''
          exclude: false
          alter:
            alter_text: false
            text: ''
            make_link: false
            path: ''
            absolute: false
            external: false
            replace_spaces: false
            path_case: none
            trim_whitespace: false
            alt: ''
            rel: ''
            link_class: ''
            prefix: ''
            suffix: ''
            target: ''
            nl2br: false
            max_length: 0
            word_boundary: true
            ellipsis: true
            more_link: false
            more_link_text: ''
            more_link_path: ''
            strip_tags: false
            trim: false
            preserve_tags: ''
            html: false
          element_type: ''
          element_class: ''
          element_label_type: ''
          element_label_class: ''
          element_label_colon: false
          element_wrapper_type: ''
          element_wrapper_class: ''
          element_default_classes: true
          empty: ''
          hide_empty: false
          empty_zero: false
          hide_alter_empty: true
          click_sort_column: value
          type: edtf_default
          settings:
            date_separator: dash
            date_order: big_endian
            month_format: mm
            day_format: dd
            year_format: 'y'
            relationship: field_media_of
            fieldsets:
              - more
              - admin_label
            custom_label: 0
            label: ''
            element_label_colon: 0
            exclude: 0
            element_type_enable: 0
            element_type: ''
            element_class_enable: 0
            element_class: ''
            element_label_type_enable: 0
            element_label_type: ''
            element_label_class_enable: 0
            element_label_class: ''
            element_wrapper_type_enable: 0
            element_wrapper_type: ''
            element_wrapper_class_enable: 0
            element_wrapper_class: ''
            element_default_classes: 1
            alter:
              alter_text: 0
              text: ''
              make_link: 0
              path: ''
              absolute: 0
              replace_spaces: 0
              external: 0
              path_case: none
              link_class: ''
              alt: ''
              rel: ''
              prefix: ''
              suffix: ''
              target: ''
              trim: 0
              max_length: '0'
              word_boundary: 1
              ellipsis: 1
              more_link: 0
              more_link_text: ''
              more_link_path: ''
              html: 0
              strip_tags: 0
              preserve_tags: ''
              trim_whitespace: 0
              nl2br: 0
            empty: ''
            empty_zero: 0
            hide_empty: 0
            hide_alter_empty: 1
            group_rows: 1
            multi_type: separator
            separator: ', '
            delta_limit: '0'
            delta_offset: '0'
            delta_reversed: 0
            delta_first_last: 0
            click_sort_column: value
            type: edtf_default
            field_api_classes: 0
          group_column: value
          group_columns: {  }
          group_rows: true
          delta_limit: 0
          delta_offset: 0
          delta_reversed: false
          delta_first_last: false
          multi_type: separator
          separator: ', '
          field_api_classes: false
        field_description:
          id: field_description
          table: node__field_description
          field: field_description
          relationship: field_media_of
          group_type: group
          admin_label: ''
          plugin_id: field
          label: Description
          exclude: false
          alter:
            alter_text: false
            text: ''
            make_link: false
            path: ''
            absolute: false
            external: false
            replace_spaces: false
            path_case: none
            trim_whitespace: false
            alt: ''
            rel: ''
            link_class: ''
            prefix: ''
            suffix: ''
            target: ''
            nl2br: false
            max_length: 0
            word_boundary: true
            ellipsis: true
            more_link: false
            more_link_text: ''
            more_link_path: ''
            strip_tags: false
            trim: false
            preserve_tags: ''
            html: false
          element_type: ''
          element_class: ''
          element_label_type: ''
          element_label_class: ''
          element_label_colon: false
          element_wrapper_type: ''
          element_wrapper_class: ''
          element_default_classes: true
          empty: ''
          hide_empty: false
          empty_zero: false
          hide_alter_empty: true
          click_sort_column: value
          type: basic_string
          settings: {  }
          group_column: value
          group_columns: {  }
          group_rows: true
          delta_limit: 0
          delta_offset: 0
          delta_reversed: false
          delta_first_last: false
          multi_type: separator
          separator: ', '
          field_api_classes: false
        field_identifier:
          id: field_identifier
          table: node__field_identifier
          field: field_identifier
          relationship: field_media_of
          group_type: group
          admin_label: Identifier
          plugin_id: field
          label: ''
          exclude: false
          alter:
            alter_text: false
            text: ''
            make_link: false
            path: ''
            absolute: false
            external: false
            replace_spaces: false
            path_case: none
            trim_whitespace: false
            alt: ''
            rel: ''
            link_class: ''
            prefix: ''
            suffix: ''
            target: ''
            nl2br: false
            max_length: 0
            word_boundary: true
            ellipsis: true
            more_link: false
            more_link_text: ''
            more_link_path: ''
            strip_tags: false
            trim: false
            preserve_tags: ''
            html: false
          element_type: ''
          element_class: ''
          element_label_type: ''
          element_label_class: ''
          element_label_colon: false
          element_wrapper_type: ''
          element_wrapper_class: ''
          element_default_classes: true
          empty: ''
          hide_empty: false
          empty_zero: false
          hide_alter_empty: true
          click_sort_column: value
          type: string
          settings:
            link_to_entity: false
          group_column: value
          group_columns: {  }
          group_rows: true
          delta_limit: 0
          delta_offset: 0
          delta_reversed: false
          delta_first_last: false
          multi_type: separator
          separator: ', '
          field_api_classes: false
      pager:
        type: mini
        options:
          offset: 0
          pagination_heading_level: h4
          items_per_page: 10
          total_pages: null
          id: 0
          tags:
            next: ››
            previous: ‹‹
          expose:
            items_per_page: false
            items_per_page_label: 'Items per page'
            items_per_page_options: '5, 10, 25, 50'
            items_per_page_options_all: false
            items_per_page_options_all_label: '- All -'
            offset: false
            offset_label: Offset
      exposed_form:
        type: basic
        options:
          submit_button: Apply
          reset_button: false
          reset_button_label: Reset
          exposed_sorts_label: 'Sort by'
          expose_sort_order: true
          sort_asc_label: Asc
          sort_desc_label: Desc
      access:
        type: perm
        options:
          perm: 'view media'
      cache:
        type: tag
        options: {  }
      empty: {  }
      sorts:
        field_weight_value:
          id: field_weight_value
          table: node__field_weight
          field: field_weight_value
          relationship: field_media_of
          group_type: group
          admin_label: ''
          plugin_id: standard
          order: ASC
          expose:
            label: ''
            field_identifier: field_weight_value
          exposed: false
        created:
          id: created
          table: node_field_data
          field: created
          relationship: field_media_of
          group_type: group
          admin_label: ''
          entity_type: node
          entity_field: created
          plugin_id: date
          order: ASC
          expose:
            label: ''
            field_identifier: ''
          exposed: false
          granularity: second
      arguments:
        field_member_of_target_id:
          id: field_member_of_target_id
          table: node__field_member_of
          field: field_member_of_target_id
          relationship: field_media_of
          group_type: group
          admin_label: ''
          plugin_id: entity_target_id
          default_action: default
          exception:
            value: all
            title_enable: false
            title: All
          title_enable: false
          title: ''
          default_argument_type: node
          default_argument_options: {  }
          summary_options:
            base_path: ''
            count: true
            override: false
            items_per_page: 25
          summary:
            sort_order: asc
            number_of_records: 0
            format: default_summary
          specify_validation: true
          validate:
            type: 'entity:node'
            fail: 'not found'
          validate_options:
            bundles: {  }
            access: true
            operation: view
            multiple: 0
          break_phrase: false
          not: false
          target_entity_type_id: node
      filters:
        status:
          id: status
          table: media_field_data
          field: status
          entity_type: media
          entity_field: status
          plugin_id: boolean
          value: '1'
          group: 1
          expose:
            operator: ''
            operator_limit_selection: false
            operator_list: {  }
        field_external_uri_uri:
          id: field_external_uri_uri
          table: taxonomy_term__field_external_uri
          field: field_external_uri_uri
          relationship: field_media_use
          group_type: group
          admin_label: ''
          plugin_id: string
          operator: '='
          value: 'http://pcdm.org/use#OriginalFile'
          group: 1
          exposed: false
          expose:
            operator_id: ''
            label: ''
            description: ''
            use_operator: false
            operator: ''
            operator_limit_selection: false
            operator_list: {  }
            identifier: ''
            required: false
            remember: false
            multiple: false
            remember_roles:
              authenticated: authenticated
            placeholder: ''
          is_grouped: false
          group_info:
            label: ''
            description: ''
            identifier: ''
            optional: true
            widget: select
            multiple: false
            remember: false
            default_group: All
            default_group_multiple: {  }
            group_items: {  }
      filter_groups:
        operator: AND
        groups:
          1: AND
      style:
        type: serializer
      row:
        type: fields
        options:
          default_field_elements: true
          inline: {  }
          separator: ''
          hide_empty: false
      query:
        type: views_query
        options:
          query_comment: ''
          disable_sql_rewrite: false
          distinct: false
          replica: false
          query_tags: {  }
      relationships:
        field_media_of:
          id: field_media_of
          table: media__field_media_of
          field: field_media_of
          relationship: none
          group_type: group
          admin_label: 'field_media_of: Content'
          plugin_id: standard
          required: true
        field_media_use:
          id: field_media_use
          table: media__field_media_use
          field: field_media_use
          relationship: none
          group_type: group
          admin_label: 'field_media_use: Taxonomy term'
          plugin_id: standard
          required: false
      header: {  }
      footer: {  }
      display_extenders: {  }
    cache_metadata:
      max-age: -1
      contexts:
        - 'languages:language_content'
        - 'languages:language_interface'
        - request_format
        - url
        - url.query_args
        - user.permissions
      tags:
        - 'config:field.storage.media.field_media_file'
        - 'config:field.storage.media.field_media_image'
        - 'config:field.storage.node.field_description'
        - 'config:field.storage.node.field_edtf_date'
        - 'config:field.storage.node.field_edtf_date_created'
        - 'config:field.storage.node.field_identifier'
        - 'config:field.storage.node.field_linked_agent'
  rest_export_1:
    id: rest_export_1
    display_title: 'REST export'
    display_plugin: rest_export
    position: 1
    display_options:
      pager:
        type: none
        options:
          offset: 0
      filters:
        status:
          id: status
          table: media_field_data
          field: status
          entity_type: media
          entity_field: status
          plugin_id: boolean
          value: '1'
          group: 1
          expose:
            operator: ''
            operator_limit_selection: false
            operator_list: {  }
        field_external_uri_uri:
          id: field_external_uri_uri
          table: taxonomy_term__field_external_uri
          field: field_external_uri_uri
          relationship: field_media_use
          group_type: group
          admin_label: ''
          plugin_id: string
          operator: '='
          value: 'http://pcdm.org/use#ServiceFile'
          group: 1
          exposed: false
          expose:
            operator_id: ''
            label: ''
            description: ''
            use_operator: false
            operator: ''
            operator_limit_selection: false
            operator_list: {  }
            identifier: ''
            required: false
            remember: false
            multiple: false
            remember_roles:
              authenticated: authenticated
            placeholder: ''
          is_grouped: false
          group_info:
            label: ''
            description: ''
            identifier: ''
            optional: true
            widget: select
            multiple: false
            remember: false
            default_group: All
            default_group_multiple: {  }
            group_items: {  }
      filter_groups:
        operator: AND
        groups:
          1: AND
      style:
        type: iiif_manifest
        options:
          iiif_tile_field:
            field_media_file: field_media_file
            field_media_image: field_media_image
          search_endpoint: ''
          canvas_label: title
          metadata_fields:
            title: title
            field_linked_agent: field_linked_agent
            field_edtf_date: field_edtf_date
            field_edtf_date_created: field_edtf_date_created
            field_description: field_description
            field_identifier: field_identifier
          advanced:
            custom_width_height:
              height_field: ''
              width_field: ''
            iiif_ocr_file_field:
              field_media_file: 0
              field_media_image: 0
          structured_text_term: null
      row:
        type: data_field
        options:
          field_options:
            name:
              alias: ''
              raw_output: false
      defaults:
        filters: false
        filter_groups: false
      display_extenders: {  }
      path: node/%node/book-manifest
    cache_metadata:
      max-age: -1
      contexts:
        - 'languages:language_content'
        - 'languages:language_interface'
        - url
        - user.permissions
      tags:
        - 'config:field.storage.media.field_media_file'
        - 'config:field.storage.media.field_media_image'
        - 'config:field.storage.node.field_description'
        - 'config:field.storage.node.field_edtf_date'
        - 'config:field.storage.node.field_edtf_date_created'
        - 'config:field.storage.node.field_identifier'
        - 'config:field.storage.node.field_linked_agent'
  rest_export_2:
    id: rest_export_2
    display_title: 'REST export - single node'
    display_plugin: rest_export
    position: 1
    display_options:
      pager:
        type: none
        options:
          offset: 0
      arguments:
        field_media_of_target_id:
          id: field_media_of_target_id
          table: media__field_media_of
          field: field_media_of_target_id
          relationship: none
          group_type: group
          admin_label: ''
          plugin_id: entity_target_id
          default_action: default
          exception:
            value: all
            title_enable: false
            title: All
          title_enable: false
          title: ''
          default_argument_type: node
          default_argument_options: {  }
          summary_options:
            base_path: ''
            count: true
            override: false
            items_per_page: 25
          summary:
            sort_order: asc
            number_of_records: 0
            format: default_summary
          specify_validation: false
          validate:
            type: none
            fail: 'not found'
          validate_options: {  }
          break_phrase: false
          not: false
          target_entity_type_id: node
      filters:
        status:
          id: status
          table: media_field_data
          field: status
          entity_type: media
          entity_field: status
          plugin_id: boolean
          value: '1'
          group: 1
          expose:
            operator: ''
            operator_limit_selection: false
            operator_list: {  }
        field_external_uri_uri:
          id: field_external_uri_uri
          table: taxonomy_term__field_external_uri
          field: field_external_uri_uri
          relationship: field_media_use
          group_type: group
          admin_label: ''
          plugin_id: string
          operator: '='
          value: 'http://pcdm.org/use#ServiceFile'
          group: 1
          exposed: false
          expose:
            operator_id: ''
            label: ''
            description: ''
            use_operator: false
            operator: ''
            operator_limit_selection: false
            operator_list: {  }
            identifier: ''
            required: false
            remember: false
            multiple: false
            remember_roles:
              authenticated: authenticated
            placeholder: ''
          is_grouped: false
          group_info:
            label: ''
            description: ''
            identifier: ''
            optional: true
            widget: select
            multiple: false
            remember: false
            default_group: All
            default_group_multiple: {  }
            group_items: {  }
      filter_groups:
        operator: AND
        groups:
          1: AND
      style:
        type: iiif_manifest
        options:
          iiif_tile_field:
            field_media_file: field_media_file
            field_media_image: field_media_image
      row:
        type: data_field
        options:
          field_options:
            name:
              alias: ''
              raw_output: false
      defaults:
        relationships: false
        arguments: false
        filters: false
        filter_groups: false
      relationships:
        field_media_of:
          id: field_media_of
          table: media__field_media_of
          field: field_media_of
          relationship: none
          group_type: group
          admin_label: 'field_media_of: Content'
          plugin_id: standard
          required: true
        field_media_use:
          id: field_media_use
          table: media__field_media_use
          field: field_media_use
          relationship: none
          group_type: group
          admin_label: 'field_media_use: Taxonomy term'
          plugin_id: standard
          required: false
      display_description: ''
      display_extenders: {  }
      path: node/%node/manifest
    cache_metadata:
      max-age: -1
      contexts:
        - 'languages:language_content'
        - 'languages:language_interface'
        - url
        - user.permissions
      tags:
        - 'config:field.storage.media.field_media_file'
        - 'config:field.storage.media.field_media_image'
        - 'config:field.storage.node.field_description'
        - 'config:field.storage.node.field_edtf_date'
        - 'config:field.storage.node.field_edtf_date_created'
        - 'config:field.storage.node.field_identifier'
        - 'config:field.storage.node.field_linked_agent'
  rest_export_3:
    id: rest_export_3
    display_title: 'Book Manifest (Original File)'
    display_plugin: rest_export
    position: 3
    display_options:
      pager:
        type: none
        options:
          offset: 0
      style:
        type: iiif_manifest
        options:
          iiif_tile_field:
            field_media_file: field_media_file
            field_media_image: field_media_image
          search_endpoint: ''
          canvas_label: title
          advanced:
            custom_width_height:
              height_field: ''
              width_field: ''
            iiif_ocr_file_field:
              field_media_file: 0
              field_media_image: 0
      row:
        type: data_field
        options:
          field_options:
            field_media_file:
              alias: ''
              raw_output: false
            field_media_image:
              alias: ''
              raw_output: false
      display_description: ''
      display_extenders: {  }
      path: node/%node/book-manifest-original
    cache_metadata:
      max-age: -1
      contexts:
        - 'languages:language_content'
        - 'languages:language_interface'
        - url
        - user.permissions
      tags:
        - 'config:field.storage.media.field_media_file'
        - 'config:field.storage.media.field_media_image'
        - 'config:field.storage.node.field_description'
        - 'config:field.storage.node.field_edtf_date'
        - 'config:field.storage.node.field_edtf_date_created'
        - 'config:field.storage.node.field_identifier'
        - 'config:field.storage.node.field_linked_agent'

```
</details>

# Interested parties
@Islandora/committers, esp @alxp and @joecorall 
