### PR TITLE
Drupal 11 compatibility

### DIFF
--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -119,7 +119,7 @@ jobs:
       - name: PHPUNIT tests
         run: |
           cd $DRUPAL_DIR/web/core
-          $DRUPAL_DIR/vendor/bin/phpunit --verbose --testsuite "${{ matrix.test-suite }}"
+          $DRUPAL_DIR/vendor/bin/phpunit --testsuite "${{ matrix.test-suite }}"
 
       - name: Print chromedriver logs
         if: matrix.test-suite == 'functional-javascript'

--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -22,9 +22,14 @@ jobs:
       matrix:
         php-versions: ["8.1", "8.2", "8.3"]
         test-suite: ["kernel", "functional", "functional-javascript"]
-        drupal-version: ["10.2.x", "10.3.x", "10.4.x-dev"]
+        drupal-version: ["10.2.x", "10.3.x", "10.4.x-dev", "11.0.x"]
         mysql: ["8.0"]
         allowed_failure: [false]
+        exclude:
+          - drupal-version: "11.0.x"
+            php-versions: "8.1"
+          - drupal-version: "11.0.x"
+            php-versions: "8.2"
 
     name: PHP ${{ matrix.php-versions }} | drupal ${{ matrix.drupal-version }} | mysql ${{ matrix.mysql }} | test-suite ${{ matrix.test-suite }}
 

--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         php-versions: ["8.1", "8.2", "8.3"]
         test-suite: ["kernel", "functional", "functional-javascript"]
-        drupal-version: ["10.2.x", "10.3.x", "10.4.x", "11.0.x"]
+        drupal-version: ["10.3.x", "10.4.x", "11.0.x"]
         mysql: ["8.0"]
         allowed_failure: [false]
         exclude:

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ You can set the following configuration at `admin/config/islandora/core`:
 
 ## Documentation
 
-Further documentation for this module is available on the [Islandora 8 documentation site](https://islandora.github.io/documentation/).
+Further documentation for this module is available on the [Islandora documentation site](https://islandora.github.io/documentation/).
 
 ## Troubleshooting/Issues
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ Installing via composer will download all required libraries and modules.  Howev
 - [search_api](http://drupal.org/project/search_api)
 - [jsonld](http://drupal.org/project/jsonld)
 - [jwt](http://drupal.org/project/jwt)
+  - In preparation for Drupal 11 compatibility, the version constraint of
+    `drupal/jwt` in this module's composer requirements has been expanded to
+    include `^3` which could install `drupal/jwt:dev-3.x` as a dependency until
+    a proper release is minted. There is a drupal.org issue to check for updates and
+    context on this:
+    [Drupal 11 - 3.x releaseplan](https://www.drupal.org/project/jwt/issues/3504600)
 - [filehash](http://drupal.org/project/filehash)
 - [prepopulate](http://drupal.org/project/prepopulate)
 - [eva](http://drupal.org/project/eva)

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "drupal/filehash": "^2 || ^3",
     "drupal/flysystem" : "^2.0@alpha",
     "drupal/jsonld": "^2 || ^3",
-    "drupal/jwt": "^1.1 || ^2",
+    "drupal/jwt": "^2.2 || ^3",
     "drupal/migrate_plus" : "^5.1 || ^6",
     "drupal/migrate_source_csv" : "^3.4",
     "drupal/prepopulate" : "^2.2",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     }
   ],
   "require": {
-    "drupal/action": "^0.1 || ^0.2",
+    "drupal/action": "^0.2",
     "drupal/context": "^4 || ^5@RC",
     "drupal/ctools": "^3.8 || ^4",
     "drupal/eva" : "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     }
   ],
   "require": {
-    "drupal/action": "^0.2",
+    "drupal/action": "^0.1 || ^0.2",
     "drupal/context": "^4 || ^5@RC",
     "drupal/ctools": "^3.8 || ^4",
     "drupal/eva" : "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     }
   ],
   "require": {
+    "drupal/action": "^0.2",
     "drupal/context": "^4 || ^5@RC",
     "drupal/ctools": "^3.8 || ^4",
     "drupal/eva" : "^3.0",

--- a/islandora.info.yml
+++ b/islandora.info.yml
@@ -4,7 +4,7 @@ name: 'islandora'
 description: "Islandora Core"
 type: module
 package: Islandora
-core_version_requirement: ^10.2
+core_version_requirement: ^10.2 || ^11
 dependencies:
   - context:context_ui
   - ctools:ctools

--- a/islandora.info.yml
+++ b/islandora.info.yml
@@ -4,7 +4,7 @@ name: 'islandora'
 description: "Islandora Core"
 type: module
 package: Islandora
-core_version_requirement: ^10.2 || ^11
+core_version_requirement: ^10.3 || ^11
 dependencies:
   - action:action
   - context:context_ui

--- a/islandora.info.yml
+++ b/islandora.info.yml
@@ -6,9 +6,9 @@ type: module
 package: Islandora
 core_version_requirement: ^10.2 || ^11
 dependencies:
+  - action:action
   - context:context_ui
   - ctools:ctools
-  - drupal:action
   - drupal:basic_auth
   - drupal:block
   - drupal:content_translation

--- a/islandora.services.yml
+++ b/islandora.services.yml
@@ -51,7 +51,7 @@ services:
       - { name: 'context_provider' }
   islandora.media_source_service:
     class: Drupal\islandora\MediaSource\MediaSourceService
-    arguments: ['@entity_type.manager', '@current_user', '@language_manager', '@file_system', '@islandora.utils']
+    arguments: ['@entity_type.manager', '@current_user', '@language_manager', '@file_system', '@islandora.utils', '@file.validator']
   islandora.utils:
     class: Drupal\islandora\IslandoraUtils
     arguments: ['@entity_type.manager', '@entity_field.manager', '@context.manager', '@flysystem_factory', '@language_manager', '@current_user', '@config.factory']

--- a/modules/islandora_advanced_search/README.md
+++ b/modules/islandora_advanced_search/README.md
@@ -218,7 +218,7 @@ checkbox.
 ## Documentation
 
 Further documentation for this module is available on the
-[Islandora 8 documentation site](https://islandora.github.io/documentation/).
+[Islandora documentation site](https://islandora.github.io/documentation/).
 
 ## Troubleshooting/Issues
 

--- a/modules/islandora_advanced_search/islandora_advanced_search.info.yml
+++ b/modules/islandora_advanced_search/islandora_advanced_search.info.yml
@@ -4,7 +4,7 @@ name: 'Islandora Advanced Search'
 description: "Creates an Advanced Search block and other enhancements to search."
 type: module
 package: Islandora
-core_version_requirement: ^9 || ^10 || ^11
+core_version_requirement: ^10.3 || ^11
 dependencies:
   - drupal:facets
   - drupal:facets_summary

--- a/modules/islandora_advanced_search/islandora_advanced_search.info.yml
+++ b/modules/islandora_advanced_search/islandora_advanced_search.info.yml
@@ -4,7 +4,7 @@ name: 'Islandora Advanced Search'
 description: "Creates an Advanced Search block and other enhancements to search."
 type: module
 package: Islandora
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^9 || ^10 || ^11
 dependencies:
   - drupal:facets
   - drupal:facets_summary

--- a/modules/islandora_audio/README.md
+++ b/modules/islandora_audio/README.md
@@ -30,7 +30,7 @@ $ drush en islandora_audio
 
 ## Documentation
 
-Official documentation is available on the [Islandora 8 documentation site](https://islandora.github.io/documentation/).
+Official documentation is available on the [Islandora documentation site](https://islandora.github.io/documentation/).
 
 ## Development
 

--- a/modules/islandora_audio/islandora_audio.info.yml
+++ b/modules/islandora_audio/islandora_audio.info.yml
@@ -2,6 +2,6 @@ name: 'Islandora Audio'
 description: 'Islandora audio derivative actions'
 type: module
 package: Islandora
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^9 || ^10 || ^11
 dependencies:
   - drupal:islandora

--- a/modules/islandora_audio/islandora_audio.info.yml
+++ b/modules/islandora_audio/islandora_audio.info.yml
@@ -2,6 +2,6 @@ name: 'Islandora Audio'
 description: 'Islandora audio derivative actions'
 type: module
 package: Islandora
-core_version_requirement: ^9 || ^10 || ^11
+core_version_requirement: ^10.3 || ^11
 dependencies:
   - drupal:islandora

--- a/modules/islandora_breadcrumbs/README.md
+++ b/modules/islandora_breadcrumbs/README.md
@@ -27,7 +27,7 @@ $ drush en islandora_breadcrumbs
 
 ## Documentation
 
-Official documentation is available on the [Islandora 8 documentation site](https://islandora.github.io/documentation/).
+Official documentation is available on the [Islandora documentation site](https://islandora.github.io/documentation/).
 
 ## Development
 

--- a/modules/islandora_breadcrumbs/islandora_breadcrumbs.info.yml
+++ b/modules/islandora_breadcrumbs/islandora_breadcrumbs.info.yml
@@ -1,7 +1,7 @@
 name: 'Islandora Breadcrumbs'
 type: module
 description: 'Builds breadcrumbs based on field_member_of relationships.'
-core_version_requirement: ^9 || ^10 || ^11
+core_version_requirement: ^10.3 || ^11
 package: Islandora
 dependencies:
   - islandora:islandora

--- a/modules/islandora_breadcrumbs/islandora_breadcrumbs.info.yml
+++ b/modules/islandora_breadcrumbs/islandora_breadcrumbs.info.yml
@@ -1,7 +1,7 @@
 name: 'Islandora Breadcrumbs'
 type: module
 description: 'Builds breadcrumbs based on field_member_of relationships.'
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^9 || ^10 || ^11
 package: Islandora
 dependencies:
   - islandora:islandora

--- a/modules/islandora_core_feature/README.md
+++ b/modules/islandora_core_feature/README.md
@@ -26,7 +26,7 @@ $ drush mim islandora_tags
 
 ## Documentation
 
-Official documentation is available on the [Islandora 8 documentation site](https://islandora.github.io/documentation/).
+Official documentation is available on the [Islandora documentation site](https://islandora.github.io/documentation/).
 
 ## Development
 

--- a/modules/islandora_core_feature/config/optional/views.view.display_media.yml
+++ b/modules/islandora_core_feature/config/optional/views.view.display_media.yml
@@ -159,7 +159,6 @@ display:
           title: ''
           default_argument_type: node
           default_argument_options: {  }
-          default_argument_skip_url: false
           summary_options:
             base_path: ''
             count: true

--- a/modules/islandora_core_feature/config/optional/views.view.file_checksum.yml
+++ b/modules/islandora_core_feature/config/optional/views.view.file_checksum.yml
@@ -211,7 +211,6 @@ display:
           default_argument_type: fixed
           default_argument_options:
             argument: ''
-          default_argument_skip_url: false
           summary_options:
             base_path: ''
             count: true

--- a/modules/islandora_core_feature/config/optional/views.view.manage_members.yml
+++ b/modules/islandora_core_feature/config/optional/views.view.manage_members.yml
@@ -247,7 +247,6 @@ display:
           title: ''
           default_argument_type: node
           default_argument_options: {  }
-          default_argument_skip_url: false
           summary_options:
             base_path: ''
             count: true

--- a/modules/islandora_core_feature/config/optional/views.view.media_of.yml
+++ b/modules/islandora_core_feature/config/optional/views.view.media_of.yml
@@ -442,7 +442,6 @@ display:
           title: ''
           default_argument_type: node
           default_argument_options: {  }
-          default_argument_skip_url: false
           summary_options:
             base_path: ''
             count: true

--- a/modules/islandora_core_feature/config/optional/views.view.reorder_children.yml
+++ b/modules/islandora_core_feature/config/optional/views.view.reorder_children.yml
@@ -206,7 +206,6 @@ display:
           title: ''
           default_argument_type: node
           default_argument_options: {  }
-          default_argument_skip_url: false
           summary_options:
             base_path: ''
             count: true

--- a/modules/islandora_core_feature/islandora_core_feature.info.yml
+++ b/modules/islandora_core_feature/islandora_core_feature.info.yml
@@ -1,7 +1,7 @@
 name: 'Islandora Core Feature'
 description: 'Minimum configuration required for Islandora.'
 type: module
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^9 || ^10 || ^11
 dependencies:
   - drupal:basic_auth
   - drupal:content_translation

--- a/modules/islandora_iiif/islandora_iiif.info.yml
+++ b/modules/islandora_iiif/islandora_iiif.info.yml
@@ -1,7 +1,7 @@
 name: 'Islandora IIIF'
 type: module
 description: 'IIIF support for Islandora'
-core_version_requirement: ^9 || ^10 || ^11
+core_version_requirement: ^10.3 || ^11
 package: Islandora
 dependencies:
   - drupal:islandora

--- a/modules/islandora_iiif/islandora_iiif.info.yml
+++ b/modules/islandora_iiif/islandora_iiif.info.yml
@@ -1,7 +1,7 @@
 name: 'Islandora IIIF'
 type: module
 description: 'IIIF support for Islandora'
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^9 || ^10 || ^11
 package: Islandora
 dependencies:
   - drupal:islandora

--- a/modules/islandora_image/README.md
+++ b/modules/islandora_image/README.md
@@ -30,7 +30,7 @@ $ drush en islandora_image
 
 ## Documentation
 
-Further documentation for this module is available on the [Islandora 8 documentation site](https://islandora.github.io/documentation/).
+Further documentation for this module is available on the [Islandora documentation site](https://islandora.github.io/documentation/).
 
 ## Troubleshooting/Issues
 

--- a/modules/islandora_image/islandora_image.info.yml
+++ b/modules/islandora_image/islandora_image.info.yml
@@ -1,7 +1,7 @@
 name: 'Islandora Image'
 type: module
 description: 'Islandora Image derivative actions'
-core_version_requirement: ^9 || ^10 || ^11
+core_version_requirement: ^10.3 || ^11
 package: Islandora
 dependencies:
   - drupal:islandora

--- a/modules/islandora_image/islandora_image.info.yml
+++ b/modules/islandora_image/islandora_image.info.yml
@@ -1,7 +1,7 @@
 name: 'Islandora Image'
 type: module
 description: 'Islandora Image derivative actions'
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^9 || ^10 || ^11
 package: Islandora
 dependencies:
   - drupal:islandora

--- a/modules/islandora_text_extraction/README.md
+++ b/modules/islandora_text_extraction/README.md
@@ -30,7 +30,7 @@ $ drush en islandora_text_extraction
 
 ## Documentation
 
-Official documentation is available on the [Islandora 8 documentation site](https://islandora.github.io/documentation/).
+Official documentation is available on the [Islandora documentation site](https://islandora.github.io/documentation/).
 
 ## Sponsors
 

--- a/modules/islandora_text_extraction/islandora_text_extraction.info.yml
+++ b/modules/islandora_text_extraction/islandora_text_extraction.info.yml
@@ -1,7 +1,7 @@
 name: 'Islandora Text Extraction'
 type: module
 description: 'Islandora 8 module to connect to Hypercube microservice, and to get text from PDF ingest'
-core_version_requirement: ^9 || ^10 || ^11
+core_version_requirement: ^10.3 || ^11
 package: 'Islandora'
 dependencies:
   - drupal:islandora

--- a/modules/islandora_text_extraction/islandora_text_extraction.info.yml
+++ b/modules/islandora_text_extraction/islandora_text_extraction.info.yml
@@ -1,7 +1,7 @@
 name: 'Islandora Text Extraction'
 type: module
 description: 'Islandora 8 module to connect to Hypercube microservice, and to get text from PDF ingest'
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^9 || ^10 || ^11
 package: 'Islandora'
 dependencies:
   - drupal:islandora

--- a/modules/islandora_text_extraction_defaults/README.md
+++ b/modules/islandora_text_extraction_defaults/README.md
@@ -27,7 +27,7 @@ $ drush en islandora_text_extraction
 
 ## Documentation
 
-Official documentation is available on the [Islandora 8 documentation site](https://islandora.github.io/documentation/).
+Official documentation is available on the [Islandora documentation site](https://islandora.github.io/documentation/).
 
 ## Development
 

--- a/modules/islandora_text_extraction_defaults/islandora_text_extraction_defaults.info.yml
+++ b/modules/islandora_text_extraction_defaults/islandora_text_extraction_defaults.info.yml
@@ -1,7 +1,7 @@
 name: 'Islandora Text Extraction Defaults'
 type: module
 description: 'Default config for the Islandora Text Extraction module.'
-core_version_requirement: ^9 || ^10  || ^11
+core_version_requirement: ^10.3  || ^11
 package: Islandora
 dependencies:
   - drupal:field

--- a/modules/islandora_text_extraction_defaults/islandora_text_extraction_defaults.info.yml
+++ b/modules/islandora_text_extraction_defaults/islandora_text_extraction_defaults.info.yml
@@ -1,7 +1,7 @@
 name: 'Islandora Text Extraction Defaults'
 type: module
 description: 'Default config for the Islandora Text Extraction module.'
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^9 || ^10  || ^11
 package: Islandora
 dependencies:
   - drupal:field

--- a/modules/islandora_video/README.md
+++ b/modules/islandora_video/README.md
@@ -30,7 +30,7 @@ $ drush en islandora_video
 
 ## Documentation
 
-Official documentation is available on the [Islandora 8 documentation site](https://islandora.github.io/documentation/).
+Official documentation is available on the [Islandora documentation site](https://islandora.github.io/documentation/).
 
 ## Development
 

--- a/modules/islandora_video/islandora_video.info.yml
+++ b/modules/islandora_video/islandora_video.info.yml
@@ -2,6 +2,6 @@ name: 'Islandora Video'
 description: 'Islandora video derivative actions'
 type: module
 package: Islandora
-core_version_requirement: ^9 || ^10 || ^11
+core_version_requirement: ^10.3 || ^11
 dependencies:
   - drupal:islandora

--- a/modules/islandora_video/islandora_video.info.yml
+++ b/modules/islandora_video/islandora_video.info.yml
@@ -2,6 +2,6 @@ name: 'Islandora Video'
 description: 'Islandora video derivative actions'
 type: module
 package: Islandora
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^9 || ^10 || ^11
 dependencies:
   - drupal:islandora

--- a/src/Controller/ManageMediaController.php
+++ b/src/Controller/ManageMediaController.php
@@ -35,7 +35,7 @@ class ManageMediaController extends ManageMembersController {
       ['query' => ["edit[$field][widget][0][target_id]" => $node->id()]]
     );
 
-    $manage_link = Url::fromRoute('entity.media_type.collection')->toRenderArray();
+    $manage_link['#url'] = Url::fromRoute('entity.media_type.collection');
     $manage_link['#title'] = $this->t('Manage media types');
     $manage_link['#type'] = 'link';
     $manage_link['#prefix'] = ' ';

--- a/src/Controller/ManageMembersController.php
+++ b/src/Controller/ManageMembersController.php
@@ -99,7 +99,7 @@ class ManageMembersController extends EntityController {
       ['query' => ["edit[$field][widget][0][target_id]" => $node->id()]]
     );
 
-    $manage_link = Url::fromRoute('entity.node_type.collection')->toRenderArray();
+    $manage_link['#url'] = Url::fromRoute('entity.node_type.collection');
     $manage_link['#title'] = $this->t('Manage content types');
     $manage_link['#type'] = 'link';
     $manage_link['#prefix'] = ' ';

--- a/src/EventSubscriber/JwtEventSubscriber.php
+++ b/src/EventSubscriber/JwtEventSubscriber.php
@@ -72,7 +72,7 @@ class JwtEventSubscriber implements EventSubscriberInterface {
   /**
    * {@inheritdoc}
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     $events[JwtAuthEvents::VALIDATE][] = ['validate'];
     $events[JwtAuthEvents::VALID][] = ['loadUser'];
     $events[JwtAuthEvents::GENERATE][] = ['setIslandoraClaims'];

--- a/src/EventSubscriber/JwtEventSubscriber.php
+++ b/src/EventSubscriber/JwtEventSubscriber.php
@@ -154,7 +154,7 @@ class JwtEventSubscriber implements EventSubscriberInterface {
     $token = $event->getToken();
     $uid = $token->getClaim('webid');
     $user = $this->userStorage->load($uid);
-    $event->setUser($user);
+    $event->setAccount($user);
   }
 
 }

--- a/src/EventSubscriber/LinkHeaderSubscriber.php
+++ b/src/EventSubscriber/LinkHeaderSubscriber.php
@@ -113,7 +113,7 @@ abstract class LinkHeaderSubscriber implements EventSubscriberInterface {
   /**
    * {@inheritdoc}
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     // Run this early so the headers get cached.
     $events[KernelEvents::RESPONSE][] = ['onResponse', 129];
 

--- a/src/EventSubscriber/StompHeaderEventSubscriber.php
+++ b/src/EventSubscriber/StompHeaderEventSubscriber.php
@@ -36,7 +36,7 @@ class StompHeaderEventSubscriber implements EventSubscriberInterface {
   /**
    * {@inheritdoc}
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       StompHeaderEventInterface::EVENT_NAME => ['baseHeaders', -100],
     ];

--- a/src/MediaSource/MediaSourceService.php
+++ b/src/MediaSource/MediaSourceService.php
@@ -78,7 +78,7 @@ class MediaSourceService {
    *   File system service.
    * @param \Drupal\islandora\IslandoraUtils $islandora_utils
    *   Utility service.
-   * @param \Drupal\file\Validation\FileValidatorInterface
+   * @param \Drupal\file\Validation\FileValidatorInterface $file_validator
    *   File Validator service.
    */
   public function __construct(

--- a/src/MediaSource/MediaSourceService.php
+++ b/src/MediaSource/MediaSourceService.php
@@ -282,9 +282,11 @@ class MediaSourceService {
       // Validate file extension.
       $source_field_config = $this->entityTypeManager->getStorage('field_config')->load("media.$bundle.$source_field");
       $valid_extensions = $source_field_config->getSetting('file_extensions');
-      $errors = file_validate_extensions($file, $valid_extensions);
+      $validators = ['FileExtension' => ['extensions' => $valid_extensions]];
+      $file_validator = \Drupal::service('file.validator');
+      $errors = $file_validator->validate($file, $validators);
 
-      if (!empty($errors)) {
+      if ($errors->count() > 0) {
         throw new BadRequestHttpException("Invalid file extension.  Valid types are $valid_extensions");
       }
 
@@ -364,9 +366,11 @@ class MediaSourceService {
       $bundle = $media->bundle();
       $destination_field_config = $this->entityTypeManager->getStorage('field_config')->load("media.$bundle.$destination_field");
       $valid_extensions = $destination_field_config->getSetting('file_extensions');
-      $errors = file_validate_extensions($file, $valid_extensions);
+      $validators = ['FileExtension' => ['extensions' => $valid_extensions]];
+      $file_validator = \Drupal::service('file.validator');
+      $errors = $file_validator->validate($file, $validators);
 
-      if (!empty($errors)) {
+      if ($errors->count() > 0) {
         throw new BadRequestHttpException("Invalid file extension.  Valid types are $valid_extensions");
       }
 

--- a/src/MediaSource/MediaSourceService.php
+++ b/src/MediaSource/MediaSourceService.php
@@ -8,6 +8,7 @@ use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\file\FileInterface;
+use Drupal\file\Validation\FileValidatorInterface;
 use Drupal\islandora\IslandoraUtils;
 use Drupal\media\MediaInterface;
 use Drupal\media\MediaTypeInterface;
@@ -58,6 +59,13 @@ class MediaSourceService {
   protected $islandoraUtils;
 
   /**
+   * File Validator service.
+   *
+   * @var \Drupal\file\Validation\FileValidatorInterface
+   */
+  protected $fileValidator;
+
+  /**
    * Constructor.
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
@@ -70,19 +78,23 @@ class MediaSourceService {
    *   File system service.
    * @param \Drupal\islandora\IslandoraUtils $islandora_utils
    *   Utility service.
+   * @param \Drupal\file\Validation\FileValidatorInterface
+   *   File Validator service.
    */
   public function __construct(
     EntityTypeManagerInterface $entity_type_manager,
     AccountInterface $account,
     LanguageManagerInterface $language_manager,
     FileSystemInterface $file_system,
-    IslandoraUtils $islandora_utils
+    IslandoraUtils $islandora_utils,
+    FileValidatorInterface $file_validator
   ) {
     $this->entityTypeManager = $entity_type_manager;
     $this->account = $account;
     $this->languageManager = $language_manager;
     $this->fileSystem = $file_system;
     $this->islandoraUtils = $islandora_utils;
+    $this->fileValidator = $file_validator;
   }
 
   /**
@@ -283,8 +295,7 @@ class MediaSourceService {
       $source_field_config = $this->entityTypeManager->getStorage('field_config')->load("media.$bundle.$source_field");
       $valid_extensions = $source_field_config->getSetting('file_extensions');
       $validators = ['FileExtension' => ['extensions' => $valid_extensions]];
-      $file_validator = \Drupal::service('file.validator');
-      $errors = $file_validator->validate($file, $validators);
+      $errors = $this->fileValidator->validate($file, $validators);
 
       if ($errors->count() > 0) {
         throw new BadRequestHttpException("Invalid file extension.  Valid types are $valid_extensions");
@@ -367,8 +378,7 @@ class MediaSourceService {
       $destination_field_config = $this->entityTypeManager->getStorage('field_config')->load("media.$bundle.$destination_field");
       $valid_extensions = $destination_field_config->getSetting('file_extensions');
       $validators = ['FileExtension' => ['extensions' => $valid_extensions]];
-      $file_validator = \Drupal::service('file.validator');
-      $errors = $file_validator->validate($file, $validators);
+      $errors = $this->fileValidator->validate($file, $validators);
 
       if ($errors->count() > 0) {
         throw new BadRequestHttpException("Invalid file extension.  Valid types are $valid_extensions");

--- a/tests/modules/integer_weight_test_views/integer_weight_test_views.info.yml
+++ b/tests/modules/integer_weight_test_views/integer_weight_test_views.info.yml
@@ -2,13 +2,8 @@ name: 'Integer weight test views'
 type: module
 description: 'Provides default views for integer weight views tests.'
 package: Testing
-core_version_requirement: ^8 || ^9 || ^10 || ^11
+core_version_requirement: ^10.3 || ^11
 dependencies:
   - drupal:node
   - drupal:views
   - drupal:language
-
-# Information added by Drupal.org packaging script on 2024-10-28
-version: '2.13.1'
-project: 'islandora'
-datestamp: 1730125691

--- a/tests/modules/integer_weight_test_views/integer_weight_test_views.info.yml
+++ b/tests/modules/integer_weight_test_views/integer_weight_test_views.info.yml
@@ -2,7 +2,7 @@ name: 'Integer weight test views'
 type: module
 description: 'Provides default views for integer weight views tests.'
 package: Testing
-core_version_requirement: ^8 || ^9 || ^10
+core_version_requirement: ^8 || ^9 || ^10 || ^11
 dependencies:
   - drupal:node
   - drupal:views

--- a/tests/modules/integer_weight_test_views/integer_weight_test_views.info.yml
+++ b/tests/modules/integer_weight_test_views/integer_weight_test_views.info.yml
@@ -7,3 +7,8 @@ dependencies:
   - drupal:node
   - drupal:views
   - drupal:language
+
+# Information added by Drupal.org packaging script on 2024-10-28
+version: '2.13.1'
+project: 'islandora'
+datestamp: 1730125691

--- a/tests/src/Kernel/JwtEventSubscriberTest.php
+++ b/tests/src/Kernel/JwtEventSubscriberTest.php
@@ -137,7 +137,7 @@ class JwtEventSubscriberTest extends IslandoraKernelTestBase {
     $validEvent = new JwtAuthValidEvent($jwt);
     $subscriber->loadUser($validEvent);
 
-    $this->assertEquals($this->user->id(), $validEvent->getUser()->id(), "Correct user must be loaded to valid event.");
+    $this->assertEquals($this->user->id(), $validEvent->getAccount()->id(), "Correct user must be loaded to valid event.");
   }
 
 }


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/2318 and https://github.com/Islandora/islandora/issues/1054

* Other Relevant Links:
  * Built from and replacing https://github.com/Islandora/islandora/pull/1063 which was closed (and replacing https://github.com/discoverygarden/islandora/pull/83)

# What does this Pull Request do?

* Adds Drupal 11 support and any changes necessary for Drupal 11 compatibility
  * Remove/replace use of deprecated functions:
    * toRenderArray() of class Drupal\Core\Url. Deprecated in drupal:10.1.0 and is removed from drupal:11.0.0. There is no replacement.
    * file_validate_extensions(). Deprecated in drupal:10.2.0 and is removed from drupal:11.0.0. Use the 'file.validator' service instead.
  * Support from all Views contextual filter settings for the default_argument_skip_url setting is removed from drupal:11.0.0. No replacement is provided. See [The Views setting default_argument_skip_url has been removed](https://www.drupal.org/node/3382316)
  * Listing the contrib `drupal/action` module as a dependency since it is removed from core drupal in drupal 11
    * The 'administer actions' permission was moved to drupal/system module in drupal 10.3, but expected to be in the action module in 10.2, so this played a part in choosing to update the core requirements to `^10.3 || ^11` in this PR.
  * Updating `drupal/jwt` module version constraint to include support for ^3 (and remove support for drupal/jwt prior to 2.2)
    * Swap some relevant function calls that were deprecated as of drupal/jwt:2.2 and removed from drupal/jwt:3
      * These changes are in this commit of this PR: https://github.com/Islandora/islandora/pull/1076/commits/9769be31b1ea3a2af37b29c595e9e88dab9a6c9f

# What's new?

* Addressing a variety of deprecations flagged by Drupal's upgrade_status module
* Adding declarations of Drupal 11 compatibility (and removing declarations of compatibility with versions prior to Drupal 10.3)
* Adjusting dependency version constraints as needed

# How should this be tested?

* Test on an existing 10.x site
  * Functional testing as well as running upgrade_status
* Check functionality on a new Drupal 11 site

# Documentation Status

Not adding any new features or changing functionality, just focussed on basic drupal 11 compatibility here, so I don't think there are any general documentation pieces that need to get involved?

# Additional Notes:

This started from https://github.com/Islandora/islandora/pull/1063, which got closed in favour of a draft PR that was building on that work (https://github.com/discoverygarden/islandora/pull/83), so this is an attempt to organize the work that @joecorall started alongside the work that I added in a general PR for D11 compatibility, and, once this is no longer a draft, any further community reviews/comments/contributions can be added to this work so we don't need any more replacements and redirecting to other PRs (I hope).

Just going to attach the text export of the upgrade_status report for this module that I ran on a local drupal 10.3 environment as of all changes up to and including [f680565](https://github.com/Islandora/islandora/pull/1076/commits/f680565a71e663c9744d27a004e1e882cec52d3f) from this PR: 
[upgrade-status-export-2025-04-11T12_36_08-0500.txt](https://github.com/user-attachments/files/19711996/upgrade-status-export-2025-04-11T12_36_08-0500.txt)

Noting some tripping points encountered in my attempts to get islandora installed and enabled in a local D11 env:

- flysystem:
  - needs this patch: https://www.drupal.org/files/issues/2021-07-20/flysystem-no-hook-install-3109940-6.patch
  - islandora has a requirement on drupal/flysystem ^2.3.0@alpha, and there’s an issue when it comes to enabling the module: [Requirements check fails on install when dependencies are present](https://www.drupal.org/project/flysystem/issues/3109940) 
  - the fix was merged into 2.3.x branch, and [it appears that the change was merged and tagged](https://git.drupalcode.org/project/flysystem/-/merge_requests/61/diffs), but then part of it was undone just as fast in the same versions: https://git.drupalcode.org/project/flysystem/-/commit/5a9ec32595e20aa0399fa7240b938ad2cde7a41f
- the dependency on codementality/flysystem-stream-wrapper needs to be restricted to 1.1.0, not just ^1.1
  - a class namespace changed between versions [1.1.0](https://github.com/codementality/flysystem-stream-wrapper/blob/v1.1.0/src/FlysystemStreamWrapper.php) and [1.1.1](https://github.com/codementality/flysystem-stream-wrapper/blob/v1.1.1/src/FlysystemStreamWrapper.php), and drupal/flysystem 2.3.0-alpha1 and 2.3.0-alpha2 both check for the class namespace that matches what’s in codementality/flysystem-stream-wrapper:1.1.0, so [the dependency check fails if flysystem-stream-wrapper 1.1.1 is the version in use](https://git.drupalcode.org/project/flysystem/-/blob/2.3.0-alpha2/flysystem.install?ref_type=tags#L61-76).


# Interested parties
@Islandora/committers
