### PR TITLE
DGI9-221 / DGI9-222 : Fix warnings on initial derivative uploads

### DIFF
--- a/src/MediaSource/MediaSourceService.php
+++ b/src/MediaSource/MediaSourceService.php
@@ -253,13 +253,12 @@ class MediaSourceService {
    * Initialize an empty file entity.
    *
    * We create as a temporary file, in case the uploading thread
-   * exits without properly completing the upload, such that during its core
-   * cron process, Drupal should try to clean up any files that remain
-   * "temporary" that are older than the system.file:temporary_maximum_age
-   * config indicates (which defaults to 6 hours).
+   * exits without properly completing the upload. Drupal should try to clean up
+   * any "temporary" files older than the system.file:temporary_maximum_age
+   * config indicates (which defaults to 6 hours) during Drupal's cron runs.
    *
-   * Drupal should handle making the "temporary" file permanent, when a
-   * reference to the file entity is saved into the media containing it.
+   * Additionally, Drupal should handle making the "temporary" file permanent,
+   * when a reference to the file entity is saved into another entity.
    *
    * @param string $content_location
    *   The location in which to initialize the file.

--- a/src/MediaSource/MediaSourceService.php
+++ b/src/MediaSource/MediaSourceService.php
@@ -295,7 +295,10 @@ class MediaSourceService {
    */
   private function validateFileExtension(string $content_location, string $filemime, FieldConfigInterface $field_config) : void {
     // Synthesize a file entity to throw at the validator, to validate the
-    // extension while avoiding dealing with `hook_file_create()`.
+    // extension while avoiding dealing with `hook_file_create()` as those hook
+    // implementations may expect the file to exist in the indicated location;
+    // however, it is not necessary for the file to exist in the given location
+    // in order to validate its extensions.
     // XXX: Values passed to FileStorage::create() are not set directly in the
     // constructor.
     // @see https://git.drupalcode.org/project/drupal/-/blob/29c1e5b2ed2e41788869f5752c84d0237350ea12/core/lib/Drupal/Core/Entity/ContentEntityStorageBase.php#L128-129

--- a/src/MediaSource/MediaSourceService.php
+++ b/src/MediaSource/MediaSourceService.php
@@ -7,6 +7,8 @@ use Drupal\Core\Field\EntityReferenceFieldItemListInterface;
 use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\field\FieldConfigInterface;
+use Drupal\file\Entity\File;
 use Drupal\file\FileInterface;
 use Drupal\file\Validation\FileValidatorInterface;
 use Drupal\islandora\IslandoraUtils;
@@ -235,6 +237,91 @@ class MediaSourceService {
   }
 
   /**
+   * Ensure the directory exists into which we can create files.
+   *
+   * @param string $content_location
+   *   A file we want to save.
+   */
+  private function initializeDestination(string $content_location) : void {
+    $directory = $this->fileSystem->dirname($content_location);
+    if (!$this->fileSystem->prepareDirectory($directory, FileSystemInterface::CREATE_DIRECTORY | FileSystemInterface::MODIFY_PERMISSIONS)) {
+      throw new HttpException(500, "The destination directory does not exist, could not be created, or is not writable");
+    }
+  }
+
+  /**
+   * Initialize an empty file entity.
+   *
+   * We create as a temporary file, in case the uploading thread
+   * exits without properly completing the upload, such that during its core
+   * cron process, Drupal should try to clean up any files that remain
+   * "temporary" that are older than the system.file:temporary_maximum_age
+   * config indicates (which defaults to 6 hours).
+   *
+   * Drupal should handle making the "temporary" file permanent, when a
+   * reference to the file entity is saved into the media containing it.
+   *
+   * @param string $content_location
+   *   The location in which to initialize the file.
+   *
+   * @return \Drupal\file\FileInterface
+   *   The initialized file.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  private function initializeFile(string $content_location) : FileInterface {
+    $this->initializeDestination($content_location);
+
+    touch($content_location);
+    return $this->entityTypeManager->getStorage('file')->create([
+      'uid' => $this->account->id(),
+      'uri' => $content_location,
+      'filename' => $this->fileSystem->basename($content_location),
+      'filemime' => 'application/octet-stream',
+      'status' => 0,
+    ]);
+  }
+
+  /**
+   * Validate the given file's extension matches those from its field config.
+   *
+   * @param string $content_location
+   *   The URI of the content to validate.
+   * @param string $filemime
+   *   The MIME-type of the file in question, if it is used during the extension
+   *   validation.
+   * @param \Drupal\field\FieldConfigInterface $field_config
+   *   The field bearing some configured extensions against which to match.
+   */
+  private function validateFileExtension(string $content_location, string $filemime, FieldConfigInterface $field_config) : void {
+    // Synthesize a file entity to throw at the validator, to validate the
+    // extension while avoiding dealing with `hook_file_create()`.
+    // XXX: Values passed to FileStorage::create() are not set directly in the
+    // constructor.
+    // @see https://git.drupalcode.org/project/drupal/-/blob/29c1e5b2ed2e41788869f5752c84d0237350ea12/core/lib/Drupal/Core/Entity/ContentEntityStorageBase.php#L128-129
+    $file = new File([], 'file');
+    $values = [
+      'uid' => $this->account->id(),
+      'uri' => $content_location,
+      'filename' => $this->fileSystem->basename($content_location),
+      'filemime' => $filemime,
+      'status' => 0,
+    ];
+    foreach ($values as $key => $value) {
+      $file->set($key, $value);
+    }
+
+    $valid_extensions = $field_config->getSetting('file_extensions');
+    $validators = ['FileExtension' => ['extensions' => $valid_extensions]];
+    $errors = $this->fileValidator->validate($file, $validators);
+
+    if ($errors->count() > 0) {
+      throw new BadRequestHttpException("Invalid file extension.  Valid types are $valid_extensions");
+    }
+  }
+
+  /**
    * Creates a new Media using the provided resource, adding it to a Node.
    *
    * @param \Drupal\node\NodeInterface $node
@@ -282,30 +369,12 @@ class MediaSourceService {
         throw new NotFoundHttpException("Source field not set for $bundle media");
       }
 
-      // Construct the File.
-      $file = $this->entityTypeManager->getStorage('file')->create([
-        'uid' => $this->account->id(),
-        'uri' => $content_location,
-        'filename' => $this->fileSystem->basename($content_location),
-        'filemime' => $mimetype,
-      ]);
-      $file->setPermanent();
-
       // Validate file extension.
       $source_field_config = $this->entityTypeManager->getStorage('field_config')->load("media.$bundle.$source_field");
-      $valid_extensions = $source_field_config->getSetting('file_extensions');
-      $validators = ['FileExtension' => ['extensions' => $valid_extensions]];
-      $errors = $this->fileValidator->validate($file, $validators);
+      $this->validateFileExtension($content_location, $mimetype, $source_field_config);
 
-      if ($errors->count() > 0) {
-        throw new BadRequestHttpException("Invalid file extension.  Valid types are $valid_extensions");
-      }
-
-      $directory = $this->fileSystem->dirname($content_location);
-      if (!$this->fileSystem->prepareDirectory($directory, FileSystemInterface::CREATE_DIRECTORY | FileSystemInterface::MODIFY_PERMISSIONS)) {
-        throw new HttpException(500, "The destination directory does not exist, could not be created, or is not writable");
-      }
-
+      // Construct the File.
+      $file = $this->initializeFile($content_location);
       // Copy over the file content.
       $this->updateFile($file, $resource, $mimetype);
       $file->save();
@@ -364,31 +433,14 @@ class MediaSourceService {
     $content_location
   ) {
     if ($media->hasField($destination_field)) {
-      // Construct the File.
-      $file = $this->entityTypeManager->getStorage('file')->create([
-        'uid' => $this->account->id(),
-        'uri' => $content_location,
-        'filename' => $this->fileSystem->basename($content_location),
-        'filemime' => $mimetype,
-      ]);
-      $file->setPermanent();
 
       // Validate file extension.
       $bundle = $media->bundle();
       $destination_field_config = $this->entityTypeManager->getStorage('field_config')->load("media.$bundle.$destination_field");
-      $valid_extensions = $destination_field_config->getSetting('file_extensions');
-      $validators = ['FileExtension' => ['extensions' => $valid_extensions]];
-      $errors = $this->fileValidator->validate($file, $validators);
+      $this->validateFileExtension($content_location, $mimetype, $destination_field_config);
 
-      if ($errors->count() > 0) {
-        throw new BadRequestHttpException("Invalid file extension.  Valid types are $valid_extensions");
-      }
-
-      $directory = $this->fileSystem->dirname($content_location);
-      if (!$this->fileSystem->prepareDirectory($directory, FileSystemInterface::CREATE_DIRECTORY | FileSystemInterface::MODIFY_PERMISSIONS)) {
-        throw new HttpException(500, "The destination directory does not exist, could not be created, or is not writable");
-      }
-
+      // Construct the File.
+      $file = $this->initializeFile($content_location);
       // Copy over the file content.
       $this->updateFile($file, $resource, $mimetype);
       $file->save();


### PR DESCRIPTION
**GitHub Issue**: (link)

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What does this Pull Request do?

The present flow creates file entities bearing non-dereferencable URIs; however, there exist `hook_file_create()` implementations that expect to be able to dereference the URIs, resulting in warnings, such as:

<details>

<summary>`User warning: fopen(): No such file or directory in Twistor\FlysystemStreamWrapper->triggerError()`</summary>

```
User warning: fopen(): No such file or directory in Twistor\FlysystemStreamWrapper->triggerError() (line 921 of /opt/www/drupal/vendor/twistor/flysystem-stream-wrapper/src/FlysystemStreamWrapper.php)
#0 /opt/www/drupal/core/includes/bootstrap.inc(347): _drupal_error_handler_real()
#1 [internal function]: _drupal_error_handler()
#2 /opt/www/drupal/vendor/twistor/flysystem-stream-wrapper/src/FlysystemStreamWrapper.php(921): trigger_error()
#3 /opt/www/drupal/vendor/twistor/flysystem-stream-wrapper/src/FlysystemStreamWrapper.php(899): Twistor\FlysystemStreamWrapper->triggerError()
#4 /opt/www/drupal/vendor/twistor/flysystem-stream-wrapper/src/FlysystemStreamWrapper.php(512): Twistor\FlysystemStreamWrapper->invoke()
#5 [internal function]: Twistor\FlysystemStreamWrapper->stream_open()
#6 /opt/www/drupal/modules/contrib/filehash/src/FileHash.php(257): hash_file()
#7 /opt/www/drupal/modules/contrib/filehash/filehash.module(73): Drupal\filehash\FileHash->hash()
#8 [internal function]: filehash_file_create()
#9 /opt/www/drupal/core/lib/Drupal/Core/Extension/ModuleHandler.php(426): call_user_func_array()
#10 /opt/www/drupal/core/lib/Drupal/Core/Extension/ModuleHandler.php(405): Drupal\Core\Extension\ModuleHandler->Drupal\Core\Extension\{closure}()
#11 /opt/www/drupal/core/lib/Drupal/Core/Extension/ModuleHandler.php(433): Drupal\Core\Extension\ModuleHandler->invokeAllWith()
#12 /opt/www/drupal/core/lib/Drupal/Core/Entity/EntityStorageBase.php(249): Drupal\Core\Extension\ModuleHandler->invokeAll()
#13 /opt/www/drupal/core/lib/Drupal/Core/Entity/ContentEntityStorageBase.php(903): Drupal\Core\Entity\EntityStorageBase->invokeHook()
#14 /opt/www/drupal/core/lib/Drupal/Core/Entity/ContentEntityStorageBase.php(101): Drupal\Core\Entity\ContentEntityStorageBase->invokeHook()
#15 /opt/www/drupal/modules/contrib/islandora/src/MediaSource/MediaSourceService.php(271): Drupal\Core\Entity\ContentEntityStorageBase->create()
#16 /opt/www/drupal/modules/contrib/islandora/src/Controller/MediaSourceController.php(168): Drupal\islandora\MediaSource\MediaSourceService->putToNode()
#17 [internal function]: Drupal\islandora\Controller\MediaSourceController->putToNode()
#18 /opt/www/drupal/core/lib/Drupal/Core/EventSubscriber/EarlyRenderingControllerWrapperSubscriber.php(123): call_user_func_array()
#19 /opt/www/drupal/core/lib/Drupal/Core/Render/Renderer.php(564): Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->Drupal\Core\EventSubscriber\{closure}()
#20 /opt/www/drupal/core/lib/Drupal/Core/EventSubscriber/EarlyRenderingControllerWrapperSubscriber.php(124): Drupal\Core\Render\Renderer->executeInRenderContext()
#21 /opt/www/drupal/core/lib/Drupal/Core/EventSubscriber/EarlyRenderingControllerWrapperSubscriber.php(97): Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->wrapControllerExecutionInRenderContext()
#22 /opt/www/drupal/vendor/symfony/http-kernel/HttpKernel.php(169): Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->Drupal\Core\EventSubscriber\{closure}()
#23 /opt/www/drupal/vendor/symfony/http-kernel/HttpKernel.php(81): Symfony\Component\HttpKernel\HttpKernel->handleRaw()
#24 /opt/www/drupal/core/lib/Drupal/Core/StackMiddleware/Session.php(58): Symfony\Component\HttpKernel\HttpKernel->handle()
#25 /opt/www/drupal/core/lib/Drupal/Core/StackMiddleware/KernelPreHandle.php(48): Drupal\Core\StackMiddleware\Session->handle()
#26 /opt/www/drupal/core/modules/page_cache/src/StackMiddleware/PageCache.php(106): Drupal\Core\StackMiddleware\KernelPreHandle->handle()
#27 /opt/www/drupal/core/modules/page_cache/src/StackMiddleware/PageCache.php(85): Drupal\page_cache\StackMiddleware\PageCache->pass()
#28 /opt/www/drupal/core/lib/Drupal/Core/StackMiddleware/ReverseProxyMiddleware.php(48): Drupal\page_cache\StackMiddleware\PageCache->handle()
#29 /opt/www/drupal/core/lib/Drupal/Core/StackMiddleware/NegotiationMiddleware.php(51): Drupal\Core\StackMiddleware\ReverseProxyMiddleware->handle()
#30 /opt/www/drupal/vendor/stack/builder/src/Stack/StackedHttpKernel.php(23): Drupal\Core\StackMiddleware\NegotiationMiddleware->handle()
#31 /opt/www/drupal/core/lib/Drupal/Core/DrupalKernel.php(709): Stack\StackedHttpKernel->handle()
#32 /opt/www/drupal/index.php(19): Drupal\Core\DrupalKernel->handle()
#33 {main}
```

</details>

<details>

<summary>`Warning: hash_file([...]): failed to open stream: "Drupal\flysystem\FlysystemBridge::stream_open" call failed in Drupal\filehash\FileHash->hash()`</summary>

```
Warning: hash_file([...]): failed to open stream: "Drupal\flysystem\FlysystemBridge::stream_open" call failed in Drupal\filehash\FileHash->hash() (line 257 of /opt/www/drupal/modules/contrib/filehash/src/FileHash.php)
#0 /opt/www/drupal/core/includes/bootstrap.inc(347): _drupal_error_handler_real()
#1 [internal function]: _drupal_error_handler()
#2 /opt/www/drupal/modules/contrib/filehash/src/FileHash.php(257): hash_file()
#3 /opt/www/drupal/modules/contrib/filehash/filehash.module(73): Drupal\filehash\FileHash->hash()
#4 [internal function]: filehash_file_create()
#5 /opt/www/drupal/core/lib/Drupal/Core/Extension/ModuleHandler.php(426): call_user_func_array()
#6 /opt/www/drupal/core/lib/Drupal/Core/Extension/ModuleHandler.php(405): Drupal\Core\Extension\ModuleHandler->Drupal\Core\Extension\{closure}()
#7 /opt/www/drupal/core/lib/Drupal/Core/Extension/ModuleHandler.php(433): Drupal\Core\Extension\ModuleHandler->invokeAllWith()
#8 /opt/www/drupal/core/lib/Drupal/Core/Entity/EntityStorageBase.php(249): Drupal\Core\Extension\ModuleHandler->invokeAll()
#9 /opt/www/drupal/core/lib/Drupal/Core/Entity/ContentEntityStorageBase.php(903): Drupal\Core\Entity\EntityStorageBase->invokeHook()
#10 /opt/www/drupal/core/lib/Drupal/Core/Entity/ContentEntityStorageBase.php(101): Drupal\Core\Entity\ContentEntityStorageBase->invokeHook()
#11 /opt/www/drupal/modules/contrib/islandora/src/MediaSource/MediaSourceService.php(271): Drupal\Core\Entity\ContentEntityStorageBase->create()
#12 /opt/www/drupal/modules/contrib/islandora/src/Controller/MediaSourceController.php(168): Drupal\islandora\MediaSource\MediaSourceService->putToNode()
#13 [internal function]: Drupal\islandora\Controller\MediaSourceController->putToNode()
#14 /opt/www/drupal/core/lib/Drupal/Core/EventSubscriber/EarlyRenderingControllerWrapperSubscriber.php(123): call_user_func_array()
#15 /opt/www/drupal/core/lib/Drupal/Core/Render/Renderer.php(564): Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->Drupal\Core\EventSubscriber\{closure}()
#16 /opt/www/drupal/core/lib/Drupal/Core/EventSubscriber/EarlyRenderingControllerWrapperSubscriber.php(124): Drupal\Core\Render\Renderer->executeInRenderContext()
#17 /opt/www/drupal/core/lib/Drupal/Core/EventSubscriber/EarlyRenderingControllerWrapperSubscriber.php(97): Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->wrapControllerExecutionInRenderContext()
#18 /opt/www/drupal/vendor/symfony/http-kernel/HttpKernel.php(169): Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->Drupal\Core\EventSubscriber\{closure}()
#19 /opt/www/drupal/vendor/symfony/http-kernel/HttpKernel.php(81): Symfony\Component\HttpKernel\HttpKernel->handleRaw()
#20 /opt/www/drupal/core/lib/Drupal/Core/StackMiddleware/Session.php(58): Symfony\Component\HttpKernel\HttpKernel->handle()
#21 /opt/www/drupal/core/lib/Drupal/Core/StackMiddleware/KernelPreHandle.php(48): Drupal\Core\StackMiddleware\Session->handle()
#22 /opt/www/drupal/core/modules/page_cache/src/StackMiddleware/PageCache.php(106): Drupal\Core\StackMiddleware\KernelPreHandle->handle()
#23 /opt/www/drupal/core/modules/page_cache/src/StackMiddleware/PageCache.php(85): Drupal\page_cache\StackMiddleware\PageCache->pass()
#24 /opt/www/drupal/core/lib/Drupal/Core/StackMiddleware/ReverseProxyMiddleware.php(48): Drupal\page_cache\StackMiddleware\PageCache->handle()
#25 /opt/www/drupal/core/lib/Drupal/Core/StackMiddleware/NegotiationMiddleware.php(51): Drupal\Core\StackMiddleware\ReverseProxyMiddleware->handle()
#26 /opt/www/drupal/vendor/stack/builder/src/Stack/StackedHttpKernel.php(23): Drupal\Core\StackMiddleware\NegotiationMiddleware->handle()
#27 /opt/www/drupal/core/lib/Drupal/Core/DrupalKernel.php(709): Stack\StackedHttpKernel->handle()
#28 /opt/www/drupal/index.php(19): Drupal\Core\DrupalKernel->handle()
#29 {main}
```

</details>

# What's new?

Here, the process has been adjusted to:
1. use a synthetic file entity to perform extension validation
    * this avoids creating a file entity in the DB should the extension be invalid
3. front-load the directory initialization
4. create the file initially to be 0 bytes, with the MIME-type `application/octet-stream`
    * Something of an aside, but this file has been made to be "temporary", to try to help prevent failed uploads from potentially littering Drupal's storage. Drupal should handle making it "permanent" when it is referenced by its given media.
5. "update" the file indicated by the URI, saving the stream contents and updating the MIME-type appropriately
6. finally, same as previously, the (now-completed) file entity should saved into the appropriate field of the media entity
    * just reinforcing, but: Drupal should handle updating the file entity's status to make it "permanent"

# How should this be tested?

- Pull the code in
- Derivatives should essentially work as they did, just with emitting fewer warnings (and potentially creating an empty version from the initial 0 byte contents, should the underlying storage be versioned)

# Documentation Status

* Does this change existing behaviour that's currently documented? Unknown.
* Does this change require new pages or sections of documentation? Probably not?
* Who does this need to be documented for?
* Associated documentation pull request(s): ___  or documentation issue ___

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties

