### PR TITLE
IslandoraUtils::getMediaWithTerm fetches one, not many

### DIFF
--- a/src/IslandoraUtils.php
+++ b/src/IslandoraUtils.php
@@ -190,7 +190,7 @@ class IslandoraUtils {
   }
 
   /**
-   * Gets media that belong to a node with the specified term.
+   * Gets the first media that belongs to a node with the specified term.
    *
    * @param \Drupal\node\NodeInterface $node
    *   The parent node.


### PR DESCRIPTION
**GitHub Issue**: n/a

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What does this Pull Request do?
Corrects phpdoc for IslandoraUtils::getMediaWithTerm

# What's new?
n/a

# How should this be tested?
n/a

# Documentation Status

Original documentation implied many results in return; actual code performs a `reset()` to select a single result.

# Additional Notes:
n/a

# Interested parties
n/a
