### PR TITLE
Drupal 11.3 Update ManageMembersController in line with EntityController changes

### DIFF
--- a/src/Controller/ManageMembersController.php
+++ b/src/Controller/ManageMembersController.php
@@ -2,48 +2,26 @@
 
 namespace Drupal\islandora\Controller;
 
+use Drupal\Core\Entity\EntityRepositoryInterface;
+use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Render\RendererInterface;
 use Drupal\Core\Entity\Controller\EntityController;
 use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\Core\Link;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Routing\UrlGeneratorInterface;
+use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\Core\Url;
 use Drupal\islandora\IslandoraUtils;
 use Drupal\node\NodeInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Page to select new type to add as member.
  */
 class ManageMembersController extends EntityController {
-
-  /**
-   * The entity type manager.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  /**
-   * The entity field manager.
-   *
-   * @var \Drupal\Core\Entity\EntityFieldManagerInterface
-   */
-  protected $entityFieldManager;
-
-  /**
-   * The renderer.
-   *
-   * @var \Drupal\Core\Render\RendererInterface
-   */
-  protected $renderer;
-
-  /**
-   * Islandora Utils.
-   *
-   * @var \Drupal\islandora\IslandoraUtils
-   */
-  protected $utils;
 
   /**
    * Constructor.
@@ -58,15 +36,18 @@ class ManageMembersController extends EntityController {
    *   Islandora utils.
    */
   public function __construct(
-    EntityTypeManagerInterface $entity_type_manager,
-    EntityFieldManagerInterface $entity_field_manager,
+    EntityTypeManagerInterface $entityTypeManager,
+    EntityTypeBundleInfoInterface $entityTypeBundleInfo,
+    EntityRepositoryInterface $entityRepository,
     RendererInterface $renderer,
-    IslandoraUtils $utils
+    TranslationInterface $stringTranslation,
+    UrlGeneratorInterface $urlGenerator,
+    RouteMatchInterface $routeMatch,
+    RequestStack $requestStack,
+    protected EntityFieldManagerInterface $entityFieldManager,
+    protected IslandoraUtils $utils
   ) {
-    $this->entityTypeManager = $entity_type_manager;
-    $this->entityFieldManager = $entity_field_manager;
-    $this->renderer = $renderer;
-    $this->utils = $utils;
+    parent::__construct($entityTypeManager, $entityTypeBundleInfo, $entityRepository, $renderer, $stringTranslation, $urlGenerator, $routeMatch, $requestStack);
   }
 
   /**
@@ -75,8 +56,14 @@ class ManageMembersController extends EntityController {
   public static function create(ContainerInterface $container) {
     return new static(
       $container->get('entity_type.manager'),
-      $container->get('entity_field.manager'),
+      $container->get('entity_type.bundle.info'),
+      $container->get('entity.repository'),
       $container->get('renderer'),
+      $container->get('string_translation'),
+      $container->get('url_generator'),
+      $container->get('current_route_match'),
+      $container->get('request_stack'),
+      $container->get('entity_field.manager'),
       $container->get('islandora.utils')
     );
   }

--- a/src/Controller/ManageMembersController.php
+++ b/src/Controller/ManageMembersController.php
@@ -24,16 +24,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 class ManageMembersController extends EntityController {
 
   /**
-   * Constructor.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager.
-   * @param \Drupal\Core\Entity\EntityFieldManagerInterface $entity_field_manager
-   *   The entity field manager.
-   * @param \Drupal\Core\Render\RendererInterface $renderer
-   *   The renderer.
-   * @param \Drupal\islandora\IslandoraUtils $utils
-   *   Islandora utils.
+   * Constructs a new ManageMembersController.
    */
   public function __construct(
     EntityTypeManagerInterface $entityTypeManager,


### PR DESCRIPTION
# What does this Pull Request do?

Fixes error after updating to Drupal core 11.3:

```
PHP Fatal error:  Cannot redeclare readonly property Drupal\Core\Entity\Controller\EntityController::$entityTypeManager as non-readonly Drupal\islandora\Controller\ManageMembersController::$entityTypeManager in /var/www/html/web/modules/contrib/islandora/src/Controller/ManageMembersController.php on line 18
```

# What's new?

* Adds call to `parent::__construct()` from `ManageMembersController::__construct()` which wasn't there before.
* Updated dependency injections and constructor of `ManageMembersController` to include dependencies required by the `EntityController` parent constructor.
* Auto assigned properties from `ManageMembersController` constructor, and removed explicit property declarations in `ManageMembersController`.
* Does this change add any new dependencies? 
  * No
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? 
  * No
* Could this change impact execution of existing code?
  * No, it seems nothing's instantiating ManageMembersController manually, except from the router.

# How should this be tested?

A description of what steps someone could take to:
* Reproduce the problem you are fixing (if applicable)
  * Install Drupal 11.3 with Islandora 2.17.3 and try to cache clear via drush. This produces the fatal error mentioned above.

