### PR TITLE
Adding very basic sample vtt data to media track generateSampleValue function

### DIFF
--- a/src/Plugin/Field/FieldType/MediaTrackItem.php
+++ b/src/Plugin/Field/FieldType/MediaTrackItem.php
@@ -202,6 +202,19 @@ class MediaTrackItem extends FileItem {
     // $sample_file_text += randomText()
     // }
     // $file = file_write($sample_file_text, 'random_filename.vtt');
+
+    $sample_file_text = <<<EOT
+WEBVTT
+
+00:00:00.500 --> 00:00:02.000
+This is a test subtitle.
+
+00:00:04.500 --> 00:00:06.300
+This is another test subtitle.
+EOT;
+
+    $file = file_write($sample_file_text, 'sample_file.vtt');
+
     $values = [
       'target_id' => $file->id(),
       // Randomize the rest of these...
@@ -209,7 +222,7 @@ class MediaTrackItem extends FileItem {
       'kind' => '',
       'srclang' => '',
       // Careful with this one, complex validation.
-      'default' => '',
+      'default' => 0,
     ];
     return $values;
   }

--- a/src/Plugin/Field/FieldType/MediaTrackItem.php
+++ b/src/Plugin/Field/FieldType/MediaTrackItem.php
@@ -202,7 +202,6 @@ class MediaTrackItem extends FileItem {
     // $sample_file_text += randomText()
     // }
     // $file = file_write($sample_file_text, 'random_filename.vtt');
-
     $sample_file_text = <<<EOT
 WEBVTT
 

--- a/src/Plugin/Field/FieldType/MediaTrackItem.php
+++ b/src/Plugin/Field/FieldType/MediaTrackItem.php
@@ -212,7 +212,9 @@ This is a test subtitle.
 This is another test subtitle.
 EOT;
 
-    $file = file_write($sample_file_text, 'sample_file.vtt');
+    /** @var \Drupal\file\FileRepositoryInterface $file_repo */
+    $file_repo = \Drupal::service('file.repository');
+    $file = $file_repo->writeData($sample_file_text, "public://sample_file.vtt");
 
     $values = [
       'target_id' => $file->id(),

--- a/src/Plugin/Field/FieldType/MediaTrackItem.php
+++ b/src/Plugin/Field/FieldType/MediaTrackItem.php
@@ -184,24 +184,6 @@ class MediaTrackItem extends FileItem {
    * {@inheritdoc}
    */
   public static function generateSampleValue(FieldDefinitionInterface $field_definition) {
-    // @todo This will need to generate a text file, containing a sequence of
-    // timestamps and nonsense text. Include some gap periods where nothing is
-    // displayed.
-    // See the ImageItem::generateSampleValue() for how the files are saved.
-    // The part about "Generate a max of 5 different images" is a good idea
-    // here too. We only need a WebVTT few files.
-    // See one of the text item implementation for how to generate nonsense.
-    // Pseudocode plan...
-    // $sample_file_text = 'WEBVTT'; // start of file.
-    // for ($i = 0; $ < $utterances; $i++) {
-    // $sample_file_text += \n\n
-    // $timestamp += 3-10seconds // start of display
-    // $sample_file_text += $timestamp
-    // $timestamp += 3-10seconds // end of display
-    // $sample_file_text += $timestamp
-    // $sample_file_text += randomText()
-    // }
-    // $file = file_write($sample_file_text, 'random_filename.vtt');
     $sample_file_text = <<<EOT
 WEBVTT
 


### PR DESCRIPTION
# What does this Pull Request do?
Fixes an issue where when the generateSampleValue function is called as part of `devel_generate` it fails because `$file` doesn't exist when attempting to call `$file->id()`. Additionally, `default` value being set to an empty string throws an SQLSTATE error, causing the node to not be generated. Setting to 0 allows for a node to be generated without error.

# How should this be tested?
- Enable the `devel_generate` module via `/admin/modules` admin menu
- Enable `Generate` within the devel configuration `/admin/config/development/devel/toolbar` admin menu
- Running devel_generate without the supplied code to generate one(or multiple) node(s) of `islandora` content type
- Note the whitescreen error about a missing `$file` value
- Re-run the test with the supplied code in place.
- Node(s) will be properly generated by `devel_generate`

# Interested parties
@Islandora/committers
