### PR TITLE
Allow pointing alpaca to internal domains

### DIFF
--- a/config/install/islandora.settings.yml
+++ b/config/install/islandora.settings.yml
@@ -4,3 +4,4 @@ delete_media_and_files: TRUE
 gemini_pseudo_bundles: []
 allow_header_links: TRUE
 fast_term_queries: TRUE
+microservice_url_rewrites: ''

--- a/config/schema/islandora.schema.yml
+++ b/config/schema/islandora.schema.yml
@@ -37,6 +37,9 @@ islandora.settings:
       label: 'List of node, media and taxonomy terms that should include the linked Fedora URI'
       sequence:
         type: string
+    microservice_url_rewrites:
+      type: text
+      label: 'URL rewrite rules for microservice events'
 
 
 action.configuration.emit_node_event:

--- a/islandora.services.yml
+++ b/islandora.services.yml
@@ -3,7 +3,7 @@
 services:
   islandora.eventgenerator:
     class: Drupal\islandora\EventGenerator\EventGenerator
-    arguments: ['@islandora.utils', '@islandora.media_source_service']
+    arguments: ['@islandora.utils', '@islandora.media_source_service', '@config.factory']
   islandora.stomp:
     class: Stomp\StatefulStomp
     factory: ['Drupal\islandora\StompFactory', create]

--- a/src/EventGenerator/EventGenerator.php
+++ b/src/EventGenerator/EventGenerator.php
@@ -9,6 +9,8 @@ use Drupal\Core\Site\Settings;
 use Drupal\islandora\IslandoraUtils;
 use Drupal\islandora\MediaSource\MediaSourceService;
 use Drupal\user\UserInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\islandora\Form\IslandoraSettingsForm;
 
 /**
  * The default EventGenerator implementation.
@@ -32,16 +34,26 @@ class EventGenerator implements EventGeneratorInterface {
   protected $mediaSource;
 
   /**
+   * Config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
    * Constructor.
    *
    * @param \Drupal\islandora\IslandoraUtils $utils
    *   Islandora utils.
    * @param \Drupal\islandora\MediaSource\MediaSourceService $media_source
    *   Media source service.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   Config factory.
    */
-  public function __construct(IslandoraUtils $utils, MediaSourceService $media_source) {
+  public function __construct(IslandoraUtils $utils, MediaSourceService $media_source, ConfigFactoryInterface $config_factory) {
     $this->utils = $utils;
     $this->mediaSource = $media_source;
+    $this->configFactory = $config_factory;
   }
 
   /**
@@ -161,6 +173,9 @@ class EventGenerator implements EventGeneratorInterface {
       unset($data[$key]);
     }
 
+    // Apply URL rewrites for microservices.
+    $this->applyUrlRewrites($data);
+
     if (!empty($data)) {
       $event["attachment"] = [
         "type" => "Object",
@@ -170,6 +185,49 @@ class EventGenerator implements EventGeneratorInterface {
     }
 
     return json_encode($event);
+  }
+
+  /**
+   * Apply URL rewrites to event data URIs.
+   *
+   * @param array &$data
+   *   Event data array to modify.
+   */
+  protected function applyUrlRewrites(array &$data) {
+    $config = $this->configFactory->get(IslandoraSettingsForm::CONFIG_NAME);
+    $rewrites = $config->get(IslandoraSettingsForm::MICROSERVICE_URL_REWRITES);
+
+    if (empty($rewrites)) {
+      return;
+    }
+
+    // Parse rewrite rules from config.
+    $find = [];
+    $replace = [];
+    $lines = explode("\n", $rewrites);
+    foreach ($lines as $line) {
+      $line = trim($line);
+      if (empty($line)) {
+        continue;
+      }
+      $parts = explode('|', $line, 2);
+      if (count($parts) === 2) {
+        $find[] = trim($parts[0]);
+        $replace[] = trim($parts[1]);
+      }
+    }
+
+    if (empty($find)) {
+      return;
+    }
+
+    // Apply rewrites to URI fields.
+    $uri_fields = ["file_upload_uri", "source_uri", "destination_uri"];
+    foreach ($uri_fields as $key) {
+      if (isset($data[$key])) {
+        $data[$key] = str_replace($find, $replace, $data[$key]);
+      }
+    }
   }
 
   /**

--- a/src/Form/IslandoraSettingsForm.php
+++ b/src/Form/IslandoraSettingsForm.php
@@ -46,6 +46,7 @@ class IslandoraSettingsForm extends ConfigFormBase {
   const REDIRECT_AFTER_MEDIA_SAVE = 'redirect_after_media_save';
   const ALLOW_HEADER_LINKS = 'allow_header_links';
   const FAST_TERM_QUERIES = 'fast_term_queries';
+  const MICROSERVICE_URL_REWRITES = 'microservice_url_rewrites';
 
   /**
    * To list the available bundle types.
@@ -237,6 +238,14 @@ class IslandoraSettingsForm extends ConfigFormBase {
       '#default_value' => (bool) $config->get(self::FAST_TERM_QUERIES),
     ];
 
+    $form[self::MICROSERVICE_URL_REWRITES] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Microservice URL rewrites'),
+      '#description' => $this->t('URL rewrite rules for microservice events. Enter one rule per line in the format: find_pattern|replace_pattern. For example: "https://test-arch.lib.institution.edu|http://localhost" will rewrite all occurrences of the first URL to the second in file URIs sent to microservices.'),
+      '#default_value' => $config->get(self::MICROSERVICE_URL_REWRITES),
+      '#rows' => 5,
+    ];
+
     $form[self::FEDORA_URL] = [
       '#type' => 'textfield',
       '#title' => $this->t('Fedora URL'),
@@ -402,6 +411,7 @@ class IslandoraSettingsForm extends ConfigFormBase {
       ->set(self::FAST_TERM_QUERIES, $form_state->getValue(self::FAST_TERM_QUERIES))
       ->set(self::REDIRECT_AFTER_MEDIA_SAVE, $form_state->getValue(self::REDIRECT_AFTER_MEDIA_SAVE))
       ->set(self::ALLOW_HEADER_LINKS, $form_state->getValue(self::ALLOW_HEADER_LINKS))
+      ->set(self::MICROSERVICE_URL_REWRITES, $form_state->getValue(self::MICROSERVICE_URL_REWRITES))
       ->save();
 
     parent::submitForm($form, $form_state);

--- a/tests/src/Kernel/EventGeneratorTest.php
+++ b/tests/src/Kernel/EventGeneratorTest.php
@@ -66,7 +66,8 @@ class EventGeneratorTest extends IslandoraKernelTestBase {
     // Create the event generator so we can test it.
     $this->eventGenerator = new EventGenerator(
       $this->container->get('islandora.utils'),
-      $this->container->get('islandora.media_source_service')
+      $this->container->get('islandora.media_source_service'),
+      $this->container->get('config.factory')
     );
   }
 
@@ -174,6 +175,148 @@ class EventGeneratorTest extends IslandoraKernelTestBase {
         "'url' entries must be either html, json, or jsonld"
       );
     }
+  }
+
+  /**
+   * Tests URL rewriting in microservice events.
+   *
+   * @covers \Drupal\islandora\EventGenerator\EventGenerator::generateEvent
+   * @covers \Drupal\islandora\EventGenerator\EventGenerator::applyUrlRewrites
+   */
+  public function testMicroserviceUrlRewrites() {
+    // Configure URL rewrites.
+    $config = $this->container->get('config.factory')->getEditable('islandora.settings');
+    $config->set('microservice_url_rewrites', "https://example.com|http://localhost\nhttps://test.org|http://internal.local");
+    $config->save();
+
+    // Create a new event generator with the updated config.
+    $this->eventGenerator = new EventGenerator(
+      $this->container->get('islandora.utils'),
+      $this->container->get('islandora.media_source_service'),
+      $this->container->get('config.factory')
+    );
+
+    // Generate an event with URIs that should be rewritten.
+    $json = $this->eventGenerator->generateEvent(
+      $this->entity,
+      $this->user,
+      [
+        'event' => 'Generate Derivative',
+        'source_uri' => 'https://example.com/_flysystem/fedora/file.jpg',
+        'destination_uri' => 'https://example.com/media/1/source',
+        'file_upload_uri' => 'public://derivatives/test.mp4',
+      ]
+    );
+    $msg = json_decode($json, TRUE);
+
+    // Assert URIs were rewritten.
+    $this->assertTrue(
+      isset($msg['attachment']['content']['source_uri']),
+      "Event should contain source_uri in attachment content"
+    );
+    $this->assertEquals(
+      'http://localhost/_flysystem/fedora/file.jpg',
+      $msg['attachment']['content']['source_uri'],
+      "source_uri should be rewritten from https://example.com to http://localhost"
+    );
+    $this->assertEquals(
+      'http://localhost/media/1/source',
+      $msg['attachment']['content']['destination_uri'],
+      "destination_uri should be rewritten from https://example.com to http://localhost"
+    );
+    $this->assertEquals(
+      'public://derivatives/test.mp4',
+      $msg['attachment']['content']['file_upload_uri'],
+      "file_upload_uri should not be rewritten when it doesn't match any pattern"
+    );
+  }
+
+  /**
+   * Tests URL rewriting with multiple patterns.
+   *
+   * @covers \Drupal\islandora\EventGenerator\EventGenerator::generateEvent
+   * @covers \Drupal\islandora\EventGenerator\EventGenerator::applyUrlRewrites
+   */
+  public function testMicroserviceUrlRewritesMultiplePatterns() {
+    // Configure URL rewrites with multiple patterns.
+    $config = $this->container->get('config.factory')->getEditable('islandora.settings');
+    $config->set('microservice_url_rewrites', "islandora-test.lib|islandora-stage.lib\nislandora-prod.lib|preserve.lib");
+    $config->save();
+
+    // Create a new event generator with the updated config.
+    $this->eventGenerator = new EventGenerator(
+      $this->container->get('islandora.utils'),
+      $this->container->get('islandora.media_source_service'),
+      $this->container->get('config.factory')
+    );
+
+    // Generate an event with URIs that match different patterns.
+    $json = $this->eventGenerator->generateEvent(
+      $this->entity,
+      $this->user,
+      [
+        'event' => 'Generate Derivative',
+        'source_uri' => 'https://islandora-test.lib/file.jpg',
+        'destination_uri' => 'https://islandora-prod.lib/media/1/source',
+      ]
+    );
+    $msg = json_decode($json, TRUE);
+
+    // Assert both patterns were applied.
+    $this->assertEquals(
+      'https://islandora-stage.lib/file.jpg',
+      $msg['attachment']['content']['source_uri'],
+      "source_uri should be rewritten from islandora-test.lib to islandora-stage.lib"
+    );
+    $this->assertEquals(
+      'https://preserve.lib/media/1/source',
+      $msg['attachment']['content']['destination_uri'],
+      "destination_uri should be rewritten from islandora-prod.lib to preserve.lib"
+    );
+  }
+
+  /**
+   * Tests that events work correctly with no URL rewrites configured.
+   *
+   * @covers \Drupal\islandora\EventGenerator\EventGenerator::generateEvent
+   * @covers \Drupal\islandora\EventGenerator\EventGenerator::applyUrlRewrites
+   */
+  public function testNoUrlRewrites() {
+    // Ensure no rewrites are configured.
+    $config = $this->container->get('config.factory')->getEditable('islandora.settings');
+    $config->set('microservice_url_rewrites', '');
+    $config->save();
+
+    // Create a new event generator with the updated config.
+    $this->eventGenerator = new EventGenerator(
+      $this->container->get('islandora.utils'),
+      $this->container->get('islandora.media_source_service'),
+      $this->container->get('config.factory')
+    );
+
+    // Generate an event.
+    $json = $this->eventGenerator->generateEvent(
+      $this->entity,
+      $this->user,
+      [
+        'event' => 'Generate Derivative',
+        'source_uri' => 'https://example.com/_flysystem/fedora/file.jpg',
+        'destination_uri' => 'https://example.com/media/1/source',
+      ]
+    );
+    $msg = json_decode($json, TRUE);
+
+    // Assert URIs were NOT rewritten.
+    $this->assertEquals(
+      'https://example.com/_flysystem/fedora/file.jpg',
+      $msg['attachment']['content']['source_uri'],
+      "source_uri should not be rewritten when no rewrites are configured"
+    );
+    $this->assertEquals(
+      'https://example.com/media/1/source',
+      $msg['attachment']['content']['destination_uri'],
+      "destination_uri should not be rewritten when no rewrites are configured"
+    );
   }
 
 }


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/2181

* https://islandora.slack.com/archives/C019U12D44Q/p1761594623294649

# What does this Pull Request do?

Allow events emitted from Drupal to point to internal domains instead of the public domain

# What's new?

Adds a config option to set search/replace on URIs in the Islandora event to allow rewriting the domain alpaca/scyllaridae should hit Drupal from.

# How should this be tested?

# Documentation Status

* Does this change existing behaviour that's currently documented?
* Does this change require new pages or sections of documentation?
* Who does this need to be documented for?
* Associated documentation pull request(s): ___  or documentation issue ___

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
@ruebot @rbos