### PR TITLE
Fix IIIF config form for Drupal 11 and GitHub CI tests

### DIFF
--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         php-versions: ["8.3", "8.4"]
         test-suite: ["kernel", "functional", "functional-javascript"]
-        drupal-version: ["10.5", "10.6", "11.2", "11.3"]
+        drupal-version: ["10.5", "10.6", "11.2"]
     name: PHP ${{ matrix.php-versions }} | drupal ${{ matrix.drupal-version }} | test-suite ${{ matrix.test-suite }}
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
@@ -36,6 +36,7 @@ jobs:
             --rm \
             --volume $(pwd):/var/www/drupal/web/modules/contrib/$ENABLE_MODULES:ro \
             --env ENABLE_MODULES \
+            --env LINT \
             --env DRUPAL_PRACTICE \
             --env TEST_SUITE \
             --env MINK_DRIVER_ARGS_WEBDRIVER \
@@ -44,6 +45,7 @@ jobs:
            ghcr.io/islandora/ci:${{ matrix.drupal-version }}-php${{ matrix.php-versions }}
         env:
           ENABLE_MODULES: islandora
+          LINT: 0
           DRUPAL_PRACTICE: 0
           TEST_SUITE: ${{ matrix.test-suite }}
           MINK_DRIVER_ARGS_WEBDRIVER: '["chrome", {"browserName":"chrome","goog:chromeOptions":{"args":["--disable-gpu","--headless", "--no-sandbox", "--disable-dev-shm-usage"]}}, "http://chromedriver:9515"]'

--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -45,11 +45,14 @@ jobs:
            ghcr.io/islandora/ci:${{ matrix.drupal-version }}-php${{ matrix.php-versions }}
         env:
           ENABLE_MODULES: islandora
-          LINT: 0
-          DRUPAL_PRACTICE: 0
           TEST_SUITE: ${{ matrix.test-suite }}
+          # have drupal functional JS tests point to chromedriver docker container started in step above
           MINK_DRIVER_ARGS_WEBDRIVER: '["chrome", {"browserName":"chrome","goog:chromeOptions":{"args":["--disable-gpu","--headless", "--no-sandbox", "--disable-dev-shm-usage"]}}, "http://chromedriver:9515"]'
           SYMFONY_DEPRECATIONS_HELPER: weak
+          # once we get our codebase lint'd we should enable these
+          LINT: 0
+          DRUPAL_PRACTICE: 0
+
       - name: Print chromedriver logs
         if: matrix.test-suite == 'functional-javascript'
-        run: cat /tmp/chromedriver.log
+        run: docker logs chromedriver

--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -55,12 +55,12 @@ jobs:
     steps:
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: build_dir
 
       - name: Checkout islandora_ci
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: islandora/islandora_ci
           ref: joecorall-patch-1

--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -22,18 +22,10 @@ jobs:
       matrix:
         php-versions: ["8.3", "8.4"]
         test-suite: ["kernel", "functional", "functional-javascript"]
-        drupal-version: ["10.5.x", "10.6.x", "11.2.x", "11.3.x"]
+        drupal-version: ["10.5.x", "10.6.x", "11.0.x", "11.1.x"]
         mysql: ["8.0"]
         allowed_failure: [false]
-        exclude:
-          - drupal-version: "11.0.x"
-            php-versions: "8.1"
-          - drupal-version: "11.0.x"
-            php-versions: "8.2"
-          - drupal-version: "11.1.x"
-            php-versions: "8.1"
-          - drupal-version: "11.1.x"
-            php-versions: "8.2"
+
 
     name: PHP ${{ matrix.php-versions }} | drupal ${{ matrix.drupal-version }} | mysql ${{ matrix.mysql }} | test-suite ${{ matrix.test-suite }}
 

--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -9,123 +9,45 @@ on:
 
 jobs:
   build:
-    env:
-      DRUPAL_VERSION: ${{ matrix.drupal-version }}
-      SCRIPT_DIR: ${{ github.workspace }}/islandora_ci
-      DRUPAL_DIR: /opt/drupal
-      PHPUNIT_FILE: ${{ github.workspace }}/build_dir/phpunit.xml
-
-    runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.allowed_failure }}
+    runs-on: ubuntu-24.04
+    continue-on-error: false
     strategy:
       fail-fast: false
       matrix:
         php-versions: ["8.3", "8.4"]
         test-suite: ["kernel", "functional", "functional-javascript"]
-        drupal-version: ["10.5.x", "10.6.x", "11.0.x", "11.1.x"]
-        mysql: ["8.0"]
-        allowed_failure: [false]
-
-
-    name: PHP ${{ matrix.php-versions }} | drupal ${{ matrix.drupal-version }} | mysql ${{ matrix.mysql }} | test-suite ${{ matrix.test-suite }}
-
-    services:
-      mysql:
-        image: mysql:${{ matrix.mysql }}
-        env:
-          MYSQL_ALLOW_EMPTY_PASSWORD: yes
-          MYSQL_DATABASE: drupal
-        ports:
-          - 3306:3306
-      activemq:
-        image: webcenter/activemq:5.14.3
-        ports:
-          - 8161:8161
-          - 61616:61616
-          - 61613:61613
-
+        drupal-version: ["10.5", "10.6", "11.2", "11.3"]
+    name: PHP ${{ matrix.php-versions }} | drupal ${{ matrix.drupal-version }} | test-suite ${{ matrix.test-suite }}
     steps:
-
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          path: build_dir
-
-      - name: Checkout islandora_ci
-        uses: actions/checkout@v6
-        with:
-          repository: islandora/islandora_ci
-          ref: joecorall-patch-1
-          path: islandora_ci
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php-versions }}
-          tools: composer:v2
-
-      - name: Setup Mysql client
-        run: |
-          sudo apt-get update
-          sudo apt-get remove -y mysql-client mysql-common
-          sudo apt-get install -y mysql-client
-
-      - name: Cache Composer dependencies
-        uses: actions/cache@v4
-        with:
-          path: /tmp/composer-cache
-          key: ${{ runner.os }}-${{ hashFiles('**/composer.lock') }}
-
-      - name: Setup Drupal
-        run: |
-          mkdir $DRUPAL_DIR
-          $SCRIPT_DIR/travis_setup_drupal.sh
-          cd $DRUPAL_DIR
-          chmod -R u+w web/sites/default
-          mkdir -p web/sites/simpletest/browser_output
-
-      - name: Setup composer paths
-        run: |
-          git -C "$GITHUB_WORKSPACE/build_dir" checkout -b github-testing
-          cd $DRUPAL_DIR
-          composer config repositories.local path "$GITHUB_WORKSPACE/build_dir"
-          composer config minimum-stability dev
-          composer require \
-            drupal/action \
-            drupal/context \
-            "drupal/islandora:dev-github-testing as dev-2.x"
-
-      - name: Install modules
-        run: |
-          cd $DRUPAL_DIR/web
-          drush --uri=127.0.0.1:8282 en -y \
-            islandora_audio \
-            islandora_breadcrumbs \
-            islandora_iiif \
-            islandora_image \
-            islandora_video \
-            islandora_text_extraction_defaults
-
-      - name: Copy PHPunit file
-        run: cp $PHPUNIT_FILE $DRUPAL_DIR/web/core/phpunit.xml
-
-      - name: Test scripts
-        run: $SCRIPT_DIR/travis_scripts.sh
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
 
       - name: Start chromedriver
         if: matrix.test-suite == 'functional-javascript'
         run: |-
-          /usr/local/share/chromedriver-linux64/chromedriver \
-            --log-path=/tmp/chromedriver.log \
-            --verbose \
-            --allowed-ips= \
-            --allowed-origins=* &
+          docker run -d \
+            --name chromedriver \
+            --network default \
+            drupalci/webdriver-chromedriver:production \
+            chromedriver --log-path=/dev/null --verbose --allowed-ips= --allowed-origins=*
 
       - name: PHPUNIT tests
         run: |
-          cd $DRUPAL_DIR/web/core
-          $DRUPAL_DIR/vendor/bin/phpunit --testsuite "${{ matrix.test-suite }}"
-
+          docker run \
+            --rm \
+            --volume $(pwd):/var/www/drupal/web/modules/contrib/$ENABLE_MODULES:r \
+            --env ENABLE_MODULES \
+            --env DRUPAL_PRACTICE \
+            --env TEST_SUITE \
+            --env MINK_DRIVER_ARGS_WEBDRIVER \
+            --env SYMFONY_DEPRECATIONS_HELPER \
+            --network default \
+           ghcr.io/islandora/ci:${{ matrix.drupal-version }}-php${{ matrix.php-versions }}
+        env:
+          ENABLE_MODULES: islandora
+          DRUPAL_PRACTICE: 0
+          TEST_SUITE: ${{ matrix.test-suite }}
+          MINK_DRIVER_ARGS_WEBDRIVER: '["chrome", {"browserName":"chrome","goog:chromeOptions":{"args":["--disable-gpu","--headless", "--no-sandbox", "--disable-dev-shm-usage"]}}, "http://chromedriver:9515"]'
+          SYMFONY_DEPRECATIONS_HELPER: weak
       - name: Print chromedriver logs
         if: matrix.test-suite == 'functional-javascript'
         run: cat /tmp/chromedriver.log

--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           docker run \
             --rm \
-            --volume $(pwd):/var/www/drupal/web/modules/contrib/$ENABLE_MODULES:r \
+            --volume $(pwd):/var/www/drupal/web/modules/contrib/$ENABLE_MODULES:ro \
             --env ENABLE_MODULES \
             --env DRUPAL_PRACTICE \
             --env TEST_SUITE \

--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         php-versions: ["8.3", "8.4"]
         test-suite: ["kernel", "functional", "functional-javascript"]
-        drupal-version: ["10.5.x", "10.6.x", "11.2.x", "11.3.x"]
+        drupal-version: ["10.5.x", "10.6.x", "11.0.x", "11.1.x"]
         mysql: ["8.0"]
         allowed_failure: [false]
 

--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -20,9 +20,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ["8.1", "8.2", "8.3"]
+        php-versions: ["8.3", "8.4"]
         test-suite: ["kernel", "functional", "functional-javascript"]
-        drupal-version: ["10.3.x", "10.4.x", "11.0.x", "11.1.x"]
+        drupal-version: ["10.5.x", "10.6.x", "11.2.x", "11.3.x"]
         mysql: ["8.0"]
         allowed_failure: [false]
         exclude:

--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         php-versions: ["8.3", "8.4"]
         test-suite: ["kernel", "functional", "functional-javascript"]
-        drupal-version: ["10.5", "10.6", "11.2"]
+        drupal-version: ["10.5", "10.6", "11.2", "11.3"]
     name: PHP ${{ matrix.php-versions }} | drupal ${{ matrix.drupal-version }} | test-suite ${{ matrix.test-suite }}
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6

--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -63,7 +63,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: islandora/islandora_ci
-          ref: github-actions
+          ref: joecorall-patch-1
           path: islandora_ci
 
       - name: Setup PHP

--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -21,6 +21,9 @@ jobs:
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
 
+      - name: start activemq
+        run: docker run -d --name activemq --network default webcenter/activemq:5.14.3
+
       - name: Start chromedriver
         if: matrix.test-suite == 'functional-javascript'
         run: |-

--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         php-versions: ["8.3", "8.4"]
         test-suite: ["kernel", "functional", "functional-javascript"]
-        drupal-version: ["10.5.x", "10.6.x", "11.0.x", "11.1.x"]
+        drupal-version: ["10.5.x", "10.6.x", "11.2.x", "11.3.x"]
         mysql: ["8.0"]
         allowed_failure: [false]
 

--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -91,7 +91,7 @@ jobs:
           composer config repositories.local path "$GITHUB_WORKSPACE/build_dir"
           composer config minimum-stability dev
           composer require \
-            drupal/actions \
+            drupal/action \
             drupal/context \
             "drupal/islandora:dev-github-testing as dev-2.x"
 

--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -21,15 +21,18 @@ jobs:
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
 
+      - name: create docker network
+        run: docker network create ci-default
+
       - name: start activemq
-        run: docker run -d --name activemq --network default webcenter/activemq:5.14.3
+        run: docker run -d --name activemq --network ci-default webcenter/activemq:5.14.3
 
       - name: Start chromedriver
         if: matrix.test-suite == 'functional-javascript'
         run: |-
           docker run -d \
             --name chromedriver \
-            --network default \
+            --network ci-default \
             drupalci/webdriver-chromedriver:production \
             chromedriver --log-path=/dev/null --verbose --allowed-ips= --allowed-origins=*
 
@@ -44,7 +47,7 @@ jobs:
             --env TEST_SUITE \
             --env MINK_DRIVER_ARGS_WEBDRIVER \
             --env SYMFONY_DEPRECATIONS_HELPER \
-            --network default \
+            --network ci-default \
            ghcr.io/islandora/ci:${{ matrix.drupal-version }}-php${{ matrix.php-versions }}
         env:
           ENABLE_MODULES: islandora

--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -90,12 +90,21 @@ jobs:
           cd $DRUPAL_DIR
           composer config repositories.local path "$GITHUB_WORKSPACE/build_dir"
           composer config minimum-stability dev
-          composer require "drupal/islandora:dev-github-testing as dev-2.x"
+          composer require \
+            drupal/actions \
+            drupal/context \
+            "drupal/islandora:dev-github-testing as dev-2.x"
 
       - name: Install modules
         run: |
           cd $DRUPAL_DIR/web
-          drush --uri=127.0.0.1:8282 en -y islandora_audio islandora_breadcrumbs islandora_iiif islandora_image islandora_video islandora_text_extraction_defaults
+          drush --uri=127.0.0.1:8282 en -y \
+            islandora_audio \
+            islandora_breadcrumbs \
+            islandora_iiif \
+            islandora_image \
+            islandora_video \
+            islandora_text_extraction_defaults
 
       - name: Copy PHPunit file
         run: cp $PHPUNIT_FILE $DRUPAL_DIR/web/core/phpunit.xml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,6 +92,12 @@ docker run -d \
     chromedriver --log-path=/dev/null --verbose --allowed-ips= --allowed-origins=*
 ```
 
+If you're running functional tests, start an activemq docker container
+
+```bash
+docker run -d --name activemq --network default webcenter/activemq:5.14.3
+```
+
 Run the tests
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,44 @@ Take a look at [Creating a pull request](https://help.github.com/articles/creati
 
 You may want to read [Syncing a fork](https://help.github.com/articles/syncing-a-fork) for instructions on how to keep your fork up to date with the latest changes of the upstream (official) repository.
 
+## Testing locally
+
+The CI tests that run on pull requests in GitHub leverage the docker images built in [islandora/islandora_ci](https://github.com/Islandora/islandora_ci). The CI tests a wide range of PHP and Drupal version combinations. You can run these same tests locally if you have docker installed.
+
+Set which Drupal and PHP version you want to test
+
+```bash
+DRUPAL_VERSION=11.3
+PHP_VERSION=8.3
+```
+
+Optionally, if you want to run a specific test suite (e.g. `kernel`), provide it via the `TEST_SUITE` environment variable (e.g. `TEST_SUITE=kernel`). Leave the value blank if you want to run all tests.
+
+Also optional, if you're running functional javascript tests, start a chromedriver docker container
+
+```bash
+docker run -d \
+    --rm \
+    --name chromedriver \
+    --network ci-default \
+    drupalci/webdriver-chromedriver:production \
+    chromedriver --log-path=/dev/null --verbose --allowed-ips= --allowed-origins=*
+```
+
+Run the tests
+
+```bash
+docker run \
+    --name drupal-ci-$DRUPAL_VERSION-$PHP_VERSION
+    --rm \
+    --volume $(pwd):/var/www/drupal/web/modules/contrib/islandora:ro \
+    --env ENABLE_MODULES=islandora \
+    --env TEST_SUITE="${TEST_SUITE:-} \
+    --env MINK_DRIVER_ARGS_WEBDRIVER='["chrome", {"browserName":"chrome","goog:chromeOptions":{"args":["--disable-gpu","--headless", "--no-sandbox", "--disable-dev-shm-usage"]}}, "http://chromedriver:9515"]' \
+    --network ci-default \
+    ghcr.io/islandora/ci:$DRUPAL_VERSION-php$PHP_VERSION
+```
+
 ## License Agreements
 
 The Islandora Foundation requires that contributors complete a [Contributor License Agreement](http://islandora.ca/sites/default/files/islandora_cla.pdf) or be covered by a [Corporate Contributor License Agreement](http://islandora.ca/sites/default/files/islandora_ccla.pdf). The signed copy of the license agreement should be sent to <a href="mailto:community@islandora.ca?Subject=Contributor%20License%20Agreement" target="_top">community@islandora.ca</a>. This license is for your protection as a contributor as well as the protection of the Foundation and its users; it does not change your rights to use your own contributions for any other purpose. A list of current CLAs is kept [here](https://github.com/Islandora/islandora/wiki/Contributor-License-Agreements).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ docker run -d \
 If you're running functional tests, start an activemq docker container
 
 ```bash
-docker run -d --name activemq --network default webcenter/activemq:5.14.3
+docker run -d --name activemq --network ci-default webcenter/activemq:5.14.3
 ```
 
 Run the tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,11 +102,11 @@ Run the tests
 
 ```bash
 docker run \
-    --name drupal-ci-$DRUPAL_VERSION-$PHP_VERSION
+    --name drupal-ci-$DRUPAL_VERSION-$PHP_VERSION \
     --rm \
     --volume $(pwd):/var/www/drupal/web/modules/contrib/islandora:ro \
     --env ENABLE_MODULES=islandora \
-    --env TEST_SUITE="${TEST_SUITE:-} \
+    --env TEST_SUITE="${TEST_SUITE:-}" \
     --env MINK_DRIVER_ARGS_WEBDRIVER='["chrome", {"browserName":"chrome","goog:chromeOptions":{"args":["--disable-gpu","--headless", "--no-sandbox", "--disable-dev-shm-usage"]}}, "http://chromedriver:9515"]' \
     --network ci-default \
     ghcr.io/islandora/ci:$DRUPAL_VERSION-php$PHP_VERSION

--- a/config/install/islandora.settings.yml
+++ b/config/install/islandora.settings.yml
@@ -1,4 +1,4 @@
-broker_url: 'tcp://localhost:61613'
+broker_url: 'tcp://activemq:61613'
 jwt_expiry: '+2 hour'
 delete_media_and_files: TRUE
 gemini_pseudo_bundles: []

--- a/modules/islandora_iiif/src/Form/IslandoraIIIFConfigForm.php
+++ b/modules/islandora_iiif/src/Form/IslandoraIIIFConfigForm.php
@@ -3,6 +3,7 @@
 namespace Drupal\islandora_iiif\Form;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\TypedConfigManagerInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Component\Utility\UrlHelper;
@@ -26,13 +27,19 @@ class IslandoraIIIFConfigForm extends ConfigFormBase {
   /**
    * IslandoraIIIFConfigForm constructor.
    *
-   * @param \GuzzleHttp\ClientInterface $http_client
-   *   A Guzzle client object.
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
    *   The config factory service.
+   * @param \Drupal\Core\Config\TypedConfigManagerInterface $typed_config_manager
+   *   The typed config manager.
+   * @param \GuzzleHttp\ClientInterface $http_client
+   *   A Guzzle client object.
    */
-  public function __construct(ClientInterface $http_client, ConfigFactoryInterface $config_factory) {
-    parent::__construct($config_factory);
+  public function __construct(
+    ConfigFactoryInterface $config_factory,
+    TypedConfigManagerInterface $typed_config_manager,
+    ClientInterface $http_client
+  ) {
+    parent::__construct($config_factory, $typed_config_manager);
     $this->httpClient = $http_client;
   }
 
@@ -41,8 +48,9 @@ class IslandoraIIIFConfigForm extends ConfigFormBase {
    */
   public static function create(ContainerInterface $container) {
     return new static(
+      $container->get('config.factory'),
+      $container->get('config.typed'),
       $container->get('http_client'),
-      $container->get('config.factory')
     );
   }
 


### PR DESCRIPTION
Drupal 11's `ConfigFormBase::_construct` requires a second parameter: https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Form%21ConfigFormBase.php/function/ConfigFormBase%3A%3A__construct/11.x

Drupal 10.3 is the minimum version for `drupal/islandora`, and it makes the second parameter optional. So this code change won't break anyone on Drupal 10: https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Form%21ConfigFormBase.php/function/ConfigFormBase%3A%3A__construct/10

Without this code change, in Drupal 11 when viewing `/admin/config/islandora/iiif` an error is thrown

```
ArgumentCountError: Too few arguments to function Drupal\Core\Form\ConfigFormBase::__construct(), 1 passed in /var/www/drupal/web/modules/contrib/islandora/modules/islandora_iiif/src/Form/IslandoraIIIFConfigForm.php on line 35 and exactly 2 expected in Drupal\Core\Form\ConfigFormBase->__construct() (line 44 of /var/www/drupal/web/core/lib/Drupal/Core/Form/ConfigFormBase.php).
```
# Additional Notes:

The CI tests we use for PRs are broken. I tried fixing them with https://github.com/Islandora/islandora_ci/pull/19 but the dependency matrix was just getting too complicated. So instead of setting up the environment in the GitHub runner for each PR, I opted to build Drupal docker images with different Drupal version and PHP version combinations in https://github.com/Islandora/islandora_ci/tree/main. Namely in https://github.com/Islandora/islandora_ci/commit/8112f7f02355f4542462d593f9363f52301103f2 which created the ci packages: https://github.com/Islandora/islandora_ci/pkgs/container/ci

Notice https://github.com/Islandora/islandora_ci's default branch is `github-actions` rather than `main`. I propose we merge this PR, change the default branch in https://github.com/Islandora/islandora_ci to `main`. Then fix the failing Drupal 11.2 and 11.3 tests which will be helped by https://github.com/Islandora/islandora/pull/1093. We can also update [our other projects](https://github.com/search?q=org%3AIslandora+islandora_ci+language%3AYAML&type=code&l=YAML) to use this new approach for testing.

## Default update

Also updated the default activemq address to lookup using docker network namespace DNS resolution rather than assuming activemq is running on localhost https://github.com/Islandora/islandora/pull/1094/commits/e9d0a73c8f24b18987278e49ce4758818fa0960c

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
