### PR TITLE
#2370 Add host to make IIIF Identifier an HTTP(S) URI

### DIFF
--- a/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
+++ b/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
@@ -235,7 +235,7 @@ class IIIFManifest extends StylePluginBase {
       // @see https://iiif.io/api/presentation/2.1/#manifest
       $json += [
         '@type' => 'sc:Manifest',
-        '@id' => $request_url,
+        '@id' => $request_host . $request_url,
         // If the View has a title, set the View title as the manifest label.
         'label' => $label,
         '@context' => 'http://iiif.io/api/presentation/2/context.json',


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/2370

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)
IIIF standard for Presentation API re `@id` https://iiif.io/api/presentation/2.1/#id "A manifest must have exactly one id, and it must be the http(s) URI at which it is published."

# What does this Pull Request do?
Alter `IIIFManifest.php` to add request host to `@id` so that a complete URI is output, such that validation at https://presentation-validator.iiif.io/ passes (avoids 'Validation Error: The identifier '/node/29/book-manifest' is not an HTTP(S) URI'.) 

# What's new?
Manifest JSON-LD now looks like:
```json
{
  "@type": "sc:Manifest",
  "@id": "http://mydomain.lndo.site/node/419/book-manifest-original",
  "label": "The Peak : January 9, 1974",
```

# How should this be tested?

1. Apply MR or patch
2. Confirm a full URI is output in book-manifest-original
3. Validate via https://presentation-validator.iiif.io/

# Documentation Status

* N/A

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
@Islandora/committers
