### PR TITLE
Drupal 11.4 compatibility fix

### DIFF
--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         php-versions: ["8.3", "8.4"]
         test-suite: ["kernel", "unit", "functional", "functional-javascript"]
-        drupal-version: ["10.5", "10.6", "11.2", "11.3"]
+        drupal-version: ["10.6", "11.3", "11.4"]
     name: PHP ${{ matrix.php-versions }} | drupal ${{ matrix.drupal-version }} | test-suite ${{ matrix.test-suite }}
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6

--- a/src/Plugin/Field/FieldFormatter/IslandoraImageFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/IslandoraImageFormatter.php
@@ -37,11 +37,6 @@ class IslandoraImageFormatter extends ImageFormatter {
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    // Let the parent formatter build the instance so this class stays
-    // compatible across core versions regardless of changes to
-    // ImageFormatter::__construct() (e.g. the ImageDerivativeUtilities
-    // argument added in Drupal 11.4). Islandora's own dependencies are
-    // then set on the instance.
     $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
     $instance->utils = $container->get('islandora.utils');
     $instance->mediaSourceService = $container->get('islandora.media_source_service');

--- a/src/Plugin/Field/FieldFormatter/IslandoraImageFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/IslandoraImageFormatter.php
@@ -2,17 +2,11 @@
 
 namespace Drupal\islandora\Plugin\Field\FieldFormatter;
 
-use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Field\Attribute\FieldFormatter;
-use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Field\FieldItemListInterface;
-use Drupal\Core\File\FileUrlGeneratorInterface;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\image\Plugin\Field\FieldFormatter\ImageFormatter;
-use Drupal\islandora\IslandoraUtils;
-use Drupal\islandora\MediaSource\MediaSourceService;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -40,81 +34,18 @@ class IslandoraImageFormatter extends ImageFormatter {
   protected $mediaSourceService;
 
   /**
-   * Constructs an IslandoraImageFormatter object.
-   *
-   * @param string $plugin_id
-   *   The plugin_id for the formatter.
-   * @param mixed $plugin_definition
-   *   The plugin implementation definition.
-   * @param \Drupal\Core\Field\FieldDefinitionInterface $field_definition
-   *   The definition of the field to which the formatter is associated.
-   * @param array $settings
-   *   The formatter settings.
-   * @param string $label
-   *   The formatter label display setting.
-   * @param string $view_mode
-   *   The view mode.
-   * @param array $third_party_settings
-   *   Any third party settings settings.
-   * @param \Drupal\Core\Session\AccountInterface $current_user
-   *   The current user.
-   * @param \Drupal\Core\Entity\EntityStorageInterface $image_style_storage
-   *   The image style storage.
-   * @param \Drupal\islandora\IslandoraUtils $utils
-   *   Islandora utils.
-   * @param \Drupal\Core\File\FileUrlGeneratorInterface $file_url_generator
-   *   The File URL Generator.
-   * @param \Drupal\islandora\MediaSource\MediaSourceService $media_source_service
-   *   Utils to get the source file from media.
-   */
-  public function __construct(
-    $plugin_id,
-    $plugin_definition,
-    FieldDefinitionInterface $field_definition,
-    array $settings,
-    $label,
-    $view_mode,
-    array $third_party_settings,
-    AccountInterface $current_user,
-    EntityStorageInterface $image_style_storage,
-    IslandoraUtils $utils,
-    FileUrlGeneratorInterface $file_url_generator,
-    MediaSourceService $media_source_service,
-  ) {
-    parent::__construct(
-      $plugin_id,
-      $plugin_definition,
-      $field_definition,
-      $settings,
-      $label,
-      $view_mode,
-      $third_party_settings,
-      $current_user,
-      $image_style_storage,
-      $file_url_generator
-    );
-    $this->utils = $utils;
-    $this->mediaSourceService = $media_source_service;
-  }
-
-  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    return new static(
-      $plugin_id,
-      $plugin_definition,
-      $configuration['field_definition'],
-      $configuration['settings'],
-      $configuration['label'],
-      $configuration['view_mode'],
-      $configuration['third_party_settings'],
-      $container->get('current_user'),
-      $container->get('entity_type.manager')->getStorage('image_style'),
-      $container->get('islandora.utils'),
-      $container->get('file_url_generator'),
-      $container->get('islandora.media_source_service')
-    );
+    // Let the parent formatter build the instance so this class stays
+    // compatible across core versions regardless of changes to
+    // ImageFormatter::__construct() (e.g. the ImageDerivativeUtilities
+    // argument added in Drupal 11.4). Islandora's own dependencies are
+    // then set on the instance.
+    $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+    $instance->utils = $container->get('islandora.utils');
+    $instance->mediaSourceService = $container->get('islandora.media_source_service');
+    return $instance;
   }
 
   /**


### PR DESCRIPTION
# What does this Pull Request do?

After updating to Drupal 11.4.x my views that had images in them stopped working (eg. my search results with the thumbnails). It threw this error:

> ArgumentCountError: Too few arguments to function Drupal\image\Plugin\Field\FieldFormatter\ImageFormatter::__construct(), 10 passed in /var/www/drupal/web/modules/contrib/islandora/src/Plugin/Field/FieldFormatter/IslandoraImageFormatter.php on line 84 and exactly 11 expected in Drupal\image\Plugin\Field\FieldFormatter\ImageFormatter->__construct() (line 32 of /var/www/drupal/web/core/modules/image/src/Plugin/Field/FieldFormatter/ImageFormatter.php).

This PR mostly comes from Claude, so I'm going to copy the relevant conversation here:

> What happened. Drupal 11.4.0 rewrote ImageFormatter. The constructor moved to property promotion with typed properties (so $fileUrlGenerator is now protected FileUrlGeneratorInterface $fileUrlGenerator), and a new required argument, ImageDerivativeUtilities $imageDerivativeUtilities, was added — that's change record node/3567619. IslandoraImageFormatter extends ImageFormatter and calls parent::__construct() with the old ten-argument signature, so it now comes up one short. Nothing about your view is actually broken; the formatter plugin just can't be instantiated. 
> [Drupal](https://www.drupal.org/project/media_directories/issues/3607946)

> That confirms it — pattern (b), and line 84 is the parent::__construct() call. Islandora's constructor takes twelve arguments and forwards ten to core, which now wants eleven.

> The patch removes the constructor override entirely rather than adding the missing argument. The whole class of bug here is that Islandora is manually reassembling core's constructor call — so the durable fix is to stop doing that and let parent::create() build the instance, then set Islandora's two services on it afterward:

> Nothing else in the class touched the constructor's dependencies directly — viewElements() only uses $this->utils and $this->mediaSourceService, both still populated. Four use statements became unused once the constructor went, so those are dropped too.
> This also works unchanged on 11.3, which the add-the-argument approach doesn't, since ImageDerivativeUtilities doesn't exist there.

> Let me build the clean version. There's one extra cleanup the earlier draft missed: once the constructor is gone, the IslandoraUtils and MediaSourceService imports are only referenced by fully-qualified name in the @var docblocks, so they become unused imports and PHPCS would flag them in Islandora's CI. I'll drop those too.

> The whole change is: delete the __construct() override, and rewrite create() to delegate to parent::create() before setting Islandora's two services on the returned instance. Because both utils and mediaSourceService are already declared as class properties, setting them this way doesn't create dynamic properties, so there's no PHP 8.2 deprecation to worry about. I also dropped four imports that were only used by the old constructor, plus IslandoraUtils and MediaSourceService, which are now referenced only by fully-qualified name in the @var docblocks.

> Why it satisfies your cross-version requirement: the class no longer references core's constructor signature anywhere. On 11.4, parent::create() supplies ImageDerivativeUtilities; on 10.x and 11.0–11.3 it doesn't. This subclass behaves identically either way, so the same file works against the whole supported range without a version check.

# How should this be tested?

I tested on my site with version 11.4.4 and 11.3.13, and on a fresh site template install of 11.3.12 and everything seemed to work as intended. 

I would recommend testing before and after updating Drupal to 11.4.x, as well as testing Drupal 11.4.4 without this patch to see that the search results breaks .


# Documentation Status

N/A

# Interested parties
@Islandora/committers
