### PR TITLE
SUP-7141: More specific term enumeration.

### DIFF
--- a/src/Plugin/Condition/NodeHasTerm.php
+++ b/src/Plugin/Condition/NodeHasTerm.php
@@ -174,6 +174,8 @@ class NodeHasTerm extends ConditionPluginBase implements ContainerFactoryPluginI
     $form['naive_references'] = [
       '#type' => 'checkbox',
       '#title' => $this->t('Naive References'),
+      '#description' => $this->t('Use naive reference enumeration. Uncheck for better performance when dealing with sufficiently complex node content definitions containing many entity reference fields (including paragraphs, dgi_image_discovery, etc.).'),
+
       '#default_value' => $this->naiveReferences,
     ];
 

--- a/src/Plugin/Condition/NodeHasTerm.php
+++ b/src/Plugin/Condition/NodeHasTerm.php
@@ -186,8 +186,6 @@ class NodeHasTerm extends ConditionPluginBase implements ContainerFactoryPluginI
    * {@inheritdoc}
    */
   public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
-    parent::submitConfigurationForm($form, $form_state);
-
     // Set URI for term if possible.
     $value = $form_state->getValue('term');
     $uris = [];
@@ -202,11 +200,15 @@ class NodeHasTerm extends ConditionPluginBase implements ContainerFactoryPluginI
       }
     }
 
-    $this->setConfiguration([
+    $this->configuration += [
       'uri' => implode(',', $uris),
       'logic' => $form_state->getValue('logic'),
       'naive_references' => $form_state->getValue('naive_references'),
-    ]);
+    ];
+
+    // XXX: Call to the parent has to be last, due to how the context definition
+    // is added.
+    parent::submitConfigurationForm($form, $form_state);
   }
 
   /**

--- a/src/Plugin/Condition/NodeHasTerm.php
+++ b/src/Plugin/Condition/NodeHasTerm.php
@@ -3,8 +3,11 @@
 namespace Drupal\islandora\Plugin\Condition;
 
 use Drupal\Core\Condition\ConditionPluginBase;
+use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\FieldableEntityInterface;
+use Drupal\Core\Entity\Plugin\DataType\EntityReference;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\islandora\IslandoraUtils;
@@ -38,6 +41,36 @@ class NodeHasTerm extends ConditionPluginBase implements ContainerFactoryPluginI
   protected $entityTypeManager;
 
   /**
+   * URIs for which to test.
+   *
+   * @var string[]
+   */
+  protected array $uris;
+
+  /**
+   * Operand with which to combine matches.
+   *
+   * The string "and" or "or":
+   * - if "and"; all $uris must be matched
+   * - if "or"; only one of $uris much be matched.
+   *
+   * @var string
+   */
+  protected string $operand;
+
+  /**
+   * Flag, for how to enumerate candidate entities which might bear URIs.
+   *
+   * TRUE to use ::referencedEntities(); however, can be very inefficient with
+   * many other referenced entities (such as paragraphs). FALSE to constrain
+   * the fields considered to entity references fields bearing taxonomy terms
+   * earlier.
+   *
+   * @var bool
+   */
+  protected bool $naiveReferences;
+
+  /**
    * Constructor.
    *
    * @param array $configuration
@@ -67,6 +100,24 @@ class NodeHasTerm extends ConditionPluginBase implements ContainerFactoryPluginI
   }
 
   /**
+   * Helper; unpack configuration to our member variables.
+   */
+  private function unpackConfig() : static {
+    $this->uris = explode(',', $this->configuration['uri']);
+    $this->operand = $this->configuration['logic'];
+    $this->naiveReferences = $this->configuration['naive_references'];
+    return $this;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function setConfiguration(array $configuration) {
+    return parent::setConfiguration($configuration)
+      ->unpackConfig();
+  }
+
+  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
@@ -86,7 +137,8 @@ class NodeHasTerm extends ConditionPluginBase implements ContainerFactoryPluginI
     return array_merge(
       [
         'logic' => 'and',
-        'uri' => NULL,
+        'uri' => '',
+        'naive_references' => FALSE,
       ],
       parent::defaultConfiguration()
     );
@@ -97,11 +149,8 @@ class NodeHasTerm extends ConditionPluginBase implements ContainerFactoryPluginI
    */
   public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
     $default = [];
-    if (isset($this->configuration['uri']) && !empty($this->configuration['uri'])) {
-      $uris = explode(',', $this->configuration['uri']);
-      foreach ($uris as $uri) {
-        $default[] = $this->utils->getTermForUri($uri);
-      }
+    foreach ($this->uris as $uri) {
+      $default[] = $this->utils->getTermForUri($uri);
     }
 
     $form['term'] = [
@@ -122,8 +171,15 @@ class NodeHasTerm extends ConditionPluginBase implements ContainerFactoryPluginI
         'and' => 'And',
         'or' => 'Or',
       ],
-      '#default_value' => $this->configuration['logic'],
+      '#default_value' => $this->operand,
     ];
+
+    $form['naive_references'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Naive References'),
+      '#default_value' => $this->naiveReferences,
+    ];
+
     return parent::buildConfigurationForm($form, $form_state);
   }
 
@@ -131,8 +187,9 @@ class NodeHasTerm extends ConditionPluginBase implements ContainerFactoryPluginI
    * {@inheritdoc}
    */
   public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
+    parent::submitConfigurationForm($form, $form_state);
+
     // Set URI for term if possible.
-    $this->configuration['uri'] = NULL;
     $value = $form_state->getValue('term');
     $uris = [];
     if (!empty($value)) {
@@ -144,14 +201,13 @@ class NodeHasTerm extends ConditionPluginBase implements ContainerFactoryPluginI
           $uris[] = $uri;
         }
       }
-      if (!empty($uris)) {
-        $this->configuration['uri'] = implode(',', $uris);
-      }
     }
 
-    $this->configuration['logic'] = $form_state->getValue('logic');
-
-    parent::submitConfigurationForm($form, $form_state);
+    $this->setConfiguration([
+      'uri' => implode(',', $uris),
+      'logic' => $form_state->getValue('logic'),
+      'naive_references' => $form_state->getValue('naive_references'),
+    ]);
   }
 
   /**
@@ -178,64 +234,93 @@ class NodeHasTerm extends ConditionPluginBase implements ContainerFactoryPluginI
    * @return bool
    *   TRUE if entity has all the specified term(s), otherwise FALSE.
    */
-  protected function evaluateEntity(EntityInterface $entity) {
+  protected function evaluateEntity(EntityInterface $entity) : bool {
     // Find the terms on the node.
     $field_names = $this->utils->getUriFieldNamesForTerms();
-    $terms = array_filter($entity->referencedEntities(), function ($entity) use ($field_names) {
-      if ($entity->getEntityTypeId() != 'taxonomy_term') {
+    $unfiltered_terms = ($this->naiveReferences) ?
+      $entity->referencedEntities() :
+      $this->doSpecificReferenceLookup($entity);
+    /** @var \Drupal\taxonomy\TermInterface[] $terms */
+    $terms = array_filter($unfiltered_terms, static function ($entity) use ($field_names) {
+      if ($entity->getEntityTypeId() !== 'taxonomy_term') {
+        return FALSE;
+      }
+      if (!($entity instanceof FieldableEntityInterface)) {
         return FALSE;
       }
 
       foreach ($field_names as $field_name) {
         if ($entity->hasField($field_name) && !$entity->get($field_name)->isEmpty()) {
-           return TRUE;
+          return TRUE;
         }
       }
       return FALSE;
     });
 
     // Get their URIs.
-    $haystack = array_map(function ($term) {
-        return $this->utils->getUriForTerm($term);
-    },
-      $terms
-    );
+    $haystack = array_filter(array_map($this->utils->getUriForTerm(...), $terms));
 
     // FALSE if there's no URIs on the node.
     if (empty($haystack)) {
       return FALSE;
     }
 
-    // Get the URIs to look for.  It's a required field, so there
-    // will always be one.
-    $needles = explode(',', $this->configuration['uri']);
+    return match ($this->operand) {
+      'and' => count(array_intersect($this->uris, $haystack)) === count($this->uris),
+      default => count(array_intersect($this->uris, $haystack)) > 0,
+    };
+  }
 
-    // TRUE if every needle is in the haystack.
-    if ($this->configuration['logic'] == 'and') {
-      if (count(array_intersect($needles, $haystack)) == count($needles)) {
-        return TRUE;
+  /**
+   * More targetedly discover references to the taxonomy fields we care about.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity from which to examine
+   *
+   * @return \Drupal\taxonomy\TermInterface[]
+   *   Taxonomy terms to check examine.
+   * @throws \Drupal\Core\TypedData\Exception\MissingDataException
+   */
+  private function doSpecificReferenceLookup(EntityInterface $entity) : array {
+    assert($entity instanceof ContentEntityInterface);
+    $field_generator = static function (FieldableEntityInterface $entity) {
+      foreach ($entity->getFieldDefinitions() as $field_name => $field_definition) {
+        if ($field_definition->getType() !== 'entity_reference' || $field_definition->getSetting('target_type') !== 'taxonomy_term') {
+          continue;
+        }
+        yield $field_name;
       }
-      return FALSE;
-    }
-    // TRUE if any needle is in the haystack.
-    else {
-      if (count(array_intersect($needles, $haystack)) > 0) {
-        return TRUE;
+    };
+
+    $terms = [];
+
+    /** @var string $field_name */
+    foreach ($field_generator($entity) as $field_name) {
+      /** @var \Drupal\Core\Field\FieldItemInterface $field_item */
+      foreach ($entity->get($field_name) as $field_item) {
+        foreach ($field_item->getProperties(TRUE) as $property) {
+          if ($property instanceof EntityReference &&
+            $property->getTargetDefinition()->getEntityTypeId() === 'taxonomy_term' &&
+            ($term = $property->getValue())) {
+            $terms[] = $term;
+          }
+        }
       }
-      return FALSE;
     }
+
+    return $terms;
   }
 
   /**
    * {@inheritdoc}
    */
   public function summary() {
-    if (!empty($this->configuration['negate'])) {
-      return $this->t('The node is not associated with taxonomy term with uri @uri.', ['@uri' => $this->configuration['uri']]);
-    }
-    else {
-      return $this->t('The node is associated with taxonomy term with uri @uri.', ['@uri' => $this->configuration['uri']]);
-    }
+    $context = [
+      '@uri' => implode(',', $this->uris),
+    ];
+    return !empty($this->configuration['negate']) ?
+      $this->t('The node is not associated with taxonomy term with uri @uri.', $context) :
+      $this->t('The node is associated with taxonomy term with uri @uri.', $context);
   }
 
 }

--- a/src/Plugin/Condition/NodeHasTerm.php
+++ b/src/Plugin/Condition/NodeHasTerm.php
@@ -272,10 +272,11 @@ class NodeHasTerm extends ConditionPluginBase implements ContainerFactoryPluginI
    * More targetedly discover references to the taxonomy fields we care about.
    *
    * @param \Drupal\Core\Entity\EntityInterface $entity
-   *   The entity from which to examine
+   *   The entity from which to examine.
    *
    * @return \Drupal\taxonomy\TermInterface[]
    *   Taxonomy terms to check examine.
+   *
    * @throws \Drupal\Core\TypedData\Exception\MissingDataException
    */
   private function doSpecificReferenceLookup(EntityInterface $entity) : array {

--- a/src/Plugin/Condition/NodeHasTerm.php
+++ b/src/Plugin/Condition/NodeHasTerm.php
@@ -200,11 +200,9 @@ class NodeHasTerm extends ConditionPluginBase implements ContainerFactoryPluginI
       }
     }
 
-    $this->configuration += [
-      'uri' => implode(',', $uris),
-      'logic' => $form_state->getValue('logic'),
-      'naive_references' => $form_state->getValue('naive_references'),
-    ];
+    $this->configuration['uri'] = implode(',', $uris);
+    $this->configuration['logic'] = $form_state->getValue('logic');
+    $this->configuration['naive_references'] = $form_state->getValue('naive_references');
 
     // XXX: Call to the parent has to be last, due to how the context definition
     // is added.

--- a/src/Plugin/Condition/NodeHasTerm.php
+++ b/src/Plugin/Condition/NodeHasTerm.php
@@ -148,10 +148,7 @@ class NodeHasTerm extends ConditionPluginBase implements ContainerFactoryPluginI
    * {@inheritdoc}
    */
   public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
-    $default = [];
-    foreach ($this->uris as $uri) {
-      $default[] = $this->utils->getTermForUri($uri);
-    }
+    $default = array_filter(array_map($this->utils->getTermForUri(...), $this->uris));
 
     $form['term'] = [
       '#type' => 'entity_autocomplete',

--- a/tests/src/Functional/NodeHasTermTest.php
+++ b/tests/src/Functional/NodeHasTermTest.php
@@ -25,9 +25,23 @@ class NodeHasTermTest extends IslandoraFunctionalTestBase {
   }
 
   /**
-   * @covers \Drupal\islandora\Plugin\Condition\NodeHasTerm
+   * Data providing method.
+   *
+   * @return array
+   *   Arrays of test parameters.
    */
-  public function testNodeHasTerm() {
+  public function dataProvider() {
+    return [
+      'naive references' => [TRUE],
+      'specific references' => [FALSE],
+    ];
+  }
+
+  /**
+   * @covers \Drupal\islandora\Plugin\Condition\NodeHasTerm
+   * @dataProvider dataProvider
+   */
+  public function testNodeHasTerm(bool $naive_references) {
 
     // Create a new node with the tag.
     $node = $this->container->get('entity_type.manager')
@@ -44,6 +58,7 @@ class NodeHasTermTest extends IslandoraFunctionalTestBase {
       'node_has_term',
       [
         'uri' => 'http://purl.org/coar/resource_type/c_c513',
+        'naive_references' => $naive_references,
       ]
     );
     $condition->setContextValue('node', $node);
@@ -79,6 +94,7 @@ class NodeHasTermTest extends IslandoraFunctionalTestBase {
       [
         'uri' => 'http://purl.org/coar/resource_type/c_c513,http://pcdm.org/use#PreservationMasterFile',
         'logic' => 'or',
+        'naive_references' => $naive_references,
       ]
     );
     $condition->setContextValue('node', $node);
@@ -103,6 +119,7 @@ class NodeHasTermTest extends IslandoraFunctionalTestBase {
       'node_has_term',
       [
         'uri' => 'http://purl.org/coar/resource_type/c_c513,http://pcdm.org/use#PreservationMasterFile',
+        'naive_references' => $naive_references,
       ]
     );
     $condition->setContextValue('node', $node);


### PR DESCRIPTION
**GitHub Issue**: (link)

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What does this Pull Request do?

Have run into the situation where, with a sufficient complex node content definition with many entity reference fields (including paragraphs and dgi_image_discovery and the like), that a significant part of the page load can be spent iterating over irrelevant referenced entities when trying to find references to terms/URIs.  

# What's new?

New default behavior to constrain to taxonomy term referencing fields earlier.
The old behaivor can be opted-into by enabling the "Naive references" toggle.

# How should this be tested?

A description of what steps someone could take to:
* Reproduce the problem you are fixing (if applicable)
* Test that the Pull Request does what is intended.
* Please be as detailed as possible.
* Good testing instructions help get your PR completed faster.

# Documentation Status

* Does this change existing behaviour that's currently documented?
* Does this change require new pages or sections of documentation?
* Who does this need to be documented for?
* Associated documentation pull request(s): ___  or documentation issue ___

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
