### PR TITLE
Phase out 'Display' Contexts: Surface some Conditions in Block Visibility

### DIFF
--- a/islandora.module
+++ b/islandora.module
@@ -509,8 +509,6 @@ function islandora_form_block_form_alter(&$form, FormStateInterface $form_state,
   unset($form['visibility']['node_had_namespace']);
   unset($form['visibility']['node_has_ancestor']);
   unset($form['visibility']['node_has_parent']);
-  unset($form['visibility']['node_has_term']);
-  unset($form['visibility']['node_is_islandora_object']);
   unset($form['visibility']['node_referenced_by_node']);
   unset($form['visibility']['parent_node_has_term']);
 }

--- a/src/Plugin/Condition/MediaSourceHasMimetype.php
+++ b/src/Plugin/Condition/MediaSourceHasMimetype.php
@@ -85,7 +85,7 @@ class MediaSourceHasMimetype extends ConditionPluginBase {
    */
   public function defaultConfiguration() {
     return array_merge(
-      ['mimetype' => []],
+      ['mimetype' => ""],
       parent::defaultConfiguration()
     );
   }

--- a/src/Plugin/Condition/NodeIsIslandoraObject.php
+++ b/src/Plugin/Condition/NodeIsIslandoraObject.php
@@ -15,7 +15,11 @@ use Drupal\Islandora\IslandoraUtils;
  *   id = "node_is_islandora_object",
  *   label = @Translation("Node is an Islandora node"),
  *   context_definitions = {
- *     "node" = @ContextDefinition("entity:node", required = TRUE , label = @Translation("node"))
+ *     "node" = @ContextDefinition("entity:node",
+ *       required = FALSE,
+ *       label = @Translation("Node source"),
+ *       description = @Translation("The node source must be set for this condition to work as expected.")
+ *     )
  *   }
  * )
  */
@@ -61,39 +65,22 @@ class NodeIsIslandoraObject extends ConditionPluginBase implements ContainerFact
    * {@inheritdoc}
    */
   public function defaultConfiguration() {
-    return array_merge(
-      [
-        'use_this_condition' => 'no',
-      ],
-      parent::defaultConfiguration()
-    );
-  }
+    $defaults = parent::defaultConfiguration();
 
-  /**
-   * {@inheritdoc}
-   */
-  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
-    $form['use_this_condition'] = [
-      '#type' => 'radios',
-      '#title' => $this->t('Use this condition'),
-      '#description' => $this->t('Select "yes" to ensure this condition is evaluated when using in Block Visibility.'),
-      '#default_value' => $this->configuration['use_this_condition'],
-      '#options' => [
-        'yes' => 'Yes',
-        'no' => 'No',
-      ],
-    ];
+    // XXX: There appear to be expectations in Drupal that there will be more
+    // config to a plugin than just selecting the context mapping; however, it
+    // is our only configuration. Due to these expectations, it would fail to
+    // save our visibility settings. To work around, it seems to be sufficient
+    // to dynamically declare our default configuration, such that the
+    // difference from the default configuration can be detected upstream.
+    // @see https://git.drupalcode.org/project/drupal/-/blob/d87ab76d397a2cfe0457997be4f2648c4760b2f5/core/lib/Drupal/Core/Condition/ConditionPluginCollection.php#L39-44
+    if (!empty($this->configuration['context_mapping'])) {
+      $defaults += [
+        'context_mapping' => [],
+      ];
+    }
 
-    return parent::buildConfigurationForm($form, $form_state);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
-    $this->configuration['use_this_condition'] = $form_state->getValue('use_this_condition');
-
-    parent::submitConfigurationForm($form, $form_state);
+    return $defaults;
   }
 
   /**

--- a/src/Plugin/Condition/NodeIsIslandoraObject.php
+++ b/src/Plugin/Condition/NodeIsIslandoraObject.php
@@ -3,6 +3,7 @@
 namespace Drupal\islandora\Plugin\Condition;
 
 use Drupal\Core\Condition\ConditionPluginBase;
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\Islandora\IslandoraUtils;
@@ -54,6 +55,45 @@ class NodeIsIslandoraObject extends ConditionPluginBase implements ContainerFact
       $plugin_definition,
       $container->get('islandora.utils')
     );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration() {
+    return array_merge(
+      [
+        'use_this_condition' => 'no',
+      ],
+      parent::defaultConfiguration()
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
+    $form['use_this_condition'] = [
+      '#type' => 'radios',
+      '#title' => $this->t('Use this condition'),
+      '#description' => $this->t('Select "yes" to ensure this condition is evaluated.'),
+      '#default_value' => $this->configuration['use_this_condition'],
+      '#options' => [
+        'yes' => 'Yes',
+        'no' => 'No',
+      ],
+    ];
+
+    return parent::buildConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
+    $this->configuration['use_this_condition'] = $form_state->getValue('use_this_condition');
+
+    parent::submitConfigurationForm($form, $form_state);
   }
 
   /**

--- a/src/Plugin/Condition/NodeIsIslandoraObject.php
+++ b/src/Plugin/Condition/NodeIsIslandoraObject.php
@@ -3,7 +3,6 @@
 namespace Drupal\islandora\Plugin\Condition;
 
 use Drupal\Core\Condition\ConditionPluginBase;
-use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\Islandora\IslandoraUtils;

--- a/src/Plugin/Condition/NodeIsIslandoraObject.php
+++ b/src/Plugin/Condition/NodeIsIslandoraObject.php
@@ -76,7 +76,7 @@ class NodeIsIslandoraObject extends ConditionPluginBase implements ContainerFact
     $form['use_this_condition'] = [
       '#type' => 'radios',
       '#title' => $this->t('Use this condition'),
-      '#description' => $this->t('Select "yes" to ensure this condition is evaluated.'),
+      '#description' => $this->t('Select "yes" to ensure this condition is evaluated when using in Block Visibility.'),
       '#default_value' => $this->configuration['use_this_condition'],
       '#options' => [
         'yes' => 'Yes',


### PR DESCRIPTION
**Drupal Issue**: https://www.drupal.org/project/islandora/issues/3536145

* Other Relevant Links:
  * https://docs.google.com/spreadsheets/d/1WTcsRPm178dYrurpW1Cqs_MyUc-w1I1s68mq403xs6g/edit?gid=0#gid=0
  * https://www.drupal.org/project/islandora/issues/3536145#comment-16194229

# What does this Pull Request do?

Stop unsetting the 'node_has_term' and 'node_is_islandora_object' conditions in Block Visibility form to allow moving away from relying on Contexts to place various blocks.

# What's new?
This should not affect any existing configuration; it just facilitates changing block placements currently relying on various Contexts to instead use Block Visibility configuration directly.

# How should this be tested?

* after pulling in this change, the Block Visibility section of block configurations should include 'Node has term with URI' and 'Node is an Islandora node' among the available tabs.
  * try setting either one or both or none of these visibility conditions for any block.
  * these conditions should work however they are configured, and should not have any required fields to cause issues when not used (which had been the motivation for hiding at least a few of those other conditions being unset)

# Additional Notes
I did also include a small bit of cleanup so the MediaSourceHasMimetype condition has the proper default config defined so it can stop getting thrown into all the block configs that are not using it.

# Documentation Status

Don't think this should require documentation changes, though might be nice to put a blurb somewhere to suggest avoiding using Contexts to place blocks in favour of Block Visibility?

# Interested parties
@Islandora/committers
