### PR TITLE
depend on functionality instead of ui modules

### DIFF
--- a/islandora.info.yml
+++ b/islandora.info.yml
@@ -6,8 +6,7 @@ type: module
 package: Islandora
 core_version_requirement: ^10.3 || ^11
 dependencies:
-  - action:action
-  - context:context_ui
+  - context:context
   - ctools:ctools
   - drupal:basic_auth
   - drupal:block
@@ -20,7 +19,7 @@ dependencies:
   - drupal:rest
   - drupal:taxonomy
   - drupal:text
-  - drupal:views_ui
+  - drupal:views
   - eva:eva
   - file_replace:file_replace
   - filehash:filehash


### PR DESCRIPTION
* [Slack inquiry](https://islandora.slack.com/archives/CM5PPAV28/p1749960528923209)

# What does this Pull Request do?

Creates dependencies on the underlying functionality modules rather than their UI modules. The reasoning is so that we can disable the UI modules in production while keeping the functionality in place. We want to avoid configuration being done in production.

Actions UI (`action`) was brought up as potentially still needed, but it seems to me that all actions configuration is contained in config files.

# What's new?

* This is about changing dependencies.

# How should this be tested?

This could be tested by ensuring a site without the UI modules still behaves as expected minus the UI functionality for select modules.

# Documentation Status

* This would probably require people to know that the UI modules are not enabled by default. If users are starting with Islandora Starter Site the config enables them.
