### PR TITLE
fix broken rdf namespaces for new sites

### DIFF
--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         php-versions: ["8.1", "8.2", "8.3"]
         test-suite: ["kernel", "functional", "functional-javascript"]
-        drupal-version: ["10.2.x", "10.3.x", "10.4.x-dev"]
+        drupal-version: ["10.2.x", "10.3.x", "10.4.x"]
         mysql: ["8.0"]
         allowed_failure: [false]
 

--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         php-versions: ["8.1", "8.2", "8.3"]
         test-suite: ["kernel", "functional", "functional-javascript"]
-        drupal-version: ["10.2.x", "10.3.x", "10.4.x", "10.5.x"]
+        drupal-version: ["10.2.x", "10.3.x", "10.4.x"]
         mysql: ["8.0"]
         allowed_failure: [false]
 

--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         php-versions: ["8.1", "8.2", "8.3"]
         test-suite: ["kernel", "functional", "functional-javascript"]
-        drupal-version: ["10.2.x", "10.3.x", "10.4.x"]
+        drupal-version: ["10.2.x", "10.3.x", "10.4.x", "10.5.x"]
         mysql: ["8.0"]
         allowed_failure: [false]
 

--- a/islandora.install
+++ b/islandora.install
@@ -170,9 +170,11 @@ function update_jsonld_included_namespaces() {
   ];
 
   $config = \Drupal::configFactory()->getEditable('jsonld.settings');
-  if ($config && empty($config->get('rdf_namespaces'))) {
-    $config->set('rdf_namespaces', $namespaces);
-    $config->save(TRUE);
+  if ($config) {
+    if (empty($config->get('rdf_namespaces'))) {
+      $config->set('rdf_namespaces', $namespaces);
+      $config->save(TRUE);
+    }
   }
   else {
     \Drupal::logger('islandora')
@@ -236,4 +238,11 @@ function islandora_update_9001(&$sandbox) {
   $config_path = \Drupal::service('extension.list.module')->getPath('islandora') . '/config/install/' . $config_id . '.yml';
   $data = Yaml::parseFile($config_path);
   \Drupal::configFactory()->getEditable($config_id)->setData($data)->save(TRUE);
+}
+
+/**
+ * Add namespaces for sites installed in early 2025.
+ */
+function islandora_update_9002() {
+  update_jsonld_included_namespaces();
 }

--- a/islandora.install
+++ b/islandora.install
@@ -170,7 +170,7 @@ function update_jsonld_included_namespaces() {
   ];
 
   $config = \Drupal::configFactory()->getEditable('jsonld.settings');
-  if ($config && !is_array($config->get('rdf_namespaces'))) {
+  if ($config && empty($config->get('rdf_namespaces'))) {
     $config->set('rdf_namespaces', $namespaces);
     $config->save(TRUE);
   }


### PR DESCRIPTION
With https://github.com/Islandora/jsonld/pull/85 jsonld namespace settings are now defaulted to `[]` instead of `NULL`

Our install logic wasn't checking for this properly, causing our rdf namespaces never to be set, and subsequently a test to fail (yay tests found this!).

Added a second `hook_update_N` to fix any sites that have been installed since that jsonld PR merged to ensure they have the proper rdf namespaces if they haven't been set manually
