### PR TITLE
Fix type-specific media derivative attachment.

### DIFF
--- a/src/MediaSource/MediaSourceService.php
+++ b/src/MediaSource/MediaSourceService.php
@@ -441,61 +441,67 @@ class MediaSourceService {
     $existing = $this->islandoraUtils->getMediaReferencingNodeAndTerm($node, $taxonomy_term);
 
     if (!empty($existing)) {
-      // Just update already existing media.
-      $media = $this->entityTypeManager->getStorage('media')->load(reset($existing));
-      $this->updateSourceField(
+      foreach ($existing as $candidate) {
+        /** @var \Drupal\media\MediaInterface $media */
+        $media = $this->entityTypeManager->getStorage('media')->load($candidate);
+        if ($media->bundle() !== $media_type->id()) {
+          // Media unrelated to the target derivative; skip it.
+          continue;
+        }
+        // Just update already existing media.
+        $this->updateSourceField(
           $media,
           $resource,
           $mimetype
-      );
-      return FALSE;
-    }
-    else {
-      // Otherwise, the media doesn't exist yet.
-      // So make everything by hand.
-      // Get the source field for the media type.
-      $bundle = $media_type->id();
-      $source_field = $this->getSourceFieldName($bundle);
-      if (empty($source_field)) {
-        throw new NotFoundHttpException("Source field not set for $bundle media");
+        );
+        return FALSE;
       }
-
-      // Validate file extension.
-      $source_field_config = $this->entityTypeManager->getStorage('field_config')->load("media.$bundle.$source_field");
-      $this->validateFileExtension($content_location, $mimetype, $source_field_config);
-
-      // Construct the File.
-      $file = $this->initializeFile($content_location);
-      // Copy over the file content.
-      $this->updateFile($file, $resource, $mimetype);
-      $file->save();
-
-      // Construct the Media.
-      $media_struct = [
-        'bundle' => $bundle,
-        'uid' => $this->account->id(),
-        'name' => $file->getFilename(),
-        'langcode' => $this->languageManager->getDefaultLanguage()->getId(),
-        "$source_field" => [
-          'target_id' => $file->id(),
-        ],
-        IslandoraUtils::MEDIA_OF_FIELD => [
-          'target_id' => $node->id(),
-        ],
-        IslandoraUtils::MEDIA_USAGE_FIELD => [
-          'target_id' => $taxonomy_term->id(),
-        ],
-      ];
-
-      // Set alt text.
-      if ($source_field_config->getSetting('alt_field') && $source_field_config->getSetting('alt_field_required')) {
-        $media_struct[$source_field]['alt'] = $file->getFilename();
-      }
-
-      $media = $this->entityTypeManager->getStorage('media')->create($media_struct);
-      $media->save();
-      return $media;
     }
+
+    // Otherwise, the media doesn't exist yet.
+    // So make everything by hand.
+    // Get the source field for the media type.
+    $bundle = $media_type->id();
+    $source_field = $this->getSourceFieldName($bundle);
+    if (empty($source_field)) {
+      throw new NotFoundHttpException("Source field not set for $bundle media");
+    }
+
+    // Validate file extension.
+    $source_field_config = $this->entityTypeManager->getStorage('field_config')->load("media.$bundle.$source_field");
+    $this->validateFileExtension($content_location, $mimetype, $source_field_config);
+
+    // Construct the File.
+    $file = $this->initializeFile($content_location);
+    // Copy over the file content.
+    $this->updateFile($file, $resource, $mimetype);
+    $file->save();
+
+    // Construct the Media.
+    $media_struct = [
+      'bundle' => $bundle,
+      'uid' => $this->account->id(),
+      'name' => $file->getFilename(),
+      'langcode' => $this->languageManager->getDefaultLanguage()->getId(),
+      "$source_field" => [
+        'target_id' => $file->id(),
+      ],
+      IslandoraUtils::MEDIA_OF_FIELD => [
+        'target_id' => $node->id(),
+      ],
+      IslandoraUtils::MEDIA_USAGE_FIELD => [
+        'target_id' => $taxonomy_term->id(),
+      ],
+    ];
+
+    // Set alt text.
+    if ($source_field_config->getSetting('alt_field') && $source_field_config->getSetting('alt_field_required')) {
+      $media_struct[$source_field]['alt'] = $file->getFilename();
+    }
+
+    $media = $this->entityTypeManager->getStorage('media')->create($media_struct);
+    $media->save();
+    return $media;
 
   }
 


### PR DESCRIPTION
**GitHub Issue**: (link)

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What does this Pull Request do?

Derivative actions indicate the type of media they should create.

When uploading derivatives, it does not presently require existing media bearing the media use term to be of the same type before updating its content.

This PR filters the media considered to be updated to be those of the specified type, such that multiple media of different media types/bundles might share the same media use term, while related to the same node.

# What's new?

Filters the media considered to be updated to be those of the specified type, such that multiple media of different media types/bundles might share the same media use term, while related to the same node.

Where there's no media that matches both the media use term _and_ media type/bundle, a new media entity should be created matching both.

* Does this change add any new dependencies? No.
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)?  No.
* Could this change impact execution of existing code? Unlikely?

# How should this be tested?

- create a media of a different type than an expected derivative on an object
- delete the derivative meda
- trigger the derivative

Without this PR, the media of the media type unrelated to the derivative will be updated with the derivative contents.
With this PR, a new media of the media type specified in the derivative should be created with the derivative contents.

# Documentation Status

* Does this change existing behaviour that's currently documented? Don't believe so.
* Does this change require new pages or sections of documentation? Shouldn't?
* Who does this need to be documented for? 
* Associated documentation pull request(s): ___  or documentation issue ___

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
