### PR TITLE
Forward `Range` http header to fedora

### DIFF
--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -22,13 +22,17 @@ jobs:
       matrix:
         php-versions: ["8.1", "8.2", "8.3"]
         test-suite: ["kernel", "functional", "functional-javascript"]
-        drupal-version: ["10.3.x", "10.4.x", "11.0.x"]
+        drupal-version: ["10.3.x", "10.4.x", "11.0.x", "11.1.x"]
         mysql: ["8.0"]
         allowed_failure: [false]
         exclude:
           - drupal-version: "11.0.x"
             php-versions: "8.1"
           - drupal-version: "11.0.x"
+            php-versions: "8.2"
+          - drupal-version: "11.1.x"
+            php-versions: "8.1"
+          - drupal-version: "11.1.x"
             php-versions: "8.2"
 
     name: PHP ${{ matrix.php-versions }} | drupal ${{ matrix.drupal-version }} | mysql ${{ matrix.mysql }} | test-suite ${{ matrix.test-suite }}

--- a/src/Flysystem/Adapter/FedoraAdapter.php
+++ b/src/Flysystem/Adapter/FedoraAdapter.php
@@ -113,8 +113,9 @@ class FedoraAdapter implements AdapterInterface {
       $range = $this->request->headers->get('Range');
       if (str_starts_with($range, 'bytes=')) {
         // Since \Symfony\Component\HttpFoundation\BinaryFileResponse seeks
-        // to the $start of the range based on the request's Range header
-        // we need to always set start to 0 so fedora returns the
+        // to the start of the range based on the request's Range header
+        // we need to always set start to 0 so fedora returns
+        // all the bytes between zero and theb start of the range.
         [$start, $end] = explode('-', substr($range, 6), 2) + [1 => ""];
         $headers['Range'] = "bytes=0-$end";
       }

--- a/src/Flysystem/Adapter/FedoraAdapter.php
+++ b/src/Flysystem/Adapter/FedoraAdapter.php
@@ -12,6 +12,7 @@ use League\Flysystem\Config;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\StreamWrapper;
 use Symfony\Component\Mime\MimeTypeGuesserInterface;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Fedora adapter for Flysystem.
@@ -43,6 +44,13 @@ class FedoraAdapter implements AdapterInterface {
   protected $logger;
 
   /**
+   * The current request.
+   *
+   * @var \Symfony\Component\HttpFoundation\Request
+   */
+  protected $request;
+
+  /**
    * Constructs a Fedora adapter for Flysystem.
    *
    * @param \Islandora\Chullo\IFedoraApi $fedora
@@ -51,15 +59,19 @@ class FedoraAdapter implements AdapterInterface {
    *   Mimetype guesser.
    * @param \Drupal\Core\Logger\LoggerChannelInterface $logger
    *   The fedora adapter logger channel.
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   The current request.
    */
   public function __construct(
     IFedoraApi $fedora,
     MimeTypeGuesserInterface $mime_type_guesser,
-    LoggerChannelInterface $logger
+    LoggerChannelInterface $logger,
+    Request $request,
   ) {
     $this->fedora = $fedora;
     $this->mimeTypeGuesser = $mime_type_guesser;
     $this->logger = $logger;
+    $this->request = $request;
   }
 
   /**
@@ -93,9 +105,23 @@ class FedoraAdapter implements AdapterInterface {
    * {@inheritdoc}
    */
   public function readStream($path) {
-    $response = $this->fedora->getResource($path, ['Connection' => 'close']);
+    $headers = ['Connection' => 'close'];
 
-    if ($response->getStatusCode() != 200) {
+    // If the request is for a range
+    // pass that header to fedora.
+    if ($this->request && $this->request->headers->has('Range')) {
+      $range = $this->request->headers->get('Range');
+      if (str_starts_with($range, 'bytes=')) {
+        // Since \Symfony\Component\HttpFoundation\BinaryFileResponse seeks
+        // to the $start of the range based on the request's Range header
+        // we need to always set start to 0 so fedora returns the
+        [$start, $end] = explode('-', substr($range, 6), 2) + [1 => ""];
+        $headers['Range'] = "bytes=0-$end";
+      }
+    }
+
+    $response = $this->fedora->getResource($path, $headers);
+    if (!in_array($response->getStatusCode(), [200, 206], TRUE)) {
       return FALSE;
     }
 

--- a/src/Flysystem/Adapter/FedoraAdapter.php
+++ b/src/Flysystem/Adapter/FedoraAdapter.php
@@ -115,7 +115,7 @@ class FedoraAdapter implements AdapterInterface {
         // Since \Symfony\Component\HttpFoundation\BinaryFileResponse seeks
         // to the start of the range based on the request's Range header
         // we need to always set start to 0 so fedora returns
-        // all the bytes between zero and theb start of the range.
+        // all the bytes between zero and the start of the range.
         [$start, $end] = explode('-', substr($range, 6), 2) + [1 => ""];
         $headers['Range'] = "bytes=0-$end";
       }

--- a/src/Flysystem/Fedora.php
+++ b/src/Flysystem/Fedora.php
@@ -18,6 +18,7 @@ use Islandora\Chullo\IFedoraApi;
 use Psr\Http\Message\RequestInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Mime\MimeTypeGuesserInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Drupal plugin for the Fedora Flysystem adapter.
@@ -57,6 +58,13 @@ class Fedora implements FlysystemPluginInterface, ContainerFactoryPluginInterfac
   protected $logger;
 
   /**
+   * The current request.
+   *
+   * @var \Symfony\Component\HttpFoundation\Request
+   */
+  protected $request;
+
+  /**
    * Constructs a Fedora plugin for Flysystem.
    *
    * @param \Islandora\Chullo\IFedoraApi $fedora
@@ -67,17 +75,21 @@ class Fedora implements FlysystemPluginInterface, ContainerFactoryPluginInterfac
    *   Language manager.
    * @param \Drupal\Core\Logger\LoggerChannelInterface $logger
    *   The fedora adapter logger channel.
+   * @param \Symfony\Component\HttpFoundation\RequestStack $request_stack
+   *   The request stack.
    */
   public function __construct(
     IFedoraApi $fedora,
     MimeTypeGuesserInterface $mime_type_guesser,
     LanguageManagerInterface $language_manager,
-    LoggerChannelInterface $logger
+    LoggerChannelInterface $logger,
+    RequestStack $request_stack,
   ) {
     $this->fedora = $fedora;
     $this->mimeTypeGuesser = $mime_type_guesser;
     $this->languageManager = $language_manager;
     $this->logger = $logger;
+    $this->request = $request_stack->getCurrentRequest();
   }
 
   /**
@@ -95,7 +107,8 @@ class Fedora implements FlysystemPluginInterface, ContainerFactoryPluginInterfac
       $fedora,
       $container->get('file.mime_type.guesser'),
       $container->get('language_manager'),
-      $container->get('logger.channel.fedora_flysystem')
+      $container->get('logger.channel.fedora_flysystem'),
+      $container->get('request_stack')
     );
   }
 
@@ -109,7 +122,7 @@ class Fedora implements FlysystemPluginInterface, ContainerFactoryPluginInterfac
     return function (callable $handler) use ($jwt) {
       return function (
         RequestInterface $request,
-        array $options
+        array $options,
       ) use (
         $handler,
         $jwt
@@ -124,7 +137,7 @@ class Fedora implements FlysystemPluginInterface, ContainerFactoryPluginInterfac
    * {@inheritdoc}
    */
   public function getAdapter() {
-    return new FedoraAdapter($this->fedora, $this->mimeTypeGuesser, $this->logger);
+    return new FedoraAdapter($this->fedora, $this->mimeTypeGuesser, $this->logger, $this->request);
   }
 
   /**

--- a/tests/src/Kernel/FedoraAdapterTest.php
+++ b/tests/src/Kernel/FedoraAdapterTest.php
@@ -11,6 +11,7 @@ use Islandora\Chullo\IFedoraApi;
 use League\Flysystem\Config;
 use Prophecy\Argument;
 use Symfony\Component\Mime\MimeTypeGuesserInterface;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Tests the Fedora adapter for Flysystem.
@@ -36,6 +37,13 @@ class FedoraAdapterTest extends IslandoraKernelTestBase {
   private $logger;
 
   /**
+   * The current request.
+   *
+   * @var \Symfony\Component\HttpFoundation\Request
+   */
+  private $request;
+
+  /**
    * {@inheritdoc}
    */
   public function setUp(): void {
@@ -43,6 +51,8 @@ class FedoraAdapterTest extends IslandoraKernelTestBase {
     $this->mimeGuesser = $this->prophesize(MimeTypeGuesserInterface::class)
       ->reveal();
     $this->logger = $this->prophesize(LoggerChannelInterface::class)->reveal();
+
+    $this->request = Request::create('/_flysystem/fedora/path/to/file.ext');
   }
 
   /**
@@ -78,7 +88,7 @@ class FedoraAdapterTest extends IslandoraKernelTestBase {
     $prophecy->getResource('', ['Connection' => 'close'])->willReturn($response);
     $api = $prophecy->reveal();
 
-    return new FedoraAdapter($api, $this->mimeGuesser, $this->logger);
+    return new FedoraAdapter($api, $this->mimeGuesser, $this->logger, $this->request);
   }
 
   /**
@@ -93,7 +103,7 @@ class FedoraAdapterTest extends IslandoraKernelTestBase {
     $prophecy->getResource('', ['Connection' => 'close'])->willReturn($response);
     $api = $prophecy->reveal();
 
-    return new FedoraAdapter($api, $this->mimeGuesser, $this->logger);
+    return new FedoraAdapter($api, $this->mimeGuesser, $this->logger, $this->request);
   }
 
   /**
@@ -115,7 +125,7 @@ class FedoraAdapterTest extends IslandoraKernelTestBase {
     $prophecy->getResourceHeaders('', ['Connection' => 'close'])->willReturn($response);
     $api = $prophecy->reveal();
 
-    return new FedoraAdapter($api, $this->mimeGuesser, $this->logger);
+    return new FedoraAdapter($api, $this->mimeGuesser, $this->logger, $this->request);
   }
 
   /**
@@ -140,7 +150,7 @@ class FedoraAdapterTest extends IslandoraKernelTestBase {
 
     $api = $fedora_prophecy->reveal();
 
-    return new FedoraAdapter($api, $this->mimeGuesser, $this->logger);
+    return new FedoraAdapter($api, $this->mimeGuesser, $this->logger, $this->request);
   }
 
   /**
@@ -160,7 +170,7 @@ class FedoraAdapterTest extends IslandoraKernelTestBase {
 
     $api = $fedora_prophecy->reveal();
 
-    return new FedoraAdapter($api, $this->mimeGuesser, $this->logger);
+    return new FedoraAdapter($api, $this->mimeGuesser, $this->logger, $this->request);
   }
 
   /**
@@ -188,7 +198,7 @@ class FedoraAdapterTest extends IslandoraKernelTestBase {
 
     $api = $fedora_prophecy->reveal();
 
-    return new FedoraAdapter($api, $this->mimeGuesser, $this->logger);
+    return new FedoraAdapter($api, $this->mimeGuesser, $this->logger, $this->request);
   }
 
   /**
@@ -204,7 +214,7 @@ class FedoraAdapterTest extends IslandoraKernelTestBase {
     $fedora_prophecy->getResourceHeaders('', ['Connection' => 'close'])->willReturn($prophecy->reveal());
     $api = $fedora_prophecy->reveal();
 
-    return new FedoraAdapter($api, $this->mimeGuesser, $this->logger);
+    return new FedoraAdapter($api, $this->mimeGuesser, $this->logger, $this->request);
   }
 
   /**
@@ -220,7 +230,7 @@ class FedoraAdapterTest extends IslandoraKernelTestBase {
 
     $api = $fedora_prophecy->reveal();
 
-    return new FedoraAdapter($api, $this->mimeGuesser, $this->logger);
+    return new FedoraAdapter($api, $this->mimeGuesser, $this->logger, $this->request);
   }
 
   /**
@@ -248,7 +258,7 @@ class FedoraAdapterTest extends IslandoraKernelTestBase {
 
     $api = $fedora_prophecy->reveal();
 
-    return new FedoraAdapter($api, $this->mimeGuesser, $this->logger);
+    return new FedoraAdapter($api, $this->mimeGuesser, $this->logger, $this->request);
   }
 
   /**
@@ -276,7 +286,7 @@ class FedoraAdapterTest extends IslandoraKernelTestBase {
 
     $api = $fedora_prophecy->reveal();
 
-    return new FedoraAdapter($api, $this->mimeGuesser, $this->logger);
+    return new FedoraAdapter($api, $this->mimeGuesser, $this->logger, $this->request);
   }
 
   /**
@@ -637,7 +647,7 @@ class FedoraAdapterTest extends IslandoraKernelTestBase {
 
     $api = $fedora_prophecy->reveal();
 
-    $adapter = new FedoraAdapter($api, $this->mimeGuesser, $this->logger);
+    $adapter = new FedoraAdapter($api, $this->mimeGuesser, $this->logger, $this->request);
 
     $this->assertTrue($adapter->rename('', '') == TRUE, "rename() must return TRUE on success");
   }
@@ -654,7 +664,7 @@ class FedoraAdapterTest extends IslandoraKernelTestBase {
 
     $api = $fedora_prophecy->reveal();
 
-    $adapter = new FedoraAdapter($api, $this->mimeGuesser, $this->logger);
+    $adapter = new FedoraAdapter($api, $this->mimeGuesser, $this->logger, $this->request);
 
     $this->assertTrue($adapter->createDir('', $this->prophesize(Config::class)
       ->reveal()) == FALSE, "createDir() must return FALSE on fail");

--- a/tests/src/Kernel/FedoraPluginTest.php
+++ b/tests/src/Kernel/FedoraPluginTest.php
@@ -10,6 +10,8 @@ use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Mime\MimeTypeGuesserInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 
 /**
  * Tests the Fedora plugin for Flysystem.
@@ -40,6 +42,10 @@ class FedoraPluginTest extends IslandoraKernelTestBase {
     $logger = $this->prophesize(LoggerChannelInterface::class)->reveal();
 
     $request = Request::create('/_flysystem/fedora/path/to/file.ext');
+    $session = new Session(new MockArraySessionStorage());
+    $session->start();
+    $request->setSession($session);
+
     /** @var \Symfony\Component\HttpFoundation\RequestStack $request_stack */
     $request_stack = $this->container->get('request_stack');
     $request_stack->push($request);

--- a/tests/src/Kernel/FedoraPluginTest.php
+++ b/tests/src/Kernel/FedoraPluginTest.php
@@ -9,6 +9,7 @@ use League\Flysystem\AdapterInterface;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Mime\MimeTypeGuesserInterface;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Tests the Fedora plugin for Flysystem.
@@ -38,7 +39,12 @@ class FedoraPluginTest extends IslandoraKernelTestBase {
     $language_manager = $this->container->get('language_manager');
     $logger = $this->prophesize(LoggerChannelInterface::class)->reveal();
 
-    return new Fedora($api, $mime_guesser, $language_manager, $logger);
+    $request = Request::create('/_flysystem/fedora/path/to/file.ext');
+    /** @var \Symfony\Component\HttpFoundation\RequestStack $request_stack */
+    $request_stack = \Drupal::service('request_stack');
+    $request_stack->push($request);
+
+    return new Fedora($api, $mime_guesser, $language_manager, $logger, $request_stack);
   }
 
   /**

--- a/tests/src/Kernel/FedoraPluginTest.php
+++ b/tests/src/Kernel/FedoraPluginTest.php
@@ -41,7 +41,7 @@ class FedoraPluginTest extends IslandoraKernelTestBase {
 
     $request = Request::create('/_flysystem/fedora/path/to/file.ext');
     /** @var \Symfony\Component\HttpFoundation\RequestStack $request_stack */
-    $request_stack = \Drupal::service('request_stack');
+    $request_stack = $this->container->get('request_stack');
     $request_stack->push($request);
 
     return new Fedora($api, $mime_guesser, $language_manager, $logger, $request_stack);


### PR DESCRIPTION
# What does this Pull Request do?

Forwards `Range` HTTP headers to fedora. This is a sibling PR with https://github.com/Islandora/chullo/pull/101 to improve file download performance from fedora. This PR avoids sending the entire binary from fedora if a range request is made to a file stored in fedora.

However, since flysystem uses Symfony's BinaryFileResponse to serve files, that code assumes the stream it receives starts at byte `0` ([relevant code](https://github.com/symfony/http-foundation/blob/c665ed94bc8ab780f6d3bfcaf05312daf093977f/BinaryFileResponse.php#L249)), so we have to always send the range as `bytes=0-$end` so that code can `fseek` to the proper byte for the `206` HTTP response. However, this at least will not send any other bytes after the end of the range, which should be a performance improvement.

# How should this be tested?

- Apply https://github.com/Islandora/chullo/pull/101
- Run a curl command with a `Range` HTTP header
```
curl -v -r 123-456 https://islandora.dev/_flysystem/fedora/2025-05/test.pdf -o part1.resp
```
- ensure only bytes between 123 and 456 are saved in `part1.resp` and the server returned the proper response headers
```
< HTTP/2 206
...
...
< content-range: bytes 123-456/6890377
```

# Documentation Status

* Does this change existing behaviour that's currently documented? no
* Does this change require new pages or sections of documentation? no

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
@Islandora/committers
