### PR TITLE
Allow reading directly from fedora's OCFL root

### DIFF
--- a/config/install/islandora.settings.yml
+++ b/config/install/islandora.settings.yml
@@ -4,3 +4,4 @@ delete_media_and_files: TRUE
 gemini_pseudo_bundles: []
 allow_header_links: TRUE
 fast_term_queries: TRUE
+fedora_root: ''

--- a/config/schema/islandora.schema.yml
+++ b/config/schema/islandora.schema.yml
@@ -37,6 +37,9 @@ islandora.settings:
       label: 'List of node, media and taxonomy terms that should include the linked Fedora URI'
       sequence:
         type: string
+    fedora_root:
+      type: string
+      label: 'Fedora Root Path'
 
 
 action.configuration.emit_node_event:

--- a/src/Flysystem/Adapter/FedoraAdapter.php
+++ b/src/Flysystem/Adapter/FedoraAdapter.php
@@ -134,7 +134,21 @@ class FedoraAdapter implements AdapterInterface {
       $this->logger->error('Invalid JSON in OCFL inventory: @error', ['@error' => json_last_error_msg()]);
       return "";
     }
+
+    if (!isset($inventory['head'], $inventory['versions'], $inventory['manifest'])) {
+      $this->logger->error('Malformed OCFL inventory structure missing required fields: @path', ['@path' => $inventory]);
+      return "";
+    }
+
     $head = $inventory['head'];
+    if (!isset($inventory['versions'][$head]['state'])) {
+      $this->logger->error('Missing version state in OCFL inventory for version @version: @path', [
+        '@version' => $head,
+        '@path' => $inventory,
+      ]);
+      return "";
+    }
+
     $state = $inventory['versions'][$head]['state'];
     $manifest = $inventory['manifest'];
 
@@ -152,6 +166,44 @@ class FedoraAdapter implements AdapterInterface {
     }
 
     return "";
+  }
+
+  /**
+   * Get file metadata from disk with optional disk path return.
+   *
+   * @param string $path
+   *   Fedora resource path.
+   * @param bool $return_disk_path
+   *   Whether to return the disk path in the metadata.
+   *
+   * @return array|false
+   *   Metadata array with optional disk_path, or FALSE on failure.
+   */
+  protected function getDiskMetadata($path, $return_disk_path = FALSE) {
+    $diskPath = $this->getDiskPath($path);
+
+    if (!$diskPath || !file_exists($diskPath)) {
+      return FALSE;
+    }
+
+    $stat = stat($diskPath);
+    if ($stat === FALSE) {
+      return FALSE;
+    }
+
+    $meta = [
+      'type' => 'file',
+      'path' => $path,
+      'timestamp' => $stat['mtime'],
+      'size' => $stat['size'],
+      'mimetype' => $this->mimeTypeGuesser->guessMimeType($diskPath),
+    ];
+
+    if ($return_disk_path) {
+      $meta['disk_path'] = $diskPath;
+    }
+
+    return $meta;
   }
 
   /**
@@ -210,24 +262,21 @@ class FedoraAdapter implements AdapterInterface {
    */
   public function readStream($path) {
     if ($this->useDiskReading($path)) {
-      $diskPath = $this->getDiskPath($path);
+      $meta = $this->getDiskMetadata($path, TRUE);
 
-      if (!file_exists($diskPath)) {
+      if ($meta === FALSE) {
         return FALSE;
       }
 
-      $stream = fopen($diskPath, 'r');
+      $stream = fopen($meta['disk_path'], 'r');
       if ($stream === FALSE) {
         return FALSE;
       }
 
-      $meta = $this->getMetadata($path);
-      if ($meta === FALSE) {
-        fclose($stream);
-        return FALSE;
-      }
-
+      // Remove the disk_path from metadata before returning.
+      unset($meta['disk_path']);
       $meta['stream'] = $stream;
+
       return $meta;
     }
 
@@ -266,26 +315,7 @@ class FedoraAdapter implements AdapterInterface {
    */
   public function getMetadata($path) {
     if ($this->useDiskReading($path)) {
-      $diskPath = $this->getDiskPath($path);
-
-      if (!file_exists($diskPath)) {
-        return FALSE;
-      }
-
-      $stat = stat($diskPath);
-      if ($stat === FALSE) {
-        return FALSE;
-      }
-
-      $meta = [
-        'type' => 'file',
-        'path' => $path,
-        'timestamp' => $stat['mtime'],
-        'size' => $stat['size'],
-        'mimetype' => $this->mimeTypeGuesser->guessMimeType($diskPath),
-      ];
-
-      return $meta;
+      return $this->getDiskMetadata($path);
     }
 
     $response = $this->fedora->getResourceHeaders($path, ['Connection' => 'close']);

--- a/src/Flysystem/Adapter/FedoraAdapter.php
+++ b/src/Flysystem/Adapter/FedoraAdapter.php
@@ -76,7 +76,7 @@ class FedoraAdapter implements AdapterInterface {
     MimeTypeGuesserInterface $mime_type_guesser,
     LoggerChannelInterface $logger,
     Request $request,
-    string $fedora_root,
+    string $fedora_root = '',
   ) {
     $this->fedora = $fedora;
     $this->mimeTypeGuesser = $mime_type_guesser;

--- a/src/Flysystem/Adapter/FedoraAdapter.php
+++ b/src/Flysystem/Adapter/FedoraAdapter.php
@@ -118,6 +118,10 @@ class FedoraAdapter implements AdapterInterface {
     $fedora_id = 'info:fedora/' . $path;
     $ocfl_dir = $this->getOcflDir($fedora_id);
     $inventory = $ocfl_dir . '/extensions/0005-mutable-head/head/inventory.json';
+    // If no mutable head inventory fall back to root inventory.
+    if (!file_exists($inventory)) {
+      $inventory = $ocfl_dir . '/inventory.json';
+    }
     if (!file_exists($inventory)) {
       $this->logger->warning('OCFL inventory not found: @path', ['@path' => $inventory]);
       return "";

--- a/src/Flysystem/Adapter/FedoraAdapter.php
+++ b/src/Flysystem/Adapter/FedoraAdapter.php
@@ -94,7 +94,7 @@ class FedoraAdapter implements AdapterInterface {
   protected function useDiskReading($path) {
     // Prevent directory traversal.
     if (strpos($path, '..') !== FALSE || strpos($path, './') !== FALSE) {
-        return FALSE;
+      return FALSE;
     }
 
     // If we're setting up a directory in fedora
@@ -125,14 +125,14 @@ class FedoraAdapter implements AdapterInterface {
 
     $inventory_json = file_get_contents($inventory);
     if ($inventory_json === FALSE) {
-        $this->logger->error('Failed to read OCFL inventory: @path', ['@path' => $inventory]);
-        return "";
+      $this->logger->error('Failed to read OCFL inventory: @path', ['@path' => $inventory]);
+      return "";
     }
 
     $inventory = json_decode($inventory_json, TRUE);
     if (json_last_error() !== JSON_ERROR_NONE) {
-        $this->logger->error('Invalid JSON in OCFL inventory: @error', ['@error' => json_last_error_msg()]);
-        return "";
+      $this->logger->error('Invalid JSON in OCFL inventory: @error', ['@error' => json_last_error_msg()]);
+      return "";
     }
     $head = $inventory['head'];
     $state = $inventory['versions'][$head]['state'];

--- a/src/Flysystem/Adapter/FedoraAdapter.php
+++ b/src/Flysystem/Adapter/FedoraAdapter.php
@@ -51,6 +51,13 @@ class FedoraAdapter implements AdapterInterface {
   protected $request;
 
   /**
+   * The path to fedora OCFL root.
+   *
+   * @var string
+   */
+  protected $fedoraRoot;
+
+  /**
    * Constructs a Fedora adapter for Flysystem.
    *
    * @param \Islandora\Chullo\IFedoraApi $fedora
@@ -61,23 +68,109 @@ class FedoraAdapter implements AdapterInterface {
    *   The fedora adapter logger channel.
    * @param \Symfony\Component\HttpFoundation\Request $request
    *   The current request.
+   * @param string $fedora_root
+   *   The path to fedora's OCFL root directory.
    */
   public function __construct(
     IFedoraApi $fedora,
     MimeTypeGuesserInterface $mime_type_guesser,
     LoggerChannelInterface $logger,
     Request $request,
+    string $fedora_root,
   ) {
     $this->fedora = $fedora;
     $this->mimeTypeGuesser = $mime_type_guesser;
     $this->logger = $logger;
     $this->request = $request;
+    $this->fedoraRoot = $fedora_root;
+  }
+
+  /**
+   * Check if we should read from disk.
+   *
+   * @return bool
+   *   TRUE if fedoraRoot is configured and not empty.
+   */
+  protected function useDiskReading($path) {
+    // If we're setting up a directory in fedora
+    // do not attempt to read from disk.
+    $info = pathinfo($path);
+    if (empty($info['extension'])) {
+      return FALSE;
+    }
+
+    return !empty($this->fedoraRoot);
+  }
+
+  /**
+   * Convert Fedora path to disk path.
+   *
+   * @param string $path
+   *   Fedora resource path.
+   *
+   * @return string
+   *   Full disk path to the file.
+   */
+  protected function getDiskPath(string $path) : string {
+    // Remove leading slash if present.
+    $path = ltrim($path, '/');
+    $fedora_id = 'info:fedora/' . $path;
+    $ocfl_dir = $this->getOcflDir($fedora_id);
+    $inventory = $ocfl_dir . '/extensions/0005-mutable-head/head/inventory.json';
+    if (!file_exists($inventory)) {
+      return "";
+    }
+
+    $inventory_json = file_get_contents($inventory);
+    $inventory = json_decode($inventory_json, TRUE);
+    $head = $inventory['head'];
+    $state = $inventory['versions'][$head]['state'];
+    $manifest = $inventory['manifest'];
+
+    $components = explode('/', $path);
+    $filename = array_pop($components);
+    foreach ($state as $digest => $files) {
+      if (!in_array($filename, $files)) {
+        continue;
+      }
+      if (empty($manifest[$digest][0])) {
+        continue;
+      }
+
+      return $ocfl_dir . '/' . $manifest[$digest][0];
+    }
+
+    return "";
+  }
+
+  /**
+   * Helper function to get the OCFL directory of a fcrepo object ID.
+   */
+  protected function getOcflDir(string $objectId) : string {
+    $digest = hash('sha256', $objectId);
+    $tupleSize = 3;
+    $numberOfTuples = 3;
+    $path = rtrim($this->fedoraRoot, '/') . '/';
+    for ($i = 0; $i < $numberOfTuples * $tupleSize; $i += $tupleSize) {
+      $tuple = substr($digest, $i, $tupleSize);
+      $path .= $tuple . "/";
+    }
+
+    $path .= $digest;
+
+    return $path;
   }
 
   /**
    * {@inheritdoc}
    */
   public function has($path) {
+    if ($this->useDiskReading($path)) {
+      $diskPath = $this->getDiskPath($path);
+
+      return $diskPath != "" && file_exists($diskPath);
+    }
+
     $response = $this->fedora->getResourceHeaders($path, ['Connection' => 'close']);
     return $response->getStatusCode() == 200;
   }
@@ -92,7 +185,7 @@ class FedoraAdapter implements AdapterInterface {
       return FALSE;
     }
 
-    if (isset($meta['stream'])) {
+    if (!$this->useDiskReading($path) && isset($meta['stream'])) {
       $meta['contents'] = stream_get_contents($meta['stream']);
       fclose($meta['stream']);
       unset($meta['stream']);
@@ -105,6 +198,28 @@ class FedoraAdapter implements AdapterInterface {
    * {@inheritdoc}
    */
   public function readStream($path) {
+    if ($this->useDiskReading($path)) {
+      $diskPath = $this->getDiskPath($path);
+
+      if (!file_exists($diskPath)) {
+        return FALSE;
+      }
+
+      $stream = fopen($diskPath, 'r');
+      if ($stream === FALSE) {
+        return FALSE;
+      }
+
+      $meta = $this->getMetadata($path);
+      if ($meta === FALSE) {
+        fclose($stream);
+        return FALSE;
+      }
+
+      $meta['stream'] = $stream;
+      return $meta;
+    }
+
     $headers = ['Connection' => 'close'];
 
     // If the request is for a range
@@ -139,6 +254,29 @@ class FedoraAdapter implements AdapterInterface {
    * {@inheritdoc}
    */
   public function getMetadata($path) {
+    if ($this->useDiskReading($path)) {
+      $diskPath = $this->getDiskPath($path);
+
+      if (!file_exists($diskPath)) {
+        return FALSE;
+      }
+
+      $stat = stat($diskPath);
+      if ($stat === FALSE) {
+        return FALSE;
+      }
+
+      $meta = [
+        'type' => 'file',
+        'path' => $path,
+        'timestamp' => $stat['mtime'],
+        'size' => $stat['size'],
+        'mimetype' => $this->mimeTypeGuesser->guessMimeType($diskPath),
+      ];
+
+      return $meta;
+    }
+
     $response = $this->fedora->getResourceHeaders($path, ['Connection' => 'close']);
 
     if ($response->getStatusCode() != 200) {

--- a/src/Flysystem/Adapter/FedoraAdapter.php
+++ b/src/Flysystem/Adapter/FedoraAdapter.php
@@ -92,14 +92,15 @@ class FedoraAdapter implements AdapterInterface {
    *   TRUE if fedoraRoot is configured and not empty.
    */
   protected function useDiskReading($path) {
+    // Prevent directory traversal.
+    if (strpos($path, '..') !== FALSE || strpos($path, './') !== FALSE) {
+        return FALSE;
+    }
+
     // If we're setting up a directory in fedora
     // do not attempt to read from disk.
     $info = pathinfo($path);
-    if (empty($info['extension'])) {
-      return FALSE;
-    }
-
-    return !empty($this->fedoraRoot);
+    return !empty($info['extension']) && !empty($this->fedoraRoot);
   }
 
   /**
@@ -118,11 +119,21 @@ class FedoraAdapter implements AdapterInterface {
     $ocfl_dir = $this->getOcflDir($fedora_id);
     $inventory = $ocfl_dir . '/extensions/0005-mutable-head/head/inventory.json';
     if (!file_exists($inventory)) {
+      $this->logger->warning('OCFL inventory not found: @path', ['@path' => $inventory]);
       return "";
     }
 
     $inventory_json = file_get_contents($inventory);
+    if ($inventory_json === FALSE) {
+        $this->logger->error('Failed to read OCFL inventory: @path', ['@path' => $inventory]);
+        return "";
+    }
+
     $inventory = json_decode($inventory_json, TRUE);
+    if (json_last_error() !== JSON_ERROR_NONE) {
+        $this->logger->error('Invalid JSON in OCFL inventory: @error', ['@error' => json_last_error_msg()]);
+        return "";
+    }
     $head = $inventory['head'];
     $state = $inventory['versions'][$head]['state'];
     $manifest = $inventory['manifest'];

--- a/src/Flysystem/Fedora.php
+++ b/src/Flysystem/Fedora.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\islandora\Flysystem;
 
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\Core\Logger\RfcLogLevel;
@@ -65,6 +66,13 @@ class Fedora implements FlysystemPluginInterface, ContainerFactoryPluginInterfac
   protected $request;
 
   /**
+   * The path to fedora OCFL root.
+   *
+   * @var string
+   */
+  protected $fedoraRoot;
+
+  /**
    * Constructs a Fedora plugin for Flysystem.
    *
    * @param \Islandora\Chullo\IFedoraApi $fedora
@@ -77,6 +85,8 @@ class Fedora implements FlysystemPluginInterface, ContainerFactoryPluginInterfac
    *   The fedora adapter logger channel.
    * @param \Symfony\Component\HttpFoundation\RequestStack $request_stack
    *   The request stack.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory.
    */
   public function __construct(
     IFedoraApi $fedora,
@@ -84,12 +94,16 @@ class Fedora implements FlysystemPluginInterface, ContainerFactoryPluginInterfac
     LanguageManagerInterface $language_manager,
     LoggerChannelInterface $logger,
     RequestStack $request_stack,
+    ConfigFactoryInterface $config_factory,
   ) {
     $this->fedora = $fedora;
     $this->mimeTypeGuesser = $mime_type_guesser;
     $this->languageManager = $language_manager;
     $this->logger = $logger;
     $this->request = $request_stack->getCurrentRequest();
+
+    $config = $config_factory->get('islandora.settings');
+    $this->fedoraRoot = $config->get('fedora_root') ?: '';
   }
 
   /**
@@ -102,13 +116,13 @@ class Fedora implements FlysystemPluginInterface, ContainerFactoryPluginInterfac
     $stack->push(static::addJwt($container->get('jwt.authentication.jwt')));
     $fedora = FedoraApi::createWithHandler($configuration['root'], $stack);
 
-    // Return it.
     return new static(
       $fedora,
       $container->get('file.mime_type.guesser'),
       $container->get('language_manager'),
       $container->get('logger.channel.fedora_flysystem'),
-      $container->get('request_stack')
+      $container->get('request_stack'),
+      $container->get('config.factory')
     );
   }
 
@@ -137,7 +151,7 @@ class Fedora implements FlysystemPluginInterface, ContainerFactoryPluginInterfac
    * {@inheritdoc}
    */
   public function getAdapter() {
-    return new FedoraAdapter($this->fedora, $this->mimeTypeGuesser, $this->logger, $this->request);
+    return new FedoraAdapter($this->fedora, $this->mimeTypeGuesser, $this->logger, $this->request,  $this->fedoraRoot);
   }
 
   /**

--- a/src/Flysystem/Fedora.php
+++ b/src/Flysystem/Fedora.php
@@ -151,7 +151,7 @@ class Fedora implements FlysystemPluginInterface, ContainerFactoryPluginInterfac
    * {@inheritdoc}
    */
   public function getAdapter() {
-    return new FedoraAdapter($this->fedora, $this->mimeTypeGuesser, $this->logger, $this->request,  $this->fedoraRoot);
+    return new FedoraAdapter($this->fedora, $this->mimeTypeGuesser, $this->logger, $this->request, $this->fedoraRoot);
   }
 
   /**

--- a/src/Form/IslandoraSettingsForm.php
+++ b/src/Form/IslandoraSettingsForm.php
@@ -238,7 +238,6 @@ class IslandoraSettingsForm extends ConfigFormBase {
       '#default_value' => (bool) $config->get(self::FAST_TERM_QUERIES),
     ];
 
-
     $form[self::FEDORA_ROOT] = [
       '#type' => 'textfield',
       '#title' => $this->t('Fedora Root'),

--- a/src/Form/IslandoraSettingsForm.php
+++ b/src/Form/IslandoraSettingsForm.php
@@ -242,7 +242,7 @@ class IslandoraSettingsForm extends ConfigFormBase {
       '#type' => 'textfield',
       '#title' => $this->t('Fedora Root'),
       '#description' => $this->t("The absolute path to fedora's root OCFL dir. e.g. /fcrepo/home/data/ocfl-root.
-      Setting this value will read binaries off disk from the OCFL directory when access them through flysystem, rather than going through fedora's API"),
+      Setting this value will read binaries off disk from the OCFL root directory when accessing through flysystem instead of going through fedora's API"),
       '#default_value' => $config->get(self::FEDORA_ROOT),
     ];
 

--- a/src/Form/IslandoraSettingsForm.php
+++ b/src/Form/IslandoraSettingsForm.php
@@ -29,6 +29,7 @@ class IslandoraSettingsForm extends ConfigFormBase {
   const UPLOAD_FORM_LOCATION = 'upload_form_location';
   const UPLOAD_FORM_ALLOWED_MIMETYPES = 'upload_form_allowed_mimetypes';
   const GEMINI_PSEUDO = 'gemini_pseudo_bundles';
+  const FEDORA_ROOT = 'fedora_root';
   const FEDORA_URL = 'fedora_url';
   const TIME_INTERVALS = [
     'sec',
@@ -237,6 +238,15 @@ class IslandoraSettingsForm extends ConfigFormBase {
       '#default_value' => (bool) $config->get(self::FAST_TERM_QUERIES),
     ];
 
+
+    $form[self::FEDORA_ROOT] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Fedora Root'),
+      '#description' => $this->t("The absolute path to fedora's root OCFL dir. e.g. /fcrepo/home/data/ocfl-root.
+      Setting this value will read binaries off disk from the OCFL directory when access them through flysystem, rather than going through fedora's API"),
+      '#default_value' => $config->get(self::FEDORA_ROOT),
+    ];
+
     $form[self::FEDORA_URL] = [
       '#type' => 'textfield',
       '#title' => $this->t('Fedora URL'),
@@ -395,6 +405,7 @@ class IslandoraSettingsForm extends ConfigFormBase {
     $config
       ->set(self::BROKER_URL, $form_state->getValue(self::BROKER_URL))
       ->set(self::JWT_EXPIRY, $form_state->getValue(self::JWT_EXPIRY))
+      ->set(self::FEDORA_ROOT, $form_state->getValue(self::FEDORA_ROOT))
       ->set(self::UPLOAD_FORM_LOCATION, $form_state->getValue(self::UPLOAD_FORM_LOCATION))
       ->set(self::UPLOAD_FORM_ALLOWED_MIMETYPES, $form_state->getValue(self::UPLOAD_FORM_ALLOWED_MIMETYPES))
       ->set(self::GEMINI_PSEUDO, $new_pseudo_types)

--- a/tests/src/Kernel/FedoraPluginTest.php
+++ b/tests/src/Kernel/FedoraPluginTest.php
@@ -50,7 +50,9 @@ class FedoraPluginTest extends IslandoraKernelTestBase {
     $request_stack = $this->container->get('request_stack');
     $request_stack->push($request);
 
-    return new Fedora($api, $mime_guesser, $language_manager, $logger, $request_stack);
+    $configFactory = $this->container->get('config.factory');
+
+    return new Fedora($api, $mime_guesser, $language_manager, $logger, $request_stack, $configFactory);
   }
 
   /**


### PR DESCRIPTION
* Alternative to https://github.com/Islandora/chullo/pull/103
* [Slack 🧵: Slow A/V playback for fedora assets](https://islandora.slack.com/archives/CM5PPAV28/p1746569598247179)

# What does this Pull Request do?

When downloading files from fedora flysystem, allow Drupal to serve the file directly from the OCFL root directory instead of going through fedora API requests

# What's new?

A new config property is created `fedora_root` that when set reads from the OCFL directory instead of going through the fcrepo service. **This requires Drupal to have read access to the OCFL root directory of fedora**.

This was needed for us here at Lehigh because when loading paged content items with many hundred children, our requests between drupal and fedora were being buffered on disk, and this caused our disk usage to swell for these requests (and sometimes go to 100%). I believe this approach will also help with [Slack 🧵: Slow A/V playback for fedora assets](https://islandora.slack.com/archives/CM5PPAV28/p1746569598247179) while avoiding [Slack 🧵 the image upload regression my original attempts at resolving this issue introduced](https://islandora.slack.com/archives/CM5PPAV28/p1748537680421139)

# How should this be tested?

A description of what steps someone could take to:
* Mount the fcrepo OCFL root directory into your drupal service
  * Example: https://github.com/lehigh-university-libraries/isle-preserve/blob/c729464fb5cb7a00ed554585201a676708e6626a/docker-compose.yaml#L231
* Apply this PR and set the new config `fedora_root` to the location you mounted
  * Example change needed https://github.com/lehigh-university-libraries/isle-preserve/commit/2bf0b90cafcba76ef1a1086704bd55adc5e99905#diff-06e5c553e048e21dcafc74b7f2803c96c0168b59085bb17c019e4d57c221ebb4 
* Download and upload files to fedora via Drupal. Notice in fedora's logs it is only accessed by Drupal when writing files

# Documentation Status

* Does this change existing behaviour that's currently documented? no
* Does this change require new pages or sections of documentation? yes
* Who does this need to be documented for? folks using fedora as storage
* Associated documentation pull request(s): ___  or documentation issue ___

# Additional Notes:

I looked at trying to use https://github.com/discoverygarden/flysystem_ocfl instead, but I was having issues writing to fedora when using the `ocfl` driver. Though I am on Drupal 11, so could be an incompatibility with Drupal 11 - I just bumped `info.yml` in that module so i could install it without evaluating any d11 upgrades

# Interested parties
