### PR TITLE
Fix ltrim bug in IslandoraUtils:: getReferencingMedia

### DIFF
--- a/src/IslandoraUtils.php
+++ b/src/IslandoraUtils.php
@@ -231,7 +231,7 @@ class IslandoraUtils {
     $conditions = array_map(
       function ($field) {
         if (str_starts_with($field, 'media.')) {
-          $field = substr($field, strlen('media.'));
+          $field = substr($field, 6);
         }
         return $field . '.target_id';
       },

--- a/src/IslandoraUtils.php
+++ b/src/IslandoraUtils.php
@@ -230,7 +230,10 @@ class IslandoraUtils {
     // Process field names, stripping off 'media.' and appending 'target_id'.
     $conditions = array_map(
       function ($field) {
-        return ltrim($field, 'media.') . '.target_id';
+        if (str_starts_with($field, 'media.')) {
+          $field = substr($field, strlen('media.'));
+        }
+        return $field . '.target_id';
       },
       $fields
     );


### PR DESCRIPTION
**GitHub Issue**: ([link](https://github.com/Islandora/islandora/issues/1074))

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What does this Pull Request do?
Trims referencing fields.

# What's new?
The getReferencingMedia function retrieves fields, strips `media.` from the start of the file, and appends `target_id` to the end using ltrim.
ltrim treats the second argument as an array of individual characters, meaning (in my use case) `media.ableplayer_caption` becomes `bleplayer_caption`. Drupal throws an error because that field name does not exist.

The code change explicitly removes the string `media.` when it occurs at the start of the field name.

# How should this be tested?
Install and enable Ableplayer.  This can be intrusive as it will add new media types to your installation and add fields to the Audio and Video media types.

Either add or edit a Video media, and add an Ableplayer media caption media to the library.  Any VTT file will do.

<img width="759" alt="image" src="https://github.com/user-attachments/assets/900c02f5-4ff2-41eb-98d4-7287c01b5966" />

The new media should be added to the library, and there should be no errors in the logs.

# Documentation Status

No documentation changes are needed.

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
@Islandora/committers
