### PR TITLE
Fix IIIF manifest output for IIIF Image API v3

### DIFF
--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         php-versions: ["8.3", "8.4"]
-        test-suite: ["kernel", "functional", "functional-javascript"]
+        test-suite: ["kernel,unit", "functional", "functional-javascript"]
         drupal-version: ["10.5", "10.6", "11.2", "11.3"]
     name: PHP ${{ matrix.php-versions }} | drupal ${{ matrix.drupal-version }} | test-suite ${{ matrix.test-suite }}
     steps:

--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         php-versions: ["8.3", "8.4"]
-        test-suite: ["kernel,unit", "functional", "functional-javascript"]
+        test-suite: ["kernel", "unit", "functional", "functional-javascript"]
         drupal-version: ["10.5", "10.6", "11.2", "11.3"]
     name: PHP ${{ matrix.php-versions }} | drupal ${{ matrix.drupal-version }} | test-suite ${{ matrix.test-suite }}
     steps:

--- a/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
+++ b/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
@@ -527,10 +527,6 @@ class IIIFManifest extends StylePluginBase {
       $service['@context'] = 'http://iiif.io/api/image/3/context.json';
       $service['profile'] = 'level2';
     }
-    elseif (str_contains($iiif_url, '/iiif/2/')) {
-      $service['@context'] = 'http://iiif.io/api/image/2/context.json';
-      $service['profile'] = 'http://iiif.io/api/image/2/profiles/level2.json';
-    }
 
     return $service;
   }

--- a/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
+++ b/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
@@ -332,6 +332,9 @@ class IIIFManifest extends StylePluginBase {
 
           $mime_type = $image->entity->getMimeType();
           $iiif_url = rtrim($iiif_address, '/') . '/' . urlencode($file_url);
+          $full_image_url = $this->buildFullImageUrl($iiif_url);
+          $thumbnail_url = $this->buildThumbnailUrl($iiif_url);
+          $iiif_service = $this->getImageServiceDescriptor($iiif_url);
 
           // Create the necessary ID's for the canvas and annotation.
           $canvas_id = $iiif_base_id . '/canvas/' . $entity->id();
@@ -357,19 +360,23 @@ class IIIFManifest extends StylePluginBase {
                 "@type" => "oa:Annotation",
                 'motivation' => 'sc:painting',
                 'resource' => [
-                  '@id' => $iiif_url . '/full/full/0/default.jpg',
+                  '@id' => $full_image_url,
                   "@type" => "dctypes:Image",
-                  'format' => $mime_type,
+                  // The painted resource is the JPEG derivative, not the
+                  // original source MIME type.
+                  'format' => 'image/jpeg',
                   'height' => $height,
                   'width' => $width,
-                  'service' => [
-                    '@id' => $iiif_url,
-                    '@context' => 'http://iiif.io/api/image/2/context.json',
-                    'profile' => 'http://iiif.io/api/image/2/profiles/level2.json',
-                  ],
+                  'service' => $iiif_service,
                 ],
                 'on' => $canvas_id,
               ],
+            ],
+            'thumbnail' => [
+              '@id' => $thumbnail_url,
+              '@type' => 'dctypes:Image',
+              'format' => 'image/jpeg',
+              'service' => $iiif_service,
             ],
           ];
 
@@ -498,6 +505,62 @@ class IIIFManifest extends StylePluginBase {
     }
 
     return [0, 0];
+  }
+
+  /**
+   * Build a IIIF Image API service descriptor from the service URL.
+   *
+   * @param string $iiif_url
+   *   The IIIF image service URL.
+   *
+   * @return array
+   *   A service block for the manifest image resource.
+   */
+  protected function getImageServiceDescriptor(string $iiif_url): array {
+    $service = [
+      '@id' => $iiif_url,
+      '@context' => 'http://iiif.io/api/image/2/context.json',
+      'profile' => 'http://iiif.io/api/image/2/profiles/level2.json',
+    ];
+
+    if (str_contains($iiif_url, '/iiif/3/')) {
+      $service['@context'] = 'http://iiif.io/api/image/3/context.json';
+      $service['profile'] = 'level2';
+    }
+    elseif (str_contains($iiif_url, '/iiif/2/')) {
+      $service['@context'] = 'http://iiif.io/api/image/2/context.json';
+      $service['profile'] = 'http://iiif.io/api/image/2/profiles/level2.json';
+    }
+
+    return $service;
+  }
+
+  /**
+   * Build the painted image URL from a IIIF image service URL.
+   *
+   * @param string $iiif_url
+   *   The IIIF image service URL.
+   *
+   * @return string
+   *   A full-size image request URL.
+   */
+  protected function buildFullImageUrl(string $iiif_url): string {
+    return str_contains($iiif_url, '/iiif/3/')
+      ? $iiif_url . '/full/max/0/default.jpg'
+      : $iiif_url . '/full/full/0/default.jpg';
+  }
+
+  /**
+   * Build the thumbnail URL from a IIIF image service URL.
+   *
+   * @param string $iiif_url
+   *   The IIIF image service URL.
+   *
+   * @return string
+   *   A thumbnail image request URL.
+   */
+  protected function buildThumbnailUrl(string $iiif_url): string {
+    return $iiif_url . '/full/200,/0/default.jpg';
   }
 
   /**

--- a/modules/islandora_iiif/tests/src/Unit/IIIFManifestTest.php
+++ b/modules/islandora_iiif/tests/src/Unit/IIIFManifestTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Drupal\Tests\islandora_iiif\Unit;
+
+use Drupal\islandora_iiif\Plugin\views\style\IIIFManifest;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests IIIF manifest image service metadata helpers.
+ *
+ * @group islandora_iiif
+ */
+class IIIFManifestTest extends TestCase {
+
+  /**
+   * Creates a manifest plugin instance without invoking the constructor.
+   */
+  protected function createManifestPlugin(): TestableIIIFManifest {
+    return (new \ReflectionClass(TestableIIIFManifest::class))
+      ->newInstanceWithoutConstructor();
+  }
+
+  /**
+   * Tests the v2 image service descriptor.
+   */
+  public function testV2ImageServiceDescriptor(): void {
+    $plugin = $this->createManifestPlugin();
+    $url = 'https://example.test/iiif/2/example-id';
+
+    $service = $plugin->publicGetImageServiceDescriptor($url);
+
+    $this->assertSame($url, $service['@id']);
+    $this->assertSame('http://iiif.io/api/image/2/context.json', $service['@context']);
+    $this->assertSame('http://iiif.io/api/image/2/profiles/level2.json', $service['profile']);
+  }
+
+  /**
+   * Tests the v3 image service descriptor.
+   */
+  public function testV3ImageServiceDescriptor(): void {
+    $plugin = $this->createManifestPlugin();
+    $url = 'https://example.test/iiif/3/example-id';
+
+    $service = $plugin->publicGetImageServiceDescriptor($url);
+
+    $this->assertSame($url, $service['@id']);
+    $this->assertSame('http://iiif.io/api/image/3/context.json', $service['@context']);
+    $this->assertSame('level2', $service['profile']);
+  }
+
+  /**
+   * Tests the full image URL for Image API 2.
+   */
+  public function testV2FullImageUrl(): void {
+    $plugin = $this->createManifestPlugin();
+    $url = 'https://example.test/iiif/2/example-id';
+
+    $this->assertSame(
+      'https://example.test/iiif/2/example-id/full/full/0/default.jpg',
+      $plugin->publicBuildFullImageUrl($url)
+    );
+  }
+
+  /**
+   * Tests the full image URL for Image API 3.
+   */
+  public function testV3FullImageUrl(): void {
+    $plugin = $this->createManifestPlugin();
+    $url = 'https://example.test/iiif/3/example-id';
+
+    $this->assertSame(
+      'https://example.test/iiif/3/example-id/full/max/0/default.jpg',
+      $plugin->publicBuildFullImageUrl($url)
+    );
+  }
+
+  /**
+   * Tests the thumbnail URL.
+   */
+  public function testThumbnailUrl(): void {
+    $plugin = $this->createManifestPlugin();
+    $url = 'https://example.test/iiif/3/example-id';
+
+    $this->assertSame(
+      'https://example.test/iiif/3/example-id/full/200,/0/default.jpg',
+      $plugin->publicBuildThumbnailUrl($url)
+    );
+  }
+
+}
+
+/**
+ * Testable wrapper exposing protected helper methods.
+ */
+class TestableIIIFManifest extends IIIFManifest {
+
+  /**
+   * Exposes the protected service helper for unit testing.
+   */
+  public function publicGetImageServiceDescriptor(string $iiif_url): array {
+    return $this->getImageServiceDescriptor($iiif_url);
+  }
+
+  /**
+   * Exposes the protected full image URL helper for unit testing.
+   */
+  public function publicBuildFullImageUrl(string $iiif_url): string {
+    return $this->buildFullImageUrl($iiif_url);
+  }
+
+  /**
+   * Exposes the protected thumbnail URL helper for unit testing.
+   */
+  public function publicBuildThumbnailUrl(string $iiif_url): string {
+    return $this->buildThumbnailUrl($iiif_url);
+  }
+
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -51,6 +51,7 @@
   </php>
   <testsuites>
     <testsuite name="unit">
+      <directory>../modules/contrib/islandora/modules/*/tests/src/Unit</directory>
     </testsuite>
     <testsuite name="kernel">
       <directory>../modules/contrib/islandora/tests/src/Kernel</directory>


### PR DESCRIPTION
# What does this Pull Request do?

This updates `islandora_iiif` manifest generation to emit consistent Image API metadata for both IIIF Image API 2 and 3 services.

# What's new?

- Detect Image API version from the IIIF service URL
- Emit the correct service `@context` / `profile` for:
  - `/iiif/2/`
  - `/iiif/3/`
- Use the correct painted image URL for v3:
  - v2: `/full/full/0/default.jpg`
  - v3: `/full/max/0/default.jpg`
- Add explicit canvas thumbnails
- Keep painted image `format` aligned with the declared JPEG derivative URL
- Extract URL/service helper logic for testability
- Add regression tests covering v2/v3 service metadata and URL generation

# How should this be tested?

A description of what steps someone could take to:
* Reproduce the problem you are fixing (if applicable)
* Test that the Pull Request does what is intended.
* Please be as detailed as possible.
* Good testing instructions help get your PR completed faster.

# Documentation Status

* Does this change existing behaviour that's currently documented?
* Does this change require new pages or sections of documentation?
* Who does this need to be documented for?
* Associated documentation pull request(s): ___  or documentation issue ___

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
